### PR TITLE
[FLINK-24649][iteration] Add DraftExecutionEnvironment to support wrapping operators during compile time

### DIFF
--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/IterationBody.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/IterationBody.java
@@ -19,6 +19,8 @@
 package org.apache.flink.iteration;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.streaming.api.datastream.DataStream;
 
 /**
  * The builder of the subgraph that will be executed inside the iteration.
@@ -26,6 +28,16 @@ import org.apache.flink.annotation.Experimental;
  * <p>Notes that inside the iteration body, users could only create the subgraph from the {@code
  * variableStreams} and {@code dataStreams}. Users could not refers to other data stream outside the
  * iteration through the closure, and could not add new sources / sinks inside the iteration.
+ *
+ * <p>Some operations are not supported inside the iterations:
+ *
+ * <ul>
+ *   <li>Sources and Sinks.
+ *   <li>{@link DataStream#assignTimestampsAndWatermarks(WatermarkStrategy)}.
+ *   <li>{@link DataStream#iterate()}.
+ * </ul>
+ *
+ * <p>Currently we also not support nested exception.
  *
  * <p>The iteration body also requires that the parallelism of any stream in the initial variable
  * streams must equal to the parallelism of the stream at the same index of the feedback variable

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/DraftExecutionEnvironment.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/DraftExecutionEnvironment.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.core.execution.DefaultExecutorServiceLoader;
+import org.apache.flink.iteration.compile.translator.BroadcastStateTransformationTranslator;
+import org.apache.flink.iteration.compile.translator.KeyedBroadcastStateTransformationTranslator;
+import org.apache.flink.iteration.compile.translator.MultipleInputTransformationTranslator;
+import org.apache.flink.iteration.compile.translator.OneInputTransformationTranslator;
+import org.apache.flink.iteration.compile.translator.PartitionTransformationTranslator;
+import org.apache.flink.iteration.compile.translator.ReduceTransformationTranslator;
+import org.apache.flink.iteration.compile.translator.SideOutputTransformationTranslator;
+import org.apache.flink.iteration.compile.translator.TwoInputTransformationTranslator;
+import org.apache.flink.iteration.compile.translator.UnionTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.utils.ReflectionUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.transformations.BroadcastStateTransformation;
+import org.apache.flink.streaming.api.transformations.KeyedBroadcastStateTransformation;
+import org.apache.flink.streaming.api.transformations.KeyedMultipleInputTransformation;
+import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.streaming.api.transformations.ReduceTransformation;
+import org.apache.flink.streaming.api.transformations.SideOutputTransformation;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.streaming.api.transformations.UnionTransformation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A specialized stream execution environment that allows users to first construct a subgraph and
+ * later copy the transformations into the actual environment. During the copying it could apply
+ * some kinds of {@link OperatorWrapper} to change the operators in each transformation.
+ */
+public class DraftExecutionEnvironment extends StreamExecutionEnvironment {
+
+    @SuppressWarnings("rawtypes")
+    private static final Map<Class<? extends Transformation>, DraftTransformationTranslator>
+            translators = new HashMap<>();
+
+    static {
+        translators.put(
+                BroadcastStateTransformation.class, new BroadcastStateTransformationTranslator());
+        translators.put(
+                KeyedBroadcastStateTransformation.class,
+                new KeyedBroadcastStateTransformationTranslator());
+        translators.put(
+                KeyedMultipleInputTransformation.class,
+                new KeyedBroadcastStateTransformationTranslator());
+        translators.put(
+                MultipleInputTransformation.class, new MultipleInputTransformationTranslator());
+        translators.put(OneInputTransformation.class, new OneInputTransformationTranslator());
+        translators.put(PartitionTransformation.class, new PartitionTransformationTranslator());
+        translators.put(ReduceTransformation.class, new ReduceTransformationTranslator());
+        translators.put(SideOutputTransformation.class, new SideOutputTransformationTranslator());
+        translators.put(TwoInputTransformation.class, new TwoInputTransformationTranslator());
+        translators.put(UnionTransformation.class, new UnionTransformationTranslator());
+    }
+
+    private final StreamExecutionEnvironment actualEnv;
+
+    private final Map<Integer, OperatorWrapper<?, ?>> draftWrappers;
+
+    private final Map<Integer, Transformation<?>> draftToActualTransformations;
+
+    private OperatorWrapper<?, ?> currentWrapper;
+
+    public DraftExecutionEnvironment(
+            StreamExecutionEnvironment actualEnv, OperatorWrapper<?, ?> initialWrapper) {
+        super(
+                new DefaultExecutorServiceLoader(),
+                ReflectionUtils.getFieldValue(
+                        actualEnv, StreamExecutionEnvironment.class, "configuration"),
+                ReflectionUtils.getFieldValue(
+                        actualEnv, StreamExecutionEnvironment.class, "userClassloader"));
+        this.actualEnv = actualEnv;
+        this.draftWrappers = new HashMap<>();
+        this.draftToActualTransformations = new HashMap<>();
+
+        setParallelism(actualEnv.getParallelism());
+        if (actualEnv.getMaxParallelism() > 0) {
+            setMaxParallelism(actualEnv.getMaxParallelism());
+        }
+        setBufferTimeout(actualEnv.getBufferTimeout());
+
+        this.currentWrapper = initialWrapper;
+    }
+
+    public OperatorWrapper<?, ?> setCurrentWrapper(OperatorWrapper<?, ?> newWrapper) {
+        OperatorWrapper<?, ?> oldWrapper = currentWrapper;
+        currentWrapper = newWrapper;
+        return oldWrapper;
+    }
+
+    @Override
+    public void addOperator(Transformation<?> transformation) {
+        // Record the wrapper
+        recordWrapper(transformation);
+        super.addOperator(transformation);
+    }
+
+    private void recordWrapper(Transformation<?> transformation) {
+        if (draftWrappers.containsKey(transformation.getId())
+                || draftToActualTransformations.containsKey(transformation.getId())) {
+            return;
+        }
+
+        draftWrappers.put(transformation.getId(), currentWrapper);
+
+        for (Transformation<?> input : transformation.getInputs()) {
+            recordWrapper(input);
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T> DataStream<T> addDraftSource(
+            DataStream<?> actualStream, TypeInformation<T> draftOutputType) {
+        // Notes that the actual stream are given, thus it does not matter whether
+        // the draft sources have the same properties with the actual streams.
+        DataStream<T> draftSource =
+                addSource(new EmptySource<>())
+                        .setParallelism(actualStream.getParallelism())
+                        .returns((TypeInformation) draftOutputType);
+        addOperator(draftSource.getTransformation());
+        draftToActualTransformations.put(draftSource.getId(), actualStream.getTransformation());
+        return draftSource;
+    }
+
+    public void copyToActualEnvironment() {
+        for (Transformation<?> draftTransformation : transformations) {
+            transform(draftTransformation);
+        }
+    }
+
+    public <T> DataStream<T> getActualStream(int draftTransformationId) {
+        return new DataStream<T>(actualEnv, getActualTransformation(draftTransformationId));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <TF extends Transformation<?>> void transform(TF draftTransformation) {
+        if (draftToActualTransformations.containsKey(draftTransformation.getId())) {
+            return;
+        }
+
+        // Ensures the inputs are all transformed
+        for (Transformation<?> draftInput : draftTransformation.getInputs()) {
+            transform(draftInput);
+        }
+
+        OperatorWrapper<?, ?> operatorWrapper =
+                Objects.requireNonNull(draftWrappers.get(draftTransformation.getId()));
+
+        DraftTransformationTranslator<TF> transformationTranslator =
+                translators.get(draftTransformation.getClass());
+        checkState(
+                transformationTranslator != null,
+                "Unsupported transformation: " + draftTransformation);
+        Transformation<?> actualTransformation =
+                transformationTranslator.translate(
+                        draftTransformation, operatorWrapper, new TranslatorContext());
+        actualEnv.addOperator(actualTransformation);
+        draftToActualTransformations.put(draftTransformation.getId(), actualTransformation);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private <T> Transformation<T> getActualTransformation(int draftTransformationId) {
+        return (Transformation<T>)
+                Objects.requireNonNull(draftToActualTransformations.get(draftTransformationId));
+    }
+
+    @Override
+    public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
+        throw new UnsupportedOperationException(
+                "Unable to execute with a draft execution environment.");
+    }
+
+    private class TranslatorContext implements DraftTransformationTranslator.Context {
+
+        @Override
+        public Transformation<?> getActualTransformation(int draftId) {
+            return DraftExecutionEnvironment.this.getActualTransformation(draftId);
+        }
+
+        @Override
+        public ExecutionConfig getExecutionConfig() {
+            return DraftExecutionEnvironment.this.getConfig();
+        }
+    }
+
+    @VisibleForTesting
+    static class EmptySource<T> extends RichParallelSourceFunction<T> {
+
+        @Override
+        public void run(SourceContext<T> ctx) throws Exception {}
+
+        @Override
+        public void cancel() {}
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/DraftTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/DraftTransformationTranslator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+
+/** Creates the actual transformation according to the draft transformation. */
+public interface DraftTransformationTranslator<TF extends Transformation<?>> {
+
+    Transformation<?> translate(
+            TF draftTransformation, OperatorWrapper<?, ?> operatorWrapper, Context context);
+
+    /** The context for {@link DraftTransformationTranslator}. */
+    interface Context {
+
+        Transformation<?> getActualTransformation(int draftId);
+
+        ExecutionConfig getExecutionConfig();
+
+        default Transformation<?> copyProperties(
+                Transformation<?> actual, Transformation<?> draft) {
+            actual.setName(draft.getName());
+            actual.setParallelism(draft.getParallelism());
+
+            if (draft.getMaxParallelism() > 0) {
+                actual.setMaxParallelism(draft.getMaxParallelism());
+            }
+
+            if (draft.getBufferTimeout() > 0) {
+                actual.setBufferTimeout(draft.getBufferTimeout());
+            }
+
+            if (draft.getSlotSharingGroup().isPresent()) {
+                actual.setSlotSharingGroup(draft.getSlotSharingGroup().get());
+            }
+            actual.setCoLocationGroupKey(draft.getCoLocationGroupKey());
+
+            actual.setUid(draft.getUid());
+            if (draft.getUserProvidedNodeHash() != null) {
+                actual.setUidHash(draft.getUserProvidedNodeHash());
+            }
+
+            draft.getManagedMemoryOperatorScopeUseCaseWeights()
+                    .forEach(actual::declareManagedMemoryUseCaseAtOperatorScope);
+            draft.getManagedMemorySlotScopeUseCases()
+                    .forEach(actual::declareManagedMemoryUseCaseAtSlotScope);
+
+            return actual;
+        }
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/BroadcastStateTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/BroadcastStateTransformationTranslator.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile.translator;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.iteration.compile.DraftTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.co.CoBroadcastWithNonKeyedOperator;
+import org.apache.flink.streaming.api.transformations.BroadcastStateTransformation;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+
+/** Draft translator for the {@link BroadcastStateTransformation}. */
+public class BroadcastStateTransformationTranslator
+        implements DraftTransformationTranslator<BroadcastStateTransformation<?, ?, ?>> {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Transformation<?> translate(
+            BroadcastStateTransformation<?, ?, ?> draftTransformation,
+            OperatorWrapper<?, ?> operatorWrapper,
+            Context context) {
+
+        // Unfortunately the broadcast state operator does not support to set operator, we
+        // would then copy it as an TwoInputTransformation.
+        CoBroadcastWithNonKeyedOperator<?, ?, ?> operator =
+                new CoBroadcastWithNonKeyedOperator<>(
+                        draftTransformation.getUserFunction(),
+                        draftTransformation.getBroadcastStateDescriptors());
+        TwoInputTransformation<?, ?, ?> actualTransformation =
+                new TwoInputTransformation(
+                        context.getActualTransformation(
+                                draftTransformation.getRegularInput().getId()),
+                        context.getActualTransformation(
+                                draftTransformation.getBroadcastInput().getId()),
+                        draftTransformation.getName(),
+                        new WrapperOperatorFactory(
+                                SimpleOperatorFactory.of(operator), operatorWrapper),
+                        operatorWrapper.getWrappedTypeInfo(
+                                (TypeInformation) draftTransformation.getOutputType()),
+                        draftTransformation.getParallelism());
+        return context.copyProperties(actualTransformation, draftTransformation);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/KeyedBroadcastStateTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/KeyedBroadcastStateTransformationTranslator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile.translator;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.iteration.compile.DraftTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
+import org.apache.flink.streaming.api.transformations.KeyedBroadcastStateTransformation;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+
+/** Draft translator for the {@link KeyedBroadcastStateTransformation}. */
+public class KeyedBroadcastStateTransformationTranslator
+        implements DraftTransformationTranslator<KeyedBroadcastStateTransformation<?, ?, ?, ?>> {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Transformation<?> translate(
+            KeyedBroadcastStateTransformation<?, ?, ?, ?> draftTransformation,
+            OperatorWrapper<?, ?> operatorWrapper,
+            Context context) {
+
+        // Unfortunately the broadcast state operator does not support to set operator, we
+        // would then copy it as an TwoInputTransformation.
+        CoBroadcastWithKeyedOperator<?, ?, ?, ?> operator =
+                new CoBroadcastWithKeyedOperator<>(
+                        draftTransformation.getUserFunction(),
+                        draftTransformation.getBroadcastStateDescriptors());
+        TwoInputTransformation<?, ?, ?> actualTransformation =
+                new TwoInputTransformation(
+                        context.getActualTransformation(
+                                draftTransformation.getRegularInput().getId()),
+                        context.getActualTransformation(
+                                draftTransformation.getBroadcastInput().getId()),
+                        draftTransformation.getName(),
+                        new WrapperOperatorFactory(
+                                SimpleOperatorFactory.of(operator), operatorWrapper),
+                        operatorWrapper.getWrappedTypeInfo(
+                                (TypeInformation) draftTransformation.getOutputType()),
+                        draftTransformation.getParallelism());
+        actualTransformation.setStateKeyType(draftTransformation.getStateKeyType());
+        actualTransformation.setStateKeySelectors(
+                operatorWrapper.wrapKeySelector((KeySelector) draftTransformation.getKeySelector()),
+                null);
+        return context.copyProperties(actualTransformation, draftTransformation);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/KeyedMultipleInputTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/KeyedMultipleInputTransformationTranslator.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile.translator;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.iteration.compile.DraftTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.streaming.api.transformations.KeyedMultipleInputTransformation;
+
+/** Draft translator for the {@link KeyedMultipleInputTransformation}. */
+public class KeyedMultipleInputTransformationTranslator
+        implements DraftTransformationTranslator<KeyedMultipleInputTransformation<?>> {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Transformation<?> translate(
+            KeyedMultipleInputTransformation<?> draftTransformation,
+            OperatorWrapper<?, ?> operatorWrapper,
+            Context context) {
+        KeyedMultipleInputTransformation<?> actualTransformation =
+                new KeyedMultipleInputTransformation<>(
+                        draftTransformation.getName(),
+                        new WrapperOperatorFactory(
+                                draftTransformation.getOperatorFactory(), operatorWrapper),
+                        operatorWrapper.getWrappedTypeInfo(
+                                (TypeInformation) draftTransformation.getOutputType()),
+                        draftTransformation.getParallelism(),
+                        draftTransformation.getStateKeyType());
+
+        for (int i = 0; i < draftTransformation.getInputs().size(); ++i) {
+            actualTransformation.addInput(
+                    context.getActualTransformation(draftTransformation.getInputs().get(i).getId()),
+                    operatorWrapper.wrapKeySelector(
+                            (KeySelector) draftTransformation.getStateKeySelectors().get(i)));
+        }
+
+        actualTransformation.setChainingStrategy(
+                draftTransformation.getOperatorFactory().getChainingStrategy());
+        return context.copyProperties(actualTransformation, draftTransformation);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/MultipleInputTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/MultipleInputTransformationTranslator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile.translator;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.iteration.compile.DraftTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
+
+/** Draft translator for the {@link MultipleInputTransformation}. */
+public class MultipleInputTransformationTranslator
+        implements DraftTransformationTranslator<MultipleInputTransformation<?>> {
+
+    @Override
+    public Transformation<?> translate(
+            MultipleInputTransformation<?> draftTransformation,
+            OperatorWrapper<?, ?> operatorWrapper,
+            Context context) {
+        MultipleInputTransformation<?> actualTransformation =
+                new MultipleInputTransformation<>(
+                        draftTransformation.getName(),
+                        new WrapperOperatorFactory(
+                                draftTransformation.getOperatorFactory(), operatorWrapper),
+                        operatorWrapper.getWrappedTypeInfo(
+                                (TypeInformation) draftTransformation.getOutputType()),
+                        draftTransformation.getParallelism());
+
+        for (Transformation<?> draftInput : draftTransformation.getInputs()) {
+            actualTransformation.addInput(context.getActualTransformation(draftInput.getId()));
+        }
+
+        actualTransformation.setChainingStrategy(
+                draftTransformation.getOperatorFactory().getChainingStrategy());
+        return context.copyProperties(actualTransformation, draftTransformation);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/OneInputTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/OneInputTransformationTranslator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile.translator;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.iteration.compile.DraftTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+
+/** Draft translator for the {@link OneInputTransformation}. */
+public class OneInputTransformationTranslator
+        implements DraftTransformationTranslator<OneInputTransformation<?, ?>> {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Transformation<?> translate(
+            OneInputTransformation<?, ?> draftTransformation,
+            OperatorWrapper<?, ?> operatorWrapper,
+            Context context) {
+        OneInputTransformation<?, ?> actualTransformation =
+                new OneInputTransformation(
+                        context.getActualTransformation(
+                                draftTransformation.getInputs().get(0).getId()),
+                        draftTransformation.getName(),
+                        new WrapperOperatorFactory(
+                                draftTransformation.getOperatorFactory(), operatorWrapper),
+                        operatorWrapper.getWrappedTypeInfo(
+                                (TypeInformation) draftTransformation.getOutputType()),
+                        draftTransformation.getParallelism());
+
+        if (draftTransformation.getStateKeyType() != null) {
+            actualTransformation.setStateKeyType(draftTransformation.getStateKeyType());
+            actualTransformation.setStateKeySelector(
+                    operatorWrapper.wrapKeySelector(
+                            (KeySelector) draftTransformation.getStateKeySelector()));
+        }
+
+        actualTransformation.setChainingStrategy(
+                draftTransformation.getOperatorFactory().getChainingStrategy());
+        return context.copyProperties(actualTransformation, draftTransformation);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/PartitionTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/PartitionTransformationTranslator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile.translator;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.iteration.compile.DraftTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+
+/** Draft translator for the {@link PartitionTransformation}. */
+public class PartitionTransformationTranslator
+        implements DraftTransformationTranslator<PartitionTransformation<?>> {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Transformation<?> translate(
+            PartitionTransformation<?> draftTransformation,
+            OperatorWrapper<?, ?> operatorWrapper,
+            Context context) {
+        return context.copyProperties(
+                new PartitionTransformation<>(
+                        context.getActualTransformation(
+                                draftTransformation.getInputs().get(0).getId()),
+                        operatorWrapper.wrapStreamPartitioner(
+                                (StreamPartitioner) draftTransformation.getPartitioner()),
+                        draftTransformation.getExchangeMode()),
+                draftTransformation);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/ReduceTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/ReduceTransformationTranslator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile.translator;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.iteration.compile.DraftTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamGroupedReduceOperator;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.transformations.ReduceTransformation;
+
+/** Draft translator for the {@link ReduceTransformation}. */
+public class ReduceTransformationTranslator
+        implements DraftTransformationTranslator<ReduceTransformation<?, ?>> {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Transformation<?> translate(
+            ReduceTransformation<?, ?> draftTransformation,
+            OperatorWrapper<?, ?> operatorWrapper,
+            Context context) {
+
+        StreamGroupedReduceOperator<?> groupedReduce =
+                new StreamGroupedReduceOperator(
+                        draftTransformation.getReducer(),
+                        draftTransformation
+                                .getInputType()
+                                .createSerializer(context.getExecutionConfig()));
+        OneInputTransformation<?, ?> actualTransformation =
+                new OneInputTransformation(
+                        context.getActualTransformation(
+                                draftTransformation.getInputs().get(0).getId()),
+                        draftTransformation.getName(),
+                        new WrapperOperatorFactory(
+                                SimpleOperatorFactory.of(groupedReduce), operatorWrapper),
+                        operatorWrapper.getWrappedTypeInfo(
+                                (TypeInformation) draftTransformation.getOutputType()),
+                        draftTransformation.getParallelism());
+
+        actualTransformation.setStateKeyType(draftTransformation.getKeyTypeInfo());
+        actualTransformation.setStateKeySelector(
+                operatorWrapper.wrapKeySelector(
+                        (KeySelector) draftTransformation.getKeySelector()));
+
+        actualTransformation.setChainingStrategy(draftTransformation.getChainingStrategy());
+        return context.copyProperties(actualTransformation, draftTransformation);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/SideOutputTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/SideOutputTransformationTranslator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile.translator;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.iteration.compile.DraftTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.streaming.api.transformations.SideOutputTransformation;
+import org.apache.flink.util.OutputTag;
+
+/** Draft translator for the {@link SideOutputTransformation}. */
+public class SideOutputTransformationTranslator
+        implements DraftTransformationTranslator<SideOutputTransformation<?>> {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Transformation<?> translate(
+            SideOutputTransformation<?> draftTransformation,
+            OperatorWrapper<?, ?> operatorWrapper,
+            Context context) {
+
+        SideOutputTransformation<?> actualTransformation =
+                new SideOutputTransformation(
+                        context.getActualTransformation(
+                                draftTransformation.getInputs().get(0).getId()),
+                        operatorWrapper.wrapOutputTag(
+                                (OutputTag) draftTransformation.getOutputTag()));
+        return context.copyProperties(actualTransformation, draftTransformation);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/TwoInputTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/TwoInputTransformationTranslator.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile.translator;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.iteration.compile.DraftTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+
+/** Draft translator for the {@link TwoInputTransformation}. */
+public class TwoInputTransformationTranslator
+        implements DraftTransformationTranslator<TwoInputTransformation<?, ?, ?>> {
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Transformation<?> translate(
+            TwoInputTransformation<?, ?, ?> draftTransformation,
+            OperatorWrapper<?, ?> operatorWrapper,
+            Context context) {
+        TwoInputTransformation<?, ?, ?> actualTransformation =
+                new TwoInputTransformation(
+                        context.getActualTransformation(draftTransformation.getInput1().getId()),
+                        context.getActualTransformation(draftTransformation.getInput2().getId()),
+                        draftTransformation.getName(),
+                        new WrapperOperatorFactory(
+                                draftTransformation.getOperatorFactory(), operatorWrapper),
+                        operatorWrapper.getWrappedTypeInfo(
+                                (TypeInformation) draftTransformation.getOutputType()),
+                        draftTransformation.getParallelism());
+        if (draftTransformation.getStateKeyType() != null) {
+            actualTransformation.setStateKeyType(draftTransformation.getStateKeyType());
+            actualTransformation.setStateKeySelectors(
+                    operatorWrapper.wrapKeySelector(
+                            (KeySelector) draftTransformation.getStateKeySelector1()),
+                    operatorWrapper.wrapKeySelector(
+                            (KeySelector) draftTransformation.getStateKeySelector2()));
+        }
+        return context.copyProperties(actualTransformation, draftTransformation);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/UnionTransformationTranslator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/compile/translator/UnionTransformationTranslator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile.translator;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.iteration.compile.DraftTransformationTranslator;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.streaming.api.transformations.UnionTransformation;
+
+import java.util.stream.Collectors;
+
+/** Draft translator for the {@link UnionTransformation}. */
+public class UnionTransformationTranslator
+        implements DraftTransformationTranslator<UnionTransformation<?>> {
+
+    @Override
+    public Transformation<?> translate(
+            UnionTransformation<?> draftTransformation,
+            OperatorWrapper<?, ?> operatorWrapper,
+            Context context) {
+        return context.copyProperties(
+                new UnionTransformation<>(
+                        draftTransformation.getInputs().stream()
+                                .map(
+                                        draftInput ->
+                                                context.getActualTransformation(draftInput.getId()))
+                                .collect(Collectors.toList())),
+                draftTransformation);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/functions/EpochAwareAllRoundProcessFunction.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/functions/EpochAwareAllRoundProcessFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.iteration.functions;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.iteration.operator.allround.EpochAware;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.util.Collector;
@@ -28,6 +29,7 @@ import java.util.function.Supplier;
  * A specialized {@link ProcessFunction} that also provide the attach epoch with each record. It is
  * executed as all-round inside the iteration.
  */
+@Internal
 public abstract class EpochAwareAllRoundProcessFunction<I, O> extends ProcessFunction<I, O>
         implements EpochAware {
 

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/functions/EpochAwareCoProcessFunction.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/functions/EpochAwareCoProcessFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.iteration.functions;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.iteration.operator.allround.EpochAware;
 import org.apache.flink.streaming.api.functions.co.CoProcessFunction;
 import org.apache.flink.util.Collector;
@@ -28,6 +29,7 @@ import java.util.function.Supplier;
  * A specialized {@link CoProcessFunction} that also provide the attach epoch with each record. It
  * is executed as all-round inside the iteration.
  */
+@Internal
 public abstract class EpochAwareCoProcessFunction<I1, I2, O> extends CoProcessFunction<I1, I2, O>
         implements EpochAware {
 

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/OperatorWrapper.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/OperatorWrapper.java
@@ -19,9 +19,12 @@
 package org.apache.flink.iteration.operator;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.util.OutputTag;
 
 import java.io.Serializable;
 
@@ -31,6 +34,12 @@ public interface OperatorWrapper<T, R> extends Serializable {
     StreamOperator<R> wrap(
             StreamOperatorParameters<R> operatorParameters,
             StreamOperatorFactory<T> operatorFactory);
+
+    <KEY> KeySelector<R, KEY> wrapKeySelector(KeySelector<T, KEY> keySelector);
+
+    StreamPartitioner<R> wrapStreamPartitioner(StreamPartitioner<T> streamPartitioner);
+
+    OutputTag<R> wrapOutputTag(OutputTag<T> outputTag);
 
     TypeInformation<R> getWrappedTypeInfo(TypeInformation<T> typeInfo);
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/WrapperOperatorFactory.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/WrapperOperatorFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.iteration.operator;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -48,5 +49,15 @@ public class WrapperOperatorFactory<OUT>
     @Override
     public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
         return AbstractWrapperOperator.class;
+    }
+
+    @VisibleForTesting
+    public StreamOperatorFactory<OUT> getOperatorFactory() {
+        return operatorFactory;
+    }
+
+    @VisibleForTesting
+    public OperatorWrapper<OUT, IterationRecord<OUT>> getWrapper() {
+        return wrapper;
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/AllRoundOperatorWrapper.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/AllRoundOperatorWrapper.java
@@ -19,17 +19,24 @@
 package org.apache.flink.iteration.operator.allround;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.proxy.ProxyKeySelector;
+import org.apache.flink.iteration.proxy.ProxyStreamPartitioner;
+import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.util.OutputTag;
 
 /** The operator wrapper implementation for all-round wrappers. */
 public class AllRoundOperatorWrapper<T> implements OperatorWrapper<T, IterationRecord<T>> {
+
     @Override
     public StreamOperator<IterationRecord<T>> wrap(
             StreamOperatorParameters<IterationRecord<T>> operatorParameters,
@@ -49,7 +56,25 @@ public class AllRoundOperatorWrapper<T> implements OperatorWrapper<T, IterationR
     }
 
     @Override
+    public <KEY> KeySelector<IterationRecord<T>, KEY> wrapKeySelector(
+            KeySelector<T, KEY> keySelector) {
+        return new ProxyKeySelector<>(keySelector);
+    }
+
+    @Override
+    public StreamPartitioner<IterationRecord<T>> wrapStreamPartitioner(
+            StreamPartitioner<T> streamPartitioner) {
+        return new ProxyStreamPartitioner<>(streamPartitioner);
+    }
+
+    @Override
+    public OutputTag<IterationRecord<T>> wrapOutputTag(OutputTag<T> outputTag) {
+        return new OutputTag<>(
+                outputTag.getId(), new IterationRecordTypeInfo<>(outputTag.getTypeInfo()));
+    }
+
+    @Override
     public TypeInformation<IterationRecord<T>> getWrappedTypeInfo(TypeInformation<T> typeInfo) {
-        return null;
+        return new IterationRecordTypeInfo<>(typeInfo);
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/ProxyKeySelector.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/ProxyKeySelector.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.proxy;
+
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.iteration.IterationRecord;
+
+/** Proxy key selector for the wrapped one. */
+public class ProxyKeySelector<T, KEY> implements KeySelector<IterationRecord<T>, KEY> {
+
+    private final KeySelector<T, KEY> wrappedKeySelector;
+
+    public ProxyKeySelector(KeySelector<T, KEY> wrappedKeySelector) {
+        this.wrappedKeySelector = wrappedKeySelector;
+    }
+
+    @Override
+    public KEY getKey(IterationRecord<T> record) throws Exception {
+        return wrappedKeySelector.getKey(record.getValue());
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/ProxyStreamPartitioner.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/ProxyStreamPartitioner.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.proxy;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.iteration.IterationRecord;
+import org.apache.flink.iteration.typeinfo.IterationRecordSerializer;
+import org.apache.flink.iteration.utils.ReflectionUtils;
+import org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.Objects;
+
+/** Proxy stream partitioner for the wrapped one. */
+public class ProxyStreamPartitioner<T> extends StreamPartitioner<IterationRecord<T>> {
+
+    private final StreamPartitioner<T> wrappedStreamPartitioner;
+
+    private transient SerializationDelegate<StreamRecord<T>> reuseDelegate;
+
+    private transient StreamRecord<T> reuseRecord;
+
+    public ProxyStreamPartitioner(StreamPartitioner<T> wrappedStreamPartitioner) {
+        this.wrappedStreamPartitioner = Objects.requireNonNull(wrappedStreamPartitioner);
+    }
+
+    @Override
+    public StreamPartitioner<IterationRecord<T>> copy() {
+        return new ProxyStreamPartitioner<>(wrappedStreamPartitioner.copy());
+    }
+
+    @Override
+    public SubtaskStateMapper getDownstreamSubtaskStateMapper() {
+        return wrappedStreamPartitioner.getDownstreamSubtaskStateMapper();
+    }
+
+    @Override
+    public boolean isPointwise() {
+        return wrappedStreamPartitioner.isPointwise();
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public int selectChannel(SerializationDelegate<StreamRecord<IterationRecord<T>>> record) {
+        if (reuseDelegate != null) {
+            reuseDelegate.setInstance(
+                    reuseRecord.replace(
+                            record.getInstance().getValue().getValue(),
+                            record.getInstance().getTimestamp()));
+            return wrappedStreamPartitioner.selectChannel(reuseDelegate);
+        } else {
+            reuseRecord = new StreamRecord<>(null, 0);
+
+            StreamElementSerializer<IterationRecord<T>> streamElementSerializer =
+                    ReflectionUtils.getFieldValue(
+                            record, SerializationDelegate.class, "serializer");
+            IterationRecordSerializer<T> iterationRecordSerializer =
+                    (IterationRecordSerializer<T>)
+                            streamElementSerializer.getContainedTypeSerializer();
+            reuseDelegate =
+                    new SerializationDelegate<>(
+                            (TypeSerializer)
+                                    new StreamElementSerializer<>(
+                                            iterationRecordSerializer
+                                                    .getInnerSerializer()
+                                                    .duplicate()));
+
+            return selectChannel(record);
+        }
+    }
+}

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/AllRoundDraftExecutionEnvironmentTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/AllRoundDraftExecutionEnvironmentTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile;
+
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.iteration.operator.allround.AllRoundOperatorWrapper;
+import org.apache.flink.iteration.typeinfo.IterationRecordSerializer;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamNode;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests the behavior of the {@link DraftExecutionEnvironment} with {@link AllRoundOperatorWrapper}.
+ */
+public class AllRoundDraftExecutionEnvironmentTest extends DraftExecutionEnvironmentTestBase {
+
+    @Override
+    protected OperatorWrapper<?, ?> getOperatorWrapper() {
+        return new AllRoundOperatorWrapper<>();
+    }
+
+    @Override
+    protected void checkWrappedGraph(
+            StreamGraph draftStreamGraph,
+            StreamGraph actualStreamGraph,
+            DraftExecutionEnvironment draftEnv) {
+        assertNotNull("Draft stream graph should not be null", draftStreamGraph);
+        assertNotNull("Actual stream graph should not be null", actualStreamGraph);
+
+        // First check the two graphs has the isomorphic structure.
+        assertEquals(
+                draftStreamGraph.getStreamNodes().size(),
+                actualStreamGraph.getStreamNodes().size());
+        for (StreamNode draftNode : draftStreamGraph.getStreamNodes()) {
+            StreamNode actualNode =
+                    actualStreamGraph.getStreamNode(
+                            draftEnv.getActualStream(draftNode.getId()).getId());
+            assertEquals(
+                    getSortedOutEdgeTarget(draftNode).stream()
+                            .map(id -> draftEnv.getActualStream(id).getId())
+                            .collect(Collectors.toList()),
+                    getSortedOutEdgeTarget(actualNode));
+        }
+
+        // Now check each operator is correctly wrapped.
+        for (StreamNode draftNode : draftStreamGraph.getStreamNodes()) {
+            StreamNode actualNode =
+                    actualStreamGraph.getStreamNode(
+                            draftEnv.getActualStream(draftNode.getId()).getId());
+
+            // Not check sources.
+            if (actualNode.getInEdges().size() == 0) {
+                continue;
+            }
+
+            assertEquals(WrapperOperatorFactory.class, actualNode.getOperatorFactory().getClass());
+            assertEquals(
+                    AllRoundOperatorWrapper.class,
+                    ((WrapperOperatorFactory) actualNode.getOperatorFactory())
+                            .getWrapper()
+                            .getClass());
+            assertEquals(
+                    draftNode.getOperatorFactory().getClass(),
+                    ((WrapperOperatorFactory) actualNode.getOperatorFactory())
+                            .getOperatorFactory()
+                            .getClass());
+            assertEquals(
+                    draftNode
+                            .getOperatorFactory()
+                            .getStreamOperatorClass(getClass().getClassLoader()),
+                    ((WrapperOperatorFactory) actualNode.getOperatorFactory())
+                            .getOperatorFactory()
+                            .getStreamOperatorClass(getClass().getClassLoader()));
+
+            if (actualNode.getTypeSerializerOut() != null) {
+                assertEquals(
+                        IterationRecordSerializer.class,
+                        actualNode.getTypeSerializerOut().getClass());
+                assertEquals(
+                        draftNode.getTypeSerializerOut().getClass(),
+                        ((IterationRecordSerializer) actualNode.getTypeSerializerOut())
+                                .getInnerSerializer()
+                                .getClass());
+            }
+
+            assertEquals(draftNode.getStateKeySerializer(), actualNode.getStateKeySerializer());
+            assertEquals(draftNode.getParallelism(), actualNode.getParallelism());
+            assertEquals(draftNode.getBufferTimeout(), actualNode.getBufferTimeout());
+            assertEquals(draftNode.getCoLocationGroup(), actualNode.getCoLocationGroup());
+            assertEquals(draftNode.getUserHash(), actualNode.getUserHash());
+            assertEquals(
+                    draftNode.getManagedMemorySlotScopeUseCases(),
+                    actualNode.getManagedMemorySlotScopeUseCases());
+            assertEquals(
+                    draftNode.getManagedMemoryOperatorScopeUseCaseWeights(),
+                    actualNode.getManagedMemoryOperatorScopeUseCaseWeights());
+        }
+    }
+
+    private List<Integer> getSortedOutEdgeTarget(StreamNode node) {
+        return node.getOutEdges().stream()
+                .map(StreamEdge::getTargetId)
+                .sorted()
+                .collect(Collectors.toList());
+    }
+}

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/DraftExecutionEnvironmentSwitchWrapperTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/DraftExecutionEnvironmentSwitchWrapperTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.api.operators.StreamFilter;
+import org.apache.flink.streaming.api.operators.StreamMap;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests switching the operator wrapper during creating the draft. */
+public class DraftExecutionEnvironmentSwitchWrapperTest {
+
+    @Test
+    public void testSwitchingOperatorWrappers() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        DataStream<Integer> source =
+                env.addSource(new DraftExecutionEnvironment.EmptySource<Integer>() {});
+
+        DraftExecutionEnvironment draftEnv =
+                new DraftExecutionEnvironment(env, new FirstWrapper<>());
+        DataStream<Integer> draftSource =
+                draftEnv.addDraftSource(source, BasicTypeInfo.INT_TYPE_INFO);
+
+        DataStream<Integer> firstPart =
+                draftSource.process(
+                        new ProcessFunction<Integer, Integer>() {
+                            @Override
+                            public void processElement(
+                                    Integer value, Context ctx, Collector<Integer> out) {}
+                        });
+        draftEnv.setCurrentWrapper(new SecondWrapper<>());
+        firstPart
+                .keyBy(x -> x)
+                .process(
+                        new KeyedProcessFunction<Integer, Integer, Integer>() {
+                            @Override
+                            public void processElement(
+                                    Integer value, Context ctx, Collector<Integer> out) {}
+                        });
+
+        draftEnv.copyToActualEnvironment();
+        StreamGraph graph = env.getStreamGraph();
+
+        List<Integer> nodeIds =
+                graph.getStreamNodes().stream()
+                        .filter(node -> node.getInEdges().size() > 0)
+                        .map(StreamNode::getId)
+                        .sorted()
+                        .collect(Collectors.toList());
+        assertEquals(2, nodeIds.size());
+
+        assertEquals(
+                FirstWrapper.class,
+                ((WrapperOperatorFactory<?>)
+                                graph.getStreamNode(nodeIds.get(0)).getOperatorFactory())
+                        .getWrapper()
+                        .getClass());
+        assertEquals(
+                SecondWrapper.class,
+                ((WrapperOperatorFactory<?>)
+                                graph.getStreamNode(nodeIds.get(1)).getOperatorFactory())
+                        .getWrapper()
+                        .getClass());
+    }
+
+    private static class FirstWrapper<T> implements OperatorWrapper<T, T> {
+        @Override
+        public StreamOperator<T> wrap(
+                StreamOperatorParameters<T> operatorParameters,
+                StreamOperatorFactory<T> operatorFactory) {
+            return new StreamMap<>((MapFunction<T, T>) value -> value);
+        }
+
+        @Override
+        public <KEY> KeySelector<T, KEY> wrapKeySelector(KeySelector<T, KEY> keySelector) {
+            return keySelector;
+        }
+
+        @Override
+        public StreamPartitioner<T> wrapStreamPartitioner(StreamPartitioner<T> streamPartitioner) {
+            return streamPartitioner;
+        }
+
+        @Override
+        public OutputTag<T> wrapOutputTag(OutputTag<T> outputTag) {
+            return outputTag;
+        }
+
+        @Override
+        public TypeInformation<T> getWrappedTypeInfo(TypeInformation<T> typeInfo) {
+            return typeInfo;
+        }
+    }
+
+    private static class SecondWrapper<T> implements OperatorWrapper<T, T> {
+        @Override
+        public StreamOperator<T> wrap(
+                StreamOperatorParameters<T> operatorParameters,
+                StreamOperatorFactory<T> operatorFactory) {
+            return new StreamFilter<>((FilterFunction<T>) value -> true);
+        }
+
+        @Override
+        public <KEY> KeySelector<T, KEY> wrapKeySelector(KeySelector<T, KEY> keySelector) {
+            return keySelector;
+        }
+
+        @Override
+        public StreamPartitioner<T> wrapStreamPartitioner(StreamPartitioner<T> streamPartitioner) {
+            return streamPartitioner;
+        }
+
+        @Override
+        public OutputTag<T> wrapOutputTag(OutputTag<T> outputTag) {
+            return outputTag;
+        }
+
+        @Override
+        public TypeInformation<T> getWrappedTypeInfo(TypeInformation<T> typeInfo) {
+            return typeInfo;
+        }
+    }
+}

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/DraftExecutionEnvironmentSwitchWrapperTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/DraftExecutionEnvironmentSwitchWrapperTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -48,7 +49,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 
 /** Tests switching the operator wrapper during creating the draft. */
-public class DraftExecutionEnvironmentSwitchWrapperTest {
+public class DraftExecutionEnvironmentSwitchWrapperTest extends TestLogger {
 
     @Test
     public void testSwitchingOperatorWrappers() {

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/DraftExecutionEnvironmentTestBase.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/DraftExecutionEnvironmentTestBase.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.compile;
+
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.iteration.operator.OperatorWrapper;
+import org.apache.flink.iteration.operator.allround.MultipleInputAllRoundWrapperOperatorTest;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.MultipleConnectedStreams;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
+import org.apache.flink.streaming.api.functions.co.CoMapFunction;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/** Tests the behavior of the {@link DraftExecutionEnvironment}. */
+public abstract class DraftExecutionEnvironmentTestBase {
+
+    protected abstract OperatorWrapper<?, ?> getOperatorWrapper();
+
+    protected abstract void checkWrappedGraph(
+            StreamGraph nonWrapped, StreamGraph wrapped, DraftExecutionEnvironment draftEnv);
+
+    @Test
+    public void testOneInputTransformation() {
+        testWrapper(1, sources -> sources.get(0).map(x -> x).map(x -> x));
+    }
+
+    @Test
+    public void testKeyedOneInputTransformation() {
+        testWrapper(
+                1,
+                sources ->
+                        sources.get(0)
+                                .keyBy((KeySelector<Integer, Integer>) integer -> integer)
+                                .process(
+                                        new KeyedProcessFunction<Integer, Integer, Integer>() {
+                                            @Override
+                                            public void processElement(
+                                                    Integer value,
+                                                    Context ctx,
+                                                    Collector<Integer> out)
+                                                    throws Exception {}
+                                        })
+                                .map(x -> x));
+    }
+
+    @Test
+    public void testTwoInputTransformation() {
+        testWrapper(
+                2,
+                sources ->
+                        sources.get(0)
+                                .connect(sources.get(1))
+                                .map(
+                                        new CoMapFunction<Integer, Integer, Object>() {
+                                            @Override
+                                            public Object map1(Integer value) throws Exception {
+                                                return null;
+                                            }
+
+                                            @Override
+                                            public Object map2(Integer value) throws Exception {
+                                                return null;
+                                            }
+                                        })
+                                .map(x -> x));
+    }
+
+    @Test
+    public void testKeyedTwoInputTransformation() {
+        testWrapper(
+                2,
+                sources ->
+                        sources.get(0)
+                                .keyBy(i -> i)
+                                .connect(sources.get(1).keyBy(i -> i))
+                                .map(
+                                        new CoMapFunction<Integer, Integer, Object>() {
+                                            @Override
+                                            public Object map1(Integer value) throws Exception {
+                                                return null;
+                                            }
+
+                                            @Override
+                                            public Object map2(Integer value) throws Exception {
+                                                return null;
+                                            }
+                                        })
+                                .map(x -> x));
+    }
+
+    @Test
+    public void testUnionInputStream() {
+        testWrapper(
+                2,
+                sources ->
+                        sources.get(0)
+                                .keyBy(i -> i)
+                                .union(sources.get(1).keyBy(i -> i))
+                                .map(x -> x));
+    }
+
+    @Test
+    public void testBroadcastStateTransformation() {
+        testWrapper(
+                2,
+                sources -> {
+                    sources.get(0)
+                            .connect(
+                                    sources.get(1)
+                                            .broadcast(
+                                                    new MapStateDescriptor<Integer, Integer>(
+                                                            "test", Integer.class, Integer.class)))
+                            .process(
+                                    new BroadcastProcessFunction<Integer, Integer, Integer>() {
+                                        @Override
+                                        public void processElement(
+                                                Integer value,
+                                                ReadOnlyContext ctx,
+                                                Collector<Integer> out)
+                                                throws Exception {}
+
+                                        @Override
+                                        public void processBroadcastElement(
+                                                Integer value, Context ctx, Collector<Integer> out)
+                                                throws Exception {}
+                                    })
+                            .map(x -> x);
+                });
+    }
+
+    @Test
+    public void testKeyedBroadcastStateTransformation() {
+        testWrapper(
+                2,
+                sources -> {
+                    sources.get(0)
+                            .keyBy(i -> i)
+                            .connect(
+                                    sources.get(1)
+                                            .broadcast(
+                                                    new MapStateDescriptor<Integer, Integer>(
+                                                            "test", Integer.class, Integer.class)))
+                            .process(
+                                    new KeyedBroadcastProcessFunction<
+                                            Integer, Integer, Integer, Integer>() {
+                                        @Override
+                                        public void processElement(
+                                                Integer value,
+                                                ReadOnlyContext ctx,
+                                                Collector<Integer> out)
+                                                throws Exception {}
+
+                                        @Override
+                                        public void processBroadcastElement(
+                                                Integer value, Context ctx, Collector<Integer> out)
+                                                throws Exception {}
+                                    })
+                            .map(x -> x);
+                });
+    }
+
+    @Test
+    public void testReduceTransformation() {
+        testWrapper(
+                1,
+                sources ->
+                        sources.get(0)
+                                .keyBy(i -> i)
+                                .reduce(
+                                        new ReduceFunction<Integer>() {
+                                            @Override
+                                            public Integer reduce(Integer integer, Integer t1)
+                                                    throws Exception {
+                                                return null;
+                                            }
+                                        })
+                                .map(x -> x));
+    }
+
+    @Test
+    public void testSideOutput() {
+        testWrapper(
+                1,
+                sources ->
+                        sources.get(0)
+                                .process(
+                                        new ProcessFunction<Integer, Integer>() {
+                                            @Override
+                                            public void processElement(
+                                                    Integer value,
+                                                    Context ctx,
+                                                    Collector<Integer> out)
+                                                    throws Exception {}
+                                        })
+                                .getSideOutput(new OutputTag<String>("test") {})
+                                .map(x -> x));
+    }
+
+    @Test
+    public void testMultipleInputTransformation() {
+        testWrapper(
+                3,
+                sources -> {
+                    MultipleInputTransformation<Integer> multipleInputTransformation =
+                            new MultipleInputTransformation<>(
+                                    "mul",
+                                    new MultipleInputAllRoundWrapperOperatorTest
+                                            .LifeCycleTrackingTwoInputStreamOperatorFactory(),
+                                    BasicTypeInfo.INT_TYPE_INFO,
+                                    4);
+                    sources.forEach(
+                            s -> multipleInputTransformation.addInput(s.getTransformation()));
+                    sources.get(0)
+                            .getExecutionEnvironment()
+                            .addOperator(multipleInputTransformation);
+                    new MultipleConnectedStreams(sources.get(0).getExecutionEnvironment())
+                            .transform(multipleInputTransformation)
+                            .map(x -> x);
+                });
+    }
+
+    @Test
+    public void testKeyedMultipleInputTransformation() {
+        testWrapper(
+                3,
+                sources -> {
+                    MultipleInputTransformation<Integer> multipleInputTransformation =
+                            new MultipleInputTransformation<>(
+                                    "mul",
+                                    new MultipleInputAllRoundWrapperOperatorTest
+                                            .LifeCycleTrackingTwoInputStreamOperatorFactory(),
+                                    BasicTypeInfo.INT_TYPE_INFO,
+                                    4);
+                    sources.forEach(
+                            s ->
+                                    multipleInputTransformation.addInput(
+                                            s.keyBy(i -> i).getTransformation()));
+                    sources.get(0)
+                            .getExecutionEnvironment()
+                            .addOperator(multipleInputTransformation);
+                    new MultipleConnectedStreams(sources.get(0).getExecutionEnvironment())
+                            .transform(multipleInputTransformation)
+                            .map(x -> x);
+                });
+    }
+
+    private void testWrapper(
+            int numberOfSources, Consumer<List<DataStream<Integer>>> graphBuilder) {
+        StreamExecutionEnvironment env = new StreamExecutionEnvironment();
+        DraftExecutionEnvironment draftEnv =
+                new DraftExecutionEnvironment(env, getOperatorWrapper());
+        List<DataStream<Integer>> sources = new ArrayList<>();
+        for (int i = 0; i < numberOfSources; ++i) {
+            DataStreamSource<Integer> source =
+                    env.addSource(new DraftExecutionEnvironment.EmptySource<>());
+            source.returns(BasicTypeInfo.INT_TYPE_INFO);
+            env.addOperator(source.getTransformation());
+
+            sources.add(draftEnv.addDraftSource(source, BasicTypeInfo.INT_TYPE_INFO));
+        }
+        graphBuilder.accept(sources);
+        draftEnv.copyToActualEnvironment();
+
+        StreamGraph wrappedGraph = env.getStreamGraph();
+        StreamGraph nonWrappedGraph = draftEnv.getStreamGraph();
+
+        checkWrappedGraph(nonWrappedGraph, wrappedGraph, draftEnv);
+    }
+}

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/DraftExecutionEnvironmentTestBase.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/DraftExecutionEnvironmentTestBase.java
@@ -37,6 +37,7 @@ import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -45,7 +46,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 /** Tests the behavior of the {@link DraftExecutionEnvironment}. */
-public abstract class DraftExecutionEnvironmentTestBase {
+public abstract class DraftExecutionEnvironmentTestBase extends TestLogger {
 
     protected abstract OperatorWrapper<?, ?> getOperatorWrapper();
 

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/allround/MultipleInputAllRoundWrapperOperatorTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/allround/MultipleInputAllRoundWrapperOperatorTest.java
@@ -216,7 +216,8 @@ public class MultipleInputAllRoundWrapperOperatorTest extends TestLogger {
         }
     }
 
-    private static class LifeCycleTrackingTwoInputStreamOperatorFactory
+    /** The operator factory for the lifecycle-tracking operator. */
+    public static class LifeCycleTrackingTwoInputStreamOperatorFactory
             extends AbstractStreamOperatorFactory<Integer> {
 
         @Override


### PR DESCRIPTION
This PR adds a DraftExecutionEnvironment to support wrapping operators during compile time.

The users could first create a subgraph inside the DraftExecutionEnvironment and copy the transformations back to the actual execution environment. During the copying, it could apply some changes to the original graph structure. 