### PR TITLE
[FLINK-24655][iteration] Support the checkpoints for the iteration

### DIFF
--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/checkpoint/Checkpoints.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/checkpoint/Checkpoints.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.checkpoint;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.iteration.datacache.nonkeyed.DataCacheSnapshot;
+import org.apache.flink.iteration.datacache.nonkeyed.DataCacheWriter;
+import org.apache.flink.runtime.state.OperatorStateCheckpointOutputStream;
+import org.apache.flink.util.ResourceGuard;
+import org.apache.flink.util.function.SupplierWithException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/** Maintains the pending checkpoints. */
+public class Checkpoints<T> implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Checkpoints.class);
+
+    private final TypeSerializer<T> typeSerializer;
+    private final FileSystem fileSystem;
+    private final SupplierWithException<Path, IOException> pathSupplier;
+
+    private final TreeMap<Long, PendingCheckpoint> uncompletedCheckpoints = new TreeMap<>();
+
+    public Checkpoints(
+            TypeSerializer<T> typeSerializer,
+            FileSystem fileSystem,
+            SupplierWithException<Path, IOException> pathSupplier) {
+        this.typeSerializer = typeSerializer;
+        this.fileSystem = fileSystem;
+        this.pathSupplier = pathSupplier;
+    }
+
+    public void startLogging(long checkpointId, OperatorStateCheckpointOutputStream outputStream)
+            throws IOException {
+        DataCacheWriter<T> dataCacheWriter =
+                new DataCacheWriter<>(typeSerializer, fileSystem, pathSupplier);
+        ResourceGuard.Lease snapshotLease = outputStream.acquireLease();
+        uncompletedCheckpoints.put(
+                checkpointId, new PendingCheckpoint(dataCacheWriter, outputStream, snapshotLease));
+    }
+
+    public void append(T element) throws IOException {
+        for (PendingCheckpoint pendingCheckpoint : uncompletedCheckpoints.values()) {
+            pendingCheckpoint.dataCacheWriter.addRecord(element);
+        }
+    }
+
+    public void commitCheckpointsUntil(long checkpointId) {
+        SortedMap<Long, PendingCheckpoint> completedCheckpoints =
+                uncompletedCheckpoints.headMap(checkpointId, true);
+        completedCheckpoints
+                .values()
+                .forEach(
+                        pendingCheckpoint -> {
+                            try {
+                                pendingCheckpoint.dataCacheWriter.finish();
+                                DataCacheSnapshot snapshot =
+                                        new DataCacheSnapshot(
+                                                fileSystem,
+                                                null,
+                                                pendingCheckpoint.dataCacheWriter
+                                                        .getFinishSegments());
+                                pendingCheckpoint.checkpointOutputStream.startNewPartition();
+                                snapshot.writeTo(pendingCheckpoint.checkpointOutputStream);
+                                pendingCheckpoint.dataCacheWriter.cleanup();
+                            } catch (Exception e) {
+                                LOG.error("Failed to commit checkpoint until " + checkpointId, e);
+                            } finally {
+                                pendingCheckpoint.snapshotLease.close();
+                            }
+                        });
+
+        completedCheckpoints.clear();
+    }
+
+    @Override
+    public void close() {
+        uncompletedCheckpoints.forEach(
+                (checkpointId, pendingCheckpoint) -> {
+                    pendingCheckpoint.snapshotLease.close();
+                    try {
+                        pendingCheckpoint.dataCacheWriter.cleanup();
+                    } catch (IOException e) {
+                        LOG.error("Failed to cleanup " + checkpointId, e);
+                    }
+                });
+        uncompletedCheckpoints.clear();
+    }
+
+    private class PendingCheckpoint {
+        final DataCacheWriter<T> dataCacheWriter;
+
+        final OperatorStateCheckpointOutputStream checkpointOutputStream;
+
+        final ResourceGuard.Lease snapshotLease;
+
+        public PendingCheckpoint(
+                DataCacheWriter<T> dataCacheWriter,
+                OperatorStateCheckpointOutputStream checkpointOutputStream,
+                ResourceGuard.Lease snapshotLease) {
+            this.dataCacheWriter = dataCacheWriter;
+            this.checkpointOutputStream = checkpointOutputStream;
+            this.snapshotLease = snapshotLease;
+        }
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/checkpoint/Checkpoints.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/checkpoint/Checkpoints.java
@@ -19,11 +19,13 @@
 package org.apache.flink.iteration.checkpoint;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.iteration.datacache.nonkeyed.DataCacheSnapshot;
 import org.apache.flink.iteration.datacache.nonkeyed.DataCacheWriter;
 import org.apache.flink.runtime.state.OperatorStateCheckpointOutputStream;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.ResourceGuard;
 import org.apache.flink.util.function.SupplierWithException;
 
@@ -33,6 +35,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Maintains the pending checkpoints. */
 public class Checkpoints<T> implements AutoCloseable {
@@ -43,7 +48,10 @@ public class Checkpoints<T> implements AutoCloseable {
     private final FileSystem fileSystem;
     private final SupplierWithException<Path, IOException> pathSupplier;
 
-    private final TreeMap<Long, PendingCheckpoint> uncompletedCheckpoints = new TreeMap<>();
+    private final ConcurrentHashMap<Long, Tuple2<PendingCheckpoint, Boolean>>
+            uncompletedCheckpoints = new ConcurrentHashMap<>();
+
+    private final TreeMap<Long, PendingCheckpoint> sortedUncompletedCheckpoints = new TreeMap<>();
 
     public Checkpoints(
             TypeSerializer<T> typeSerializer,
@@ -51,27 +59,72 @@ public class Checkpoints<T> implements AutoCloseable {
             SupplierWithException<Path, IOException> pathSupplier) {
         this.typeSerializer = typeSerializer;
         this.fileSystem = fileSystem;
+        checkState(!fileSystem.isDistributedFS(), "Currently only local fs is supported");
         this.pathSupplier = pathSupplier;
+    }
+
+    public TypeSerializer<T> getTypeSerializer() {
+        return typeSerializer;
+    }
+
+    public FileSystem getFileSystem() {
+        return fileSystem;
+    }
+
+    public SupplierWithException<Path, IOException> getPathSupplier() {
+        return pathSupplier;
     }
 
     public void startLogging(long checkpointId, OperatorStateCheckpointOutputStream outputStream)
             throws IOException {
-        DataCacheWriter<T> dataCacheWriter =
-                new DataCacheWriter<>(typeSerializer, fileSystem, pathSupplier);
-        ResourceGuard.Lease snapshotLease = outputStream.acquireLease();
-        uncompletedCheckpoints.put(
-                checkpointId, new PendingCheckpoint(dataCacheWriter, outputStream, snapshotLease));
+        Tuple2<PendingCheckpoint, Boolean> possibleCheckpoint =
+                uncompletedCheckpoints.computeIfAbsent(
+                        checkpointId,
+                        ignored -> {
+                            try {
+                                DataCacheWriter<T> dataCacheWriter =
+                                        new DataCacheWriter<>(
+                                                typeSerializer, fileSystem, pathSupplier);
+                                ResourceGuard.Lease snapshotLease = outputStream.acquireLease();
+                                return new Tuple2<>(
+                                        new PendingCheckpoint(
+                                                dataCacheWriter, outputStream, snapshotLease),
+                                        false);
+                            } catch (IOException e) {
+                                throw new FlinkRuntimeException(e);
+                            }
+                        });
+
+        // If canceled, return
+        if (possibleCheckpoint.f1) {
+            return;
+        }
+
+        sortedUncompletedCheckpoints.put(checkpointId, possibleCheckpoint.f0);
+    }
+
+    public void abort(long checkpointId) {
+        uncompletedCheckpoints.compute(
+                checkpointId,
+                (k, v) -> {
+                    if (v == null) {
+                        return new Tuple2<>(null, true);
+                    } else {
+                        v.f0.snapshotLease.close();
+                        return new Tuple2<>(v.f0, true);
+                    }
+                });
     }
 
     public void append(T element) throws IOException {
-        for (PendingCheckpoint pendingCheckpoint : uncompletedCheckpoints.values()) {
+        for (PendingCheckpoint pendingCheckpoint : sortedUncompletedCheckpoints.values()) {
             pendingCheckpoint.dataCacheWriter.addRecord(element);
         }
     }
 
     public void commitCheckpointsUntil(long checkpointId) {
         SortedMap<Long, PendingCheckpoint> completedCheckpoints =
-                uncompletedCheckpoints.headMap(checkpointId, true);
+                sortedUncompletedCheckpoints.headMap(checkpointId, true);
         completedCheckpoints
                 .values()
                 .forEach(
@@ -86,9 +139,13 @@ public class Checkpoints<T> implements AutoCloseable {
                                                         .getFinishSegments());
                                 pendingCheckpoint.checkpointOutputStream.startNewPartition();
                                 snapshot.writeTo(pendingCheckpoint.checkpointOutputStream);
+
+                                // Directly cleanup all the files since we are using the local fs.
+                                // TODO: support of the remote fs.
                                 pendingCheckpoint.dataCacheWriter.cleanup();
                             } catch (Exception e) {
                                 LOG.error("Failed to commit checkpoint until " + checkpointId, e);
+                                throw new FlinkRuntimeException(e);
                             } finally {
                                 pendingCheckpoint.snapshotLease.close();
                             }
@@ -99,7 +156,7 @@ public class Checkpoints<T> implements AutoCloseable {
 
     @Override
     public void close() {
-        uncompletedCheckpoints.forEach(
+        sortedUncompletedCheckpoints.forEach(
                 (checkpointId, pendingCheckpoint) -> {
                     pendingCheckpoint.snapshotLease.close();
                     try {
@@ -108,10 +165,12 @@ public class Checkpoints<T> implements AutoCloseable {
                         LOG.error("Failed to cleanup " + checkpointId, e);
                     }
                 });
+        sortedUncompletedCheckpoints.clear();
         uncompletedCheckpoints.clear();
     }
 
     private class PendingCheckpoint {
+
         final DataCacheWriter<T> dataCacheWriter;
 
         final OperatorStateCheckpointOutputStream checkpointOutputStream;

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/checkpoint/CheckpointsBroker.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/checkpoint/CheckpointsBroker.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.checkpoint;
+
+import org.apache.flink.statefun.flink.core.feedback.SubtaskFeedbackKey;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Hand offs the {@link Checkpoints} from the head operator to the tail operator so that the tail
+ * operator could decrease the reference count of the raw state when checkpoints are aborted. We
+ * could not count on the head operator since it would be blocked on closing the raw state when
+ * aborting the checkpoint. It also looks like a bug.
+ */
+public class CheckpointsBroker {
+
+    private static final CheckpointsBroker INSTANCE = new CheckpointsBroker();
+
+    private final ConcurrentHashMap<SubtaskFeedbackKey<?>, Checkpoints<?>> checkpointManagers =
+            new ConcurrentHashMap<>();
+
+    public static CheckpointsBroker get() {
+        return INSTANCE;
+    }
+
+    public <V> void setCheckpoints(SubtaskFeedbackKey<V> key, Checkpoints<V> checkpoints) {
+        checkpointManagers.put(key, checkpoints);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    public <V> Checkpoints<V> getCheckpoints(SubtaskFeedbackKey<V> key) {
+        Objects.requireNonNull(key);
+        return (Checkpoints<V>) Objects.requireNonNull(checkpointManagers.get(key));
+    }
+
+    @SuppressWarnings("resource")
+    void removeChannel(SubtaskFeedbackKey<?> key) {
+        checkpointManagers.remove(key);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheSnapshot.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheSnapshot.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.runtime.util.NonClosingInputStreamDecorator;
+import org.apache.flink.runtime.util.NonClosingOutpusStreamDecorator;
+import org.apache.flink.statefun.flink.core.feedback.FeedbackConsumer;
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.function.SupplierWithException;
+
+import org.apache.commons.io.input.BoundedInputStream;
+
+import javax.annotation.Nullable;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** The snapshot of a data cache. It could be written out or read from an external stream.O */
+public class DataCacheSnapshot {
+
+    private static final int CURRENT_VERSION = 1;
+
+    private final FileSystem fileSystem;
+
+    @Nullable private final Tuple2<Integer, Integer> readerPosition;
+
+    private final List<Segment> segments;
+
+    public DataCacheSnapshot(
+            FileSystem fileSystem,
+            @Nullable Tuple2<Integer, Integer> readerPosition,
+            List<Segment> segments) {
+        this.fileSystem = fileSystem;
+        this.readerPosition = readerPosition;
+        this.segments = segments;
+    }
+
+    public FileSystem getFileSystem() {
+        return fileSystem;
+    }
+
+    @Nullable
+    public Tuple2<Integer, Integer> getReaderPosition() {
+        return readerPosition;
+    }
+
+    public List<Segment> getSegments() {
+        return segments;
+    }
+
+    public void writeTo(OutputStream checkpointOutputStream) throws IOException {
+        try (DataOutputStream dos =
+                new DataOutputStream(new NonClosingOutpusStreamDecorator(checkpointOutputStream))) {
+            dos.writeInt(CURRENT_VERSION);
+            dos.writeBoolean(readerPosition != null);
+            if (readerPosition != null) {
+                dos.writeInt(readerPosition.f0);
+                dos.writeInt(readerPosition.f1);
+            }
+
+            dos.writeBoolean(fileSystem.isDistributedFS());
+            if (fileSystem.isDistributedFS()) {
+                // We only need to record the segments itself
+                serializeSegments(segments, dos);
+            } else {
+                // We have to copy the whole streams.
+                int totalRecords = segments.stream().mapToInt(Segment::getCount).sum();
+                long totalSize = segments.stream().mapToLong(Segment::getSize).sum();
+                checkState(totalRecords >= 0, "overflowed: " + totalRecords);
+                dos.writeInt(totalRecords);
+                dos.writeLong(totalSize);
+
+                for (Segment segment : segments) {
+                    try (FSDataInputStream inputStream = fileSystem.open(segment.getPath())) {
+                        IOUtils.copyBytes(inputStream, checkpointOutputStream, false);
+                    }
+                }
+            }
+        }
+    }
+
+    public static <T> void replay(
+            InputStream checkpointInputStream,
+            TypeSerializer<T> serializer,
+            FileSystem fileSystem,
+            FeedbackConsumer<T> feedbackConsumer)
+            throws Exception {
+        try (DataInputStream dis =
+                new DataInputStream(new NonClosingInputStreamDecorator(checkpointInputStream))) {
+            int version = dis.readInt();
+            checkState(
+                    version == CURRENT_VERSION,
+                    "Currently only support version " + CURRENT_VERSION);
+            parseReaderPosition(dis);
+
+            boolean isDistributedFS = dis.readBoolean();
+            if (isDistributedFS) {
+                List<Segment> segments = deserializeSegments(dis);
+                DataCacheReader<T> dataCacheReader =
+                        new DataCacheReader<T>(serializer, fileSystem, segments);
+                while (dataCacheReader.hasNext()) {
+                    feedbackConsumer.processFeedback(dataCacheReader.next());
+                }
+            } else {
+                DataInputViewStreamWrapper dataInputView = new DataInputViewStreamWrapper(dis);
+                int totalRecords = dis.readInt();
+                // Ignore the total size.
+                dis.readLong();
+                for (int i = 0; i < totalRecords; ++i) {
+                    feedbackConsumer.processFeedback(serializer.deserialize(dataInputView));
+                }
+            }
+        }
+    }
+
+    public static DataCacheSnapshot recover(
+            InputStream checkpointInputStream,
+            FileSystem fileSystem,
+            SupplierWithException<Path, IOException> pathGenerator)
+            throws IOException {
+        try (DataInputStream dis =
+                new DataInputStream(new NonClosingInputStreamDecorator(checkpointInputStream))) {
+            int version = dis.readInt();
+            checkState(
+                    version == CURRENT_VERSION,
+                    "Currently only support version " + CURRENT_VERSION);
+            Tuple2<Integer, Integer> readerPosition = parseReaderPosition(dis);
+
+            boolean isDistributedFS = dis.readBoolean();
+            checkState(
+                    isDistributedFS == fileSystem.isDistributedFS(),
+                    "Currently we do not support changing the cache file system. "
+                            + "If required, please manually copy the directory from one filesystem to another.");
+
+            List<Segment> segments;
+            if (isDistributedFS) {
+                segments = deserializeSegments(dis);
+            } else {
+                int totalRecords = dis.readInt();
+                long totalSize = dis.readLong();
+
+                Path path = pathGenerator.get();
+                try (FSDataOutputStream outputStream =
+                        fileSystem.create(path, FileSystem.WriteMode.NO_OVERWRITE)) {
+
+                    BoundedInputStream inputStream =
+                            new BoundedInputStream(checkpointInputStream, totalSize);
+                    inputStream.setPropagateClose(false);
+                    IOUtils.copyBytes(inputStream, outputStream, false);
+                    inputStream.close();
+                }
+                segments = Collections.singletonList(new Segment(path, totalRecords, totalSize));
+            }
+
+            return new DataCacheSnapshot(fileSystem, readerPosition, segments);
+        }
+    }
+
+    private static Tuple2<Integer, Integer> parseReaderPosition(DataInputStream dataInputStream)
+            throws IOException {
+        Tuple2<Integer, Integer> readerPosition = null;
+        boolean hasReaderPosition = dataInputStream.readBoolean();
+        if (hasReaderPosition) {
+            readerPosition = new Tuple2<>(dataInputStream.readInt(), dataInputStream.readInt());
+        }
+
+        return readerPosition;
+    }
+
+    private static void serializeSegments(List<Segment> segments, DataOutputStream dataOutputStream)
+            throws IOException {
+        dataOutputStream.writeInt(segments.size());
+        for (int i = 0; i < segments.size(); ++i) {
+            dataOutputStream.writeUTF(segments.get(i).getPath().toString());
+            dataOutputStream.writeInt(segments.get(i).getCount());
+            dataOutputStream.writeLong(segments.get(i).getSize());
+        }
+    }
+
+    private static List<Segment> deserializeSegments(DataInputStream dataInputStream)
+            throws IOException {
+        List<Segment> segments = new ArrayList<>();
+        int numberOfSegments = dataInputStream.readInt();
+        for (int i = 0; i < numberOfSegments; ++i) {
+            segments.add(
+                    new Segment(
+                            new Path(dataInputStream.readUTF()),
+                            dataInputStream.readInt(),
+                            dataInputStream.readLong()));
+        }
+        return segments;
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/Segment.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/Segment.java
@@ -70,4 +70,9 @@ public class Segment implements Serializable {
     public int hashCode() {
         return Objects.hash(path, count, size);
     }
+
+    @Override
+    public String toString() {
+        return "Segment{" + "path=" + path + ", count=" + count + ", size=" + size + '}';
+    }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.iteration.operator;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.iteration.IterationID;
@@ -27,6 +28,9 @@ import org.apache.flink.iteration.broadcast.BroadcastOutput;
 import org.apache.flink.iteration.broadcast.BroadcastOutputFactory;
 import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
 import org.apache.flink.iteration.operator.event.SubtaskAlignedEvent;
+import org.apache.flink.iteration.operator.headprocessor.HeadOperatorRecordProcessor;
+import org.apache.flink.iteration.operator.headprocessor.RegularHeadOperatorRecordProcessor;
+import org.apache.flink.iteration.operator.headprocessor.TerminatingHeadOperatorRecordProcessor;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
@@ -45,17 +49,18 @@ import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
-import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.OutputTag;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 
+import static org.apache.flink.util.Preconditions.checkState;
+
 /**
- * The head operators unions the initialized variable stream and the feedback stream, and
- * synchronize the epoch watermark (round).
+ * The head operator unions the initialized variable stream and the feedback stream, and synchronize
+ * the epoch watermark (round).
  */
 public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
         implements OneInputStreamOperator<IterationRecord<?>, IterationRecord<?>>,
@@ -76,15 +81,15 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
 
     private final MailboxExecutor mailboxExecutor;
 
-    private final Map<Integer, Long> numFeedbackRecordsPerEpoch;
-
-    private transient String uniqueSenderId;
-
     private transient BroadcastOutput<?> eventBroadcastOutput;
 
-    private transient StreamRecord<IterationRecord<?>> reusable;
+    private transient ContextImpl processorContext;
 
-    private transient boolean shouldTerminate;
+    // ------------- runtime -------------------
+
+    private HeadOperatorStatus status;
+
+    private HeadOperatorRecordProcessor recordProcessor;
 
     public HeadOperator(
             IterationID iterationId,
@@ -98,7 +103,6 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
         this.isCriteriaStream = isCriteriaStream;
         this.mailboxExecutor = Objects.requireNonNull(mailboxExecutor);
         this.operatorEventGateway = Objects.requireNonNull(operatorEventGateway);
-        this.numFeedbackRecordsPerEpoch = new HashMap<>();
 
         // Even though this operator does not use the processing
         // time service, AbstractStreamOperator requires this
@@ -112,9 +116,6 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
             StreamConfig config,
             Output<StreamRecord<IterationRecord<?>>> output) {
         super.setup(containingTask, config, output);
-        uniqueSenderId =
-                OperatorUtils.getUniqueSenderId(
-                        getOperatorID(), getRuntimeContext().getIndexOfThisSubtask());
         eventBroadcastOutput =
                 BroadcastOutputFactory.createBroadcastOutput(
                         output, metrics.getIOMetricGroup().getNumRecordsOutCounter());
@@ -124,12 +125,14 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
     public void initializeState(StateInitializationContext context) throws Exception {
         super.initializeState(context);
 
-        reusable = new StreamRecord<>(null);
+        processorContext = new ContextImpl();
+        status = HeadOperatorStatus.RUNNING;
+        recordProcessor = new RegularHeadOperatorRecordProcessor(processorContext);
 
         // Here we register a mail
         registerFeedbackConsumer(
                 (Runnable runnable) -> {
-                    if (!shouldTerminate) {
+                    if (status != HeadOperatorStatus.TERMINATED) {
                         mailboxExecutor.execute(runnable::run, "Head feedback");
                     }
                 });
@@ -137,71 +140,37 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
 
     @Override
     public void processElement(StreamRecord<IterationRecord<?>> element) throws Exception {
-        processRecord(element);
+        recordProcessor.processElement(element);
     }
 
     @Override
     public void processFeedback(StreamRecord<IterationRecord<?>> iterationRecord) throws Exception {
-        if (iterationRecord.getValue().getType() == IterationRecord.Type.RECORD) {
-            numFeedbackRecordsPerEpoch.compute(
-                    iterationRecord.getValue().getEpoch(),
-                    (round, count) -> count == null ? 1 : count + 1);
-        }
-        processRecord(iterationRecord);
-    }
-
-    private void processRecord(StreamRecord<IterationRecord<?>> iterationRecord) {
-        switch (iterationRecord.getValue().getType()) {
-            case RECORD:
-                reusable.replace(iterationRecord.getValue(), iterationRecord.getTimestamp());
-                output.collect(reusable);
-                break;
-            case EPOCH_WATERMARK:
-                LOG.debug(
-                        "Head Received epoch watermark {}", iterationRecord.getValue().getEpoch());
-                sendEpochWatermarkToCoordinator(iterationRecord.getValue().getEpoch());
-                break;
+        boolean terminated = recordProcessor.processFeedbackElement(iterationRecord);
+        if (terminated) {
+            checkState(status == HeadOperatorStatus.TERMINATING);
+            status = HeadOperatorStatus.TERMINATED;
         }
     }
 
     @Override
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public void handleOperatorEvent(OperatorEvent operatorEvent) {
         if (operatorEvent instanceof GloballyAlignedEvent) {
-            try {
-                GloballyAlignedEvent globallyAlignedEvent = (GloballyAlignedEvent) operatorEvent;
-                LOG.info("Received global event {}", globallyAlignedEvent);
-
-                shouldTerminate = globallyAlignedEvent.isTerminated();
-                reusable.replace(
-                        IterationRecord.newEpochWatermark(
-                                globallyAlignedEvent.isTerminated()
-                                        ? Integer.MAX_VALUE
-                                        : globallyAlignedEvent.getEpoch(),
-                                uniqueSenderId),
-                        0);
-                eventBroadcastOutput.broadcastEmit((StreamRecord) reusable);
-                numFeedbackRecordsPerEpoch.remove(globallyAlignedEvent.getEpoch());
-            } catch (Exception e) {
-                ExceptionUtils.rethrow(e);
+            boolean shouldTerminate =
+                    recordProcessor.onGloballyAligned((GloballyAlignedEvent) operatorEvent);
+            if (shouldTerminate) {
+                status = HeadOperatorStatus.TERMINATING;
+                recordProcessor = new TerminatingHeadOperatorRecordProcessor();
             }
         }
     }
 
     @Override
     public void endInput() throws Exception {
-        sendEpochWatermarkToCoordinator(0);
-        while (!shouldTerminate) {
+        recordProcessor.processElement(
+                new StreamRecord<>(IterationRecord.newEpochWatermark(0, "fake")));
+        while (status != HeadOperatorStatus.TERMINATED) {
             mailboxExecutor.yield();
         }
-    }
-
-    private void sendEpochWatermarkToCoordinator(int round) {
-        operatorEventGateway.sendEventToCoordinator(
-                new SubtaskAlignedEvent(
-                        round,
-                        numFeedbackRecordsPerEpoch.getOrDefault(round, 0L),
-                        isCriteriaStream));
     }
 
     private void registerFeedbackConsumer(Executor mailboxExecutor) {
@@ -217,11 +186,6 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
     }
 
     @VisibleForTesting
-    Map<Integer, Long> getNumFeedbackRecordsPerEpoch() {
-        return numFeedbackRecordsPerEpoch;
-    }
-
-    @VisibleForTesting
     public OperatorEventGateway getOperatorEventGateway() {
         return operatorEventGateway;
     }
@@ -229,5 +193,63 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
     @VisibleForTesting
     MailboxExecutor getMailboxExecutor() {
         return mailboxExecutor;
+    }
+
+    @VisibleForTesting
+    HeadOperatorRecordProcessor getRecordProcessor() {
+        return recordProcessor;
+    }
+
+    @VisibleForTesting
+    public HeadOperatorStatus getStatus() {
+        return status;
+    }
+
+    @VisibleForTesting
+    enum HeadOperatorStatus {
+        RUNNING,
+
+        TERMINATING,
+
+        TERMINATED
+    }
+
+    private class ContextImpl implements HeadOperatorRecordProcessor.Context {
+
+        @Override
+        public StreamConfig getStreamConfig() {
+            return HeadOperator.this.config;
+        }
+
+        @Override
+        public TaskInfo getTaskInfo() {
+            return getContainingTask().getEnvironment().getTaskInfo();
+        }
+
+        @Override
+        public void output(StreamRecord<IterationRecord<?>> record) {
+            output.collect(record);
+        }
+
+        @Override
+        public void output(
+                OutputTag<IterationRecord<?>> outputTag, StreamRecord<IterationRecord<?>> record) {
+            output.collect(outputTag, record);
+        }
+
+        @Override
+        public void broadcastOutput(StreamRecord<IterationRecord<?>> record) {
+            try {
+                eventBroadcastOutput.broadcastEmit((StreamRecord) record);
+            } catch (IOException e) {
+                throw new FlinkRuntimeException("Failed to broadcast event", e);
+            }
+        }
+
+        @Override
+        public void updateEpochToCoordinator(int epoch, long numFeedbackRecords) {
+            operatorEventGateway.sendEventToCoordinator(
+                    new SubtaskAlignedEvent(epoch, numFeedbackRecords, isCriteriaStream));
+        }
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperator.java
@@ -21,23 +21,46 @@ package org.apache.flink.iteration.operator;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.iteration.IterationID;
 import org.apache.flink.iteration.IterationListener;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.broadcast.BroadcastOutput;
 import org.apache.flink.iteration.broadcast.BroadcastOutputFactory;
+import org.apache.flink.iteration.checkpoint.Checkpoints;
+import org.apache.flink.iteration.checkpoint.CheckpointsBroker;
+import org.apache.flink.iteration.datacache.nonkeyed.DataCacheSnapshot;
 import org.apache.flink.iteration.operator.event.CoordinatorCheckpointEvent;
 import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
 import org.apache.flink.iteration.operator.event.SubtaskAlignedEvent;
 import org.apache.flink.iteration.operator.headprocessor.HeadOperatorRecordProcessor;
+import org.apache.flink.iteration.operator.headprocessor.HeadOperatorState;
 import org.apache.flink.iteration.operator.headprocessor.RegularHeadOperatorRecordProcessor;
 import org.apache.flink.iteration.operator.headprocessor.TerminatingHeadOperatorRecordProcessor;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
+import org.apache.flink.iteration.utils.ReflectionUtils;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferConsumerWithPartialRecordLength;
+import org.apache.flink.runtime.io.network.partition.PipelinedSubpartition;
+import org.apache.flink.runtime.io.network.partition.PipelinedSubpartitionView;
+import org.apache.flink.runtime.io.network.partition.PrioritizedDeque;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEventHandler;
 import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StatePartitionStreamProvider;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackChannel;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackChannelBroker;
@@ -57,6 +80,9 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.OutputTag;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 
@@ -112,6 +138,16 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
 
     private HeadOperatorCheckpointAligner checkpointAligner;
 
+    // ------------- states -------------------
+
+    private ListState<Integer> parallelismState;
+
+    private ListState<Integer> statusState;
+
+    private ListState<HeadOperatorState> processorState;
+
+    private Checkpoints<IterationRecord<?>> checkpoints;
+
     public HeadOperator(
             IterationID iterationId,
             int feedbackIndex,
@@ -146,11 +182,86 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
     public void initializeState(StateInitializationContext context) throws Exception {
         super.initializeState(context);
 
+        parallelismState =
+                context.getOperatorStateStore()
+                        .getUnionListState(
+                                new ListStateDescriptor<>("parallelism", IntSerializer.INSTANCE));
+        OperatorStateUtils.getUniqueElement(parallelismState, "parallelism")
+                .ifPresent(
+                        oldParallelism ->
+                                checkState(
+                                        oldParallelism
+                                                == getRuntimeContext()
+                                                        .getNumberOfParallelSubtasks(),
+                                        "The head operator is recovered with parallelism changed from "
+                                                + oldParallelism
+                                                + " to "
+                                                + getRuntimeContext()
+                                                        .getNumberOfParallelSubtasks()));
+
+        // Initialize the status and the record processor.
         processorContext = new ContextImpl();
-        status = HeadOperatorStatus.RUNNING;
-        recordProcessor = new RegularHeadOperatorRecordProcessor(processorContext);
+        statusState =
+                context.getOperatorStateStore()
+                        .getListState(new ListStateDescriptor<>("status", Integer.class));
+        status =
+                HeadOperatorStatus.values()[
+                        OperatorStateUtils.getUniqueElement(statusState, "status").orElse(0)];
+        if (status == HeadOperatorStatus.RUNNING) {
+            recordProcessor = new RegularHeadOperatorRecordProcessor(processorContext);
+        } else {
+            recordProcessor = new TerminatingHeadOperatorRecordProcessor();
+        }
+
+        // Recover the process state if exists.
+        processorState =
+                context.getOperatorStateStore()
+                        .getListState(
+                                new ListStateDescriptor<>(
+                                        "processorState", HeadOperatorState.class));
+        OperatorStateUtils.getUniqueElement(processorState, "processorState")
+                .ifPresent(
+                        headOperatorState ->
+                                recordProcessor.initializeState(
+                                        headOperatorState, context.getRawOperatorStateInputs()));
 
         checkpointAligner = new HeadOperatorCheckpointAligner();
+
+        // Initialize the checkpoints
+        Path dataCachePath =
+                OperatorUtils.getDataCachePath(
+                        getRuntimeContext().getTaskManagerRuntimeInfo().getConfiguration(),
+                        getContainingTask()
+                                .getEnvironment()
+                                .getIOManager()
+                                .getSpillingDirectoriesPaths());
+        this.checkpoints =
+                new Checkpoints<>(
+                        config.getTypeSerializerOut(getClass().getClassLoader()),
+                        dataCachePath.getFileSystem(),
+                        OperatorUtils.createDataCacheFileGenerator(
+                                dataCachePath, "header-cp", getOperatorConfig().getOperatorID()));
+        CheckpointsBroker.get()
+                .setCheckpoints(
+                        OperatorUtils.<IterationRecord<?>>createFeedbackKey(
+                                        iterationId, feedbackIndex)
+                                .withSubTaskIndex(
+                                        getRuntimeContext().getIndexOfThisSubtask(),
+                                        getRuntimeContext().getAttemptNumber()),
+                        checkpoints);
+
+        try {
+            for (StatePartitionStreamProvider rawStateInput : context.getRawOperatorStateInputs()) {
+                DataCacheSnapshot.replay(
+                        rawStateInput.getStream(),
+                        checkpoints.getTypeSerializer(),
+                        checkpoints.getFileSystem(),
+                        (record) ->
+                                recordProcessor.processFeedbackElement(new StreamRecord<>(record)));
+            }
+        } catch (Exception e) {
+            throw new FlinkRuntimeException("Failed to replay the records", e);
+        }
 
         // Here we register a mail
         registerFeedbackConsumer(
@@ -171,8 +282,38 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
     @Override
     public void snapshotState(StateSnapshotContext context) throws Exception {
         super.snapshotState(context);
+
+        // Always clear the union list state before set value.
+        parallelismState.clear();
+        if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+            parallelismState.update(
+                    Collections.singletonList(getRuntimeContext().getNumberOfParallelSubtasks()));
+        }
+        statusState.update(Collections.singletonList(status.ordinal()));
+
+        HeadOperatorState currentProcessorState = recordProcessor.snapshotState();
+        if (currentProcessorState != null) {
+            processorState.update(Collections.singletonList(currentProcessorState));
+        } else {
+            processorState.clear();
+        }
+
+        if (status == HeadOperatorStatus.RUNNING) {
+            checkpoints.startLogging(
+                    context.getCheckpointId(), context.getRawOperatorStateOutput());
+        }
+
         checkpointAligner
                 .onStateSnapshot(context.getCheckpointId())
+                .forEach(this::processGloballyAlignedEvent);
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        super.notifyCheckpointAborted(checkpointId);
+
+        checkpointAligner
+                .onCheckpointAborted(checkpointId)
                 .forEach(this::processGloballyAlignedEvent);
     }
 
@@ -183,6 +324,12 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
 
     @Override
     public void processFeedback(StreamRecord<IterationRecord<?>> iterationRecord) throws Exception {
+        if (iterationRecord.getValue().getType() == IterationRecord.Type.BARRIER) {
+            checkpoints.commitCheckpointsUntil(iterationRecord.getValue().getCheckpointId());
+            return;
+        }
+
+        checkpoints.append(iterationRecord.getValue());
         boolean terminated = recordProcessor.processFeedbackElement(iterationRecord);
         if (terminated) {
             checkState(status == HeadOperatorStatus.TERMINATING);
@@ -213,10 +360,62 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
 
     @Override
     public void endInput() throws Exception {
-        recordProcessor.processElement(
-                new StreamRecord<>(IterationRecord.newEpochWatermark(0, "fake")));
+        if (status == HeadOperatorStatus.RUNNING) {
+            recordProcessor.processElement(
+                    new StreamRecord<>(IterationRecord.newEpochWatermark(0, "fake")));
+        }
+
+        // Since we choose to block here, we could not continue to process the barriers received
+        // from the task inputs, which would block the precedent tasks from finishing since
+        // they need to complete their final checkpoint. This is a temporary solution to this issue
+        // that we will check the input channels, trigger all the checkpoints until we see
+        // the EndOfPartitionEvent.
+        checkState(getContainingTask().getEnvironment().getAllInputGates().length == 1);
+        checkState(
+                getContainingTask()
+                                .getEnvironment()
+                                .getAllInputGates()[0]
+                                .getNumberOfInputChannels()
+                        == 1);
+        InputChannel inputChannel =
+                getContainingTask().getEnvironment().getAllInputGates()[0].getChannel(0);
+
+        boolean endOfPartitionReceived = false;
+        long lastTriggerCheckpointId = 0;
+        while (!endOfPartitionReceived && status != HeadOperatorStatus.TERMINATED) {
+            mailboxExecutor.tryYield();
+            Thread.sleep(200);
+
+            List<AbstractEvent> events = parseInputChannelEvents(inputChannel);
+
+            for (AbstractEvent event : events) {
+                if (event instanceof CheckpointBarrier) {
+                    CheckpointBarrier barrier = (CheckpointBarrier) event;
+                    if (barrier.getId() > lastTriggerCheckpointId) {
+                        getContainingTask()
+                                .triggerCheckpointAsync(
+                                        new CheckpointMetaData(
+                                                barrier.getId(), barrier.getTimestamp()),
+                                        barrier.getCheckpointOptions());
+                        lastTriggerCheckpointId = barrier.getId();
+                    }
+
+                } else if (event instanceof EndOfPartitionEvent) {
+                    endOfPartitionReceived = true;
+                }
+            }
+        }
+
+        // By here we could step into the normal loop.
         while (status != HeadOperatorStatus.TERMINATED) {
             mailboxExecutor.yield();
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (checkpoints != null) {
+            checkpoints.close();
         }
     }
 
@@ -230,6 +429,48 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
         FeedbackChannelBroker broker = FeedbackChannelBroker.get();
         FeedbackChannel<StreamRecord<IterationRecord<?>>> channel = broker.getChannel(key);
         OperatorUtils.registerFeedbackConsumer(channel, this, mailboxExecutor);
+    }
+
+    private List<AbstractEvent> parseInputChannelEvents(InputChannel inputChannel)
+            throws Exception {
+        List<AbstractEvent> events = new ArrayList<>();
+        if (inputChannel instanceof RemoteInputChannel) {
+            Class<?> seqBufferClass =
+                    Class.forName(
+                            "org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel$SequenceBuffer");
+            PrioritizedDeque<?> queue =
+                    ReflectionUtils.getFieldValue(
+                            inputChannel, RemoteInputChannel.class, "receivedBuffers");
+            for (Object sequenceBuffer : queue) {
+                Buffer buffer =
+                        ReflectionUtils.getFieldValue(sequenceBuffer, seqBufferClass, "buffer");
+                if (!buffer.isBuffer()) {
+                    events.add(EventSerializer.fromBuffer(buffer, getClass().getClassLoader()));
+                }
+            }
+        } else if (inputChannel instanceof LocalInputChannel) {
+            PipelinedSubpartitionView subpartitionView =
+                    ReflectionUtils.getFieldValue(
+                            inputChannel, LocalInputChannel.class, "subpartitionView");
+            PipelinedSubpartition pipelinedSubpartition =
+                    ReflectionUtils.getFieldValue(
+                            subpartitionView, PipelinedSubpartitionView.class, "parent");
+            PrioritizedDeque<BufferConsumerWithPartialRecordLength> queue =
+                    ReflectionUtils.getFieldValue(
+                            pipelinedSubpartition, PipelinedSubpartition.class, "buffers");
+            for (BufferConsumerWithPartialRecordLength bufferConsumer : queue) {
+                if (!bufferConsumer.getBufferConsumer().isBuffer()) {
+                    events.add(
+                            EventSerializer.fromBuffer(
+                                    bufferConsumer.getBufferConsumer().copy().build(),
+                                    getClass().getClassLoader()));
+                }
+            }
+        } else {
+            LOG.warn("Unknown input channel type: " + inputChannel);
+        }
+
+        return events;
     }
 
     @VisibleForTesting

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperatorCheckpointAligner.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperatorCheckpointAligner.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.operator;
+
+import org.apache.flink.iteration.operator.event.CoordinatorCheckpointEvent;
+import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
+import org.apache.flink.util.function.RunnableWithException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Aligns the checkpoint barrier from the task inputs and the checkpoint event from the coordinator.
+ * Besides, it needs to hold the other operator events after the checkpoint event till the state is
+ * snapshot.
+ */
+class HeadOperatorCheckpointAligner {
+
+    private final TreeMap<Long, CheckpointAlignment> checkpointAlignmments;
+
+    private long latestCheckpointFromCoordinator;
+
+    HeadOperatorCheckpointAligner() {
+        this.checkpointAlignmments = new TreeMap<>();
+    }
+
+    void waitTillCoordinatorNotified(long checkpointId, RunnableWithException defaultAction)
+            throws Exception {
+        CheckpointAlignment checkpointAlignment =
+                checkpointAlignmments.computeIfAbsent(
+                        checkpointId, ignored -> new CheckpointAlignment(true, false));
+        while (!checkpointAlignment.notifiedFromCoordinator) {
+            defaultAction.run();
+        }
+        checkpointAlignment.notifiedFromChannels = true;
+    }
+
+    void coordinatorNotify(CoordinatorCheckpointEvent checkpointEvent) {
+        checkState(checkpointEvent.getCheckpointId() > latestCheckpointFromCoordinator);
+        latestCheckpointFromCoordinator = checkpointEvent.getCheckpointId();
+        CheckpointAlignment checkpointAlignment =
+                checkpointAlignmments.computeIfAbsent(
+                        checkpointEvent.getCheckpointId(),
+                        ignored -> new CheckpointAlignment(false, true));
+        checkpointAlignment.notifiedFromCoordinator = true;
+    }
+
+    Optional<GloballyAlignedEvent> checkHoldingGloballyAlignedEvent(
+            GloballyAlignedEvent globallyAlignedEvent) {
+        CheckpointAlignment checkpointAlignment =
+                checkpointAlignmments.get(latestCheckpointFromCoordinator);
+        if (checkpointAlignment != null && !checkpointAlignment.notifiedFromChannels) {
+            checkpointAlignment.pendingGlobalEvents.add(globallyAlignedEvent);
+            return Optional.empty();
+        }
+
+        return Optional.of(globallyAlignedEvent);
+    }
+
+    List<GloballyAlignedEvent> onStateSnapshot(long checkpointId) {
+        CheckpointAlignment checkpointAlignment = checkpointAlignmments.remove(checkpointId);
+        checkState(
+                checkpointAlignment.notifiedFromCoordinator
+                        && checkpointAlignment.notifiedFromChannels,
+                "Checkpoint " + checkpointId + " is not fully aligned");
+        return checkpointAlignment.pendingGlobalEvents;
+    }
+
+    private static class CheckpointAlignment {
+
+        final List<GloballyAlignedEvent> pendingGlobalEvents;
+
+        boolean notifiedFromChannels;
+
+        boolean notifiedFromCoordinator;
+
+        public CheckpointAlignment(boolean notifiedFromChannels, boolean notifiedFromCoordinator) {
+            this.pendingGlobalEvents = new ArrayList<>();
+
+            this.notifiedFromChannels = notifiedFromChannels;
+            this.notifiedFromCoordinator = notifiedFromCoordinator;
+        }
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperatorFactory.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperatorFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.CoordinatedOperatorFactory;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -131,5 +132,12 @@ public class HeadOperatorFactory extends AbstractStreamOperatorFactory<Iteration
     public void setMailboxExecutor(MailboxExecutor mailboxExecutor) {
         // We need it to be yielding operator factory to disable chaining,
         // but we cannot use the given mailbox here since it has bugs.
+    }
+
+    @Override
+    public ChainingStrategy getChainingStrategy() {
+        // We could not allow the head operator chaining with the previous operator since
+        // the special treatment in endInput.
+        return ChainingStrategy.HEAD;
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/OperatorStateUtils.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/OperatorStateUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.operator;
+
+import org.apache.flink.api.common.state.ListState;
+
+import java.util.Iterator;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Utility to deal with the states inside the operator. */
+public class OperatorStateUtils {
+
+    public static <T> Optional<T> getUniqueElement(ListState<T> listState, String stateName)
+            throws Exception {
+        Iterator<T> iterator = listState.get().iterator();
+        if (!iterator.hasNext()) {
+            return Optional.empty();
+        }
+
+        T result = iterator.next();
+        checkState(!iterator.hasNext(), "The state " + stateName + " has more that one elements");
+        return Optional.of(result);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/OperatorUtils.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/OperatorUtils.java
@@ -30,13 +30,14 @@ import org.apache.flink.statefun.flink.core.feedback.FeedbackKey;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.function.SupplierWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Executor;
-import java.util.function.Supplier;
 
 /** Utility class for operators. */
 public class OperatorUtils {
@@ -92,7 +93,7 @@ public class OperatorUtils {
         return new Path(pathStr);
     }
 
-    public static Supplier<Path> createDataCacheFileGenerator(
+    public static SupplierWithException<Path, IOException> createDataCacheFileGenerator(
             Path basePath, String fileTypeName, OperatorID operatorId) {
         return () ->
                 new Path(

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/AbstractAllRoundWrapperOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/AbstractAllRoundWrapperOperator.java
@@ -18,28 +18,45 @@
 
 package org.apache.flink.iteration.operator.allround;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.iteration.IterationListener;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.AbstractWrapperOperator;
+import org.apache.flink.iteration.operator.OperatorStateUtils;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.streaming.api.operators.KeyContext;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactoryUtil;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.StreamOperatorStateContext;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.util.OutputTag;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.apache.flink.iteration.operator.OperatorUtils.processOperatorOrUdfIfSatisfy;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** The base class for the all-round wrapper operators. */
 public abstract class AbstractAllRoundWrapperOperator<T, S extends StreamOperator<T>>
@@ -48,6 +65,13 @@ public abstract class AbstractAllRoundWrapperOperator<T, S extends StreamOperato
     protected final S wrappedOperator;
 
     private final IterationContext iterationContext;
+
+    // --------------- state ---------------------------
+    private int latestEpochWatermark = -1;
+
+    private ListState<Integer> parallelismState;
+
+    private ListState<Integer> latestEpochWatermarkState;
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public AbstractAllRoundWrapperOperator(
@@ -75,6 +99,11 @@ public abstract class AbstractAllRoundWrapperOperator<T, S extends StreamOperato
 
     @Override
     public void onEpochWatermarkIncrement(int epochWatermark) throws IOException {
+        if (epochWatermark <= latestEpochWatermark) {
+            return;
+        }
+        latestEpochWatermark = epochWatermark;
+
         setIterationContextRound(epochWatermark);
         processOperatorOrUdfIfSatisfy(
                 wrappedOperator,
@@ -100,6 +129,69 @@ public abstract class AbstractAllRoundWrapperOperator<T, S extends StreamOperato
     }
 
     @Override
+    public void initializeState(StreamTaskStateInitializer streamTaskStateManager)
+            throws Exception {
+        RecordingStreamTaskStateInitializer recordingStreamTaskStateInitializer =
+                new RecordingStreamTaskStateInitializer(streamTaskStateManager);
+        wrappedOperator.initializeState(recordingStreamTaskStateInitializer);
+        checkState(recordingStreamTaskStateInitializer.lastCreated != null);
+
+        OperatorStateStore operatorStateStore =
+                recordingStreamTaskStateInitializer.lastCreated.operatorStateBackend();
+
+        parallelismState =
+                operatorStateStore.getUnionListState(
+                        new ListStateDescriptor<>("parallelism", IntSerializer.INSTANCE));
+        OperatorStateUtils.getUniqueElement(parallelismState, "parallelism")
+                .ifPresent(
+                        oldParallelism ->
+                                checkState(
+                                        oldParallelism
+                                                == containingTask
+                                                        .getEnvironment()
+                                                        .getTaskInfo()
+                                                        .getNumberOfParallelSubtasks(),
+                                        "The all-round wrapper operator is recovered with parallelism changed from "
+                                                + oldParallelism
+                                                + " to "
+                                                + containingTask
+                                                        .getEnvironment()
+                                                        .getTaskInfo()
+                                                        .getNumberOfParallelSubtasks()));
+
+        latestEpochWatermarkState =
+                operatorStateStore.getListState(
+                        new ListStateDescriptor<>("latestEpoch", IntSerializer.INSTANCE));
+        OperatorStateUtils.getUniqueElement(latestEpochWatermarkState, "latestEpoch")
+                .ifPresent(
+                        oldLatestEpochWatermark -> latestEpochWatermark = oldLatestEpochWatermark);
+    }
+
+    @Override
+    public OperatorSnapshotFutures snapshotState(
+            long checkpointId,
+            long timestamp,
+            CheckpointOptions checkpointOptions,
+            CheckpointStreamFactory storageLocation)
+            throws Exception {
+
+        // Always clear the union list state before set value.
+        parallelismState.clear();
+        if (containingTask.getEnvironment().getTaskInfo().getIndexOfThisSubtask() == 0) {
+            parallelismState.update(
+                    Collections.singletonList(
+                            containingTask
+                                    .getEnvironment()
+                                    .getTaskInfo()
+                                    .getNumberOfParallelSubtasks()));
+        }
+        latestEpochWatermarkState.update(Collections.singletonList(latestEpochWatermark));
+
+        return wrappedOperator.snapshotState(
+                checkpointId, timestamp, checkpointOptions, storageLocation);
+    }
+
+    @Override
     public void open() throws Exception {
         wrappedOperator.open();
     }
@@ -117,23 +209,6 @@ public abstract class AbstractAllRoundWrapperOperator<T, S extends StreamOperato
     @Override
     public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
         wrappedOperator.prepareSnapshotPreBarrier(checkpointId);
-    }
-
-    @Override
-    public OperatorSnapshotFutures snapshotState(
-            long checkpointId,
-            long timestamp,
-            CheckpointOptions checkpointOptions,
-            CheckpointStreamFactory storageLocation)
-            throws Exception {
-        return wrappedOperator.snapshotState(
-                checkpointId, timestamp, checkpointOptions, storageLocation);
-    }
-
-    @Override
-    public void initializeState(StreamTaskStateInitializer streamTaskStateManager)
-            throws Exception {
-        wrappedOperator.initializeState(streamTaskStateManager);
     }
 
     @Override
@@ -176,11 +251,53 @@ public abstract class AbstractAllRoundWrapperOperator<T, S extends StreamOperato
         return wrappedOperator.getCurrentKey();
     }
 
+    @VisibleForTesting
+    int getLatestEpochWatermark() {
+        return latestEpochWatermark;
+    }
+
     private class IterationContext implements IterationListener.Context {
 
         @Override
         public <X> void output(OutputTag<X> outputTag, X value) {
             proxyOutput.collect(outputTag, new StreamRecord<>(value));
+        }
+    }
+
+    private static class RecordingStreamTaskStateInitializer implements StreamTaskStateInitializer {
+
+        private final StreamTaskStateInitializer wrapped;
+
+        StreamOperatorStateContext lastCreated;
+
+        public RecordingStreamTaskStateInitializer(StreamTaskStateInitializer wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public StreamOperatorStateContext streamOperatorStateContext(
+                @Nonnull OperatorID operatorID,
+                @Nonnull String s,
+                @Nonnull ProcessingTimeService processingTimeService,
+                @Nonnull KeyContext keyContext,
+                @Nullable TypeSerializer<?> typeSerializer,
+                @Nonnull CloseableRegistry closeableRegistry,
+                @Nonnull MetricGroup metricGroup,
+                double v,
+                boolean b)
+                throws Exception {
+            lastCreated =
+                    wrapped.streamOperatorStateContext(
+                            operatorID,
+                            s,
+                            processingTimeService,
+                            keyContext,
+                            typeSerializer,
+                            closeableRegistry,
+                            metricGroup,
+                            v,
+                            b);
+            return lastCreated;
         }
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/AbstractAllRoundWrapperOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/AbstractAllRoundWrapperOperator.java
@@ -99,19 +99,18 @@ public abstract class AbstractAllRoundWrapperOperator<T, S extends StreamOperato
 
     @Override
     public void onEpochWatermarkIncrement(int epochWatermark) throws IOException {
-        if (epochWatermark <= latestEpochWatermark) {
-            return;
+        if (epochWatermark > latestEpochWatermark) {
+            latestEpochWatermark = epochWatermark;
+
+            setIterationContextRound(epochWatermark);
+            processOperatorOrUdfIfSatisfy(
+                    wrappedOperator,
+                    IterationListener.class,
+                    listener -> notifyEpochWatermarkIncrement(listener, epochWatermark));
+            clearIterationContextRound();
         }
-        latestEpochWatermark = epochWatermark;
 
-        setIterationContextRound(epochWatermark);
-        processOperatorOrUdfIfSatisfy(
-                wrappedOperator,
-                IterationListener.class,
-                listener -> notifyEpochWatermarkIncrement(listener, epochWatermark));
-        clearIterationContextRound();
-
-        // Broadcast the events.
+        // Always broadcasts the events.
         super.onEpochWatermarkIncrement(epochWatermark);
     }
 

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/MultipleInputAllRoundWrapperOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/MultipleInputAllRoundWrapperOperator.java
@@ -80,6 +80,8 @@ public class MultipleInputAllRoundWrapperOperator<OUT>
 
     @Override
     public void endInput(int i) throws Exception {
+        super.endInput(i);
+
         if (wrappedOperator instanceof BoundedMultiInput) {
             ((BoundedMultiInput) wrappedOperator).endInput(i);
         }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/TwoInputAllRoundWrapperOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/TwoInputAllRoundWrapperOperator.java
@@ -113,6 +113,8 @@ public class TwoInputAllRoundWrapperOperator<IN1, IN2, OUT>
 
     @Override
     public void endInput(int i) throws Exception {
+        super.endInput(i);
+
         if (wrappedOperator instanceof BoundedMultiInput) {
             ((BoundedMultiInput) wrappedOperator).endInput(i);
         }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/HeadOperatorCoordinator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/HeadOperatorCoordinator.java
@@ -20,6 +20,7 @@ package org.apache.flink.iteration.operator.coordinator;
 
 import org.apache.flink.iteration.IterationID;
 import org.apache.flink.iteration.operator.HeadOperator;
+import org.apache.flink.iteration.operator.event.CoordinatorCheckpointEvent;
 import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
 import org.apache.flink.iteration.operator.event.SubtaskAlignedEvent;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -37,7 +38,7 @@ import java.util.concurrent.Executors;
  * SharedProgressAligner} when received aligned event from the operator, and emit the globally
  * aligned event back after one round is globally aligned.
  */
-public class HeadOperatorCoordinator implements OperatorCoordinator {
+public class HeadOperatorCoordinator implements OperatorCoordinator, SharedProgressAlignerListener {
 
     private final Context context;
 
@@ -50,16 +51,22 @@ public class HeadOperatorCoordinator implements OperatorCoordinator {
         this.sharedProgressAligner = Objects.requireNonNull(sharedProgressAligner);
         this.subtaskGateways = new SubtaskGateway[context.currentParallelism()];
 
-        sharedProgressAligner.registerAlignedConsumer(context.getOperatorId(), this::onAligned);
+        sharedProgressAligner.registerAlignedListener(context.getOperatorId(), this);
     }
 
     @Override
     public void start() {}
 
     @Override
-    public void subtaskReady(int i, SubtaskGateway subtaskGateway) {
-        this.subtaskGateways[i] = subtaskGateway;
+    public void subtaskReady(int subtaskIndex, SubtaskGateway subtaskGateway) {
+        this.subtaskGateways[subtaskIndex] = subtaskGateway;
     }
+
+    @Override
+    public void resetToCheckpoint(long checkpointId, @Nullable byte[] bytes) {}
+
+    @Override
+    public void subtaskFailed(int subtaskIndex, @Nullable Throwable throwable) {}
 
     @Override
     public void handleEventFromOperator(int subtaskIndex, OperatorEvent operatorEvent) {
@@ -71,6 +78,11 @@ public class HeadOperatorCoordinator implements OperatorCoordinator {
         }
     }
 
+    @Override
+    public void checkpointCoordinator(long l, CompletableFuture<byte[]> completableFuture) {
+        sharedProgressAligner.requestCheckpoint(l, context.currentParallelism(), completableFuture);
+    }
+
     public void onAligned(GloballyAlignedEvent globallyAlignedEvent) {
         for (int i = 0; i < context.currentParallelism(); ++i) {
             subtaskGateways[i].sendEvent(globallyAlignedEvent);
@@ -78,23 +90,19 @@ public class HeadOperatorCoordinator implements OperatorCoordinator {
     }
 
     @Override
-    public void close() {
-        sharedProgressAligner.unregisterConsumer(context.getOperatorId());
+    public void onCheckpointAligned(CoordinatorCheckpointEvent coordinatorCheckpointEvent) {
+        for (int i = 0; i < context.currentParallelism(); ++i) {
+            subtaskGateways[i].sendEvent(coordinatorCheckpointEvent);
+        }
     }
 
     @Override
-    public void checkpointCoordinator(long l, CompletableFuture<byte[]> completableFuture) {
-        completableFuture.complete(new byte[0]);
+    public void close() {
+        sharedProgressAligner.unregisterListener(context.getOperatorId());
     }
 
     @Override
     public void notifyCheckpointComplete(long l) {}
-
-    @Override
-    public void resetToCheckpoint(long l, @Nullable byte[] bytes) {}
-
-    @Override
-    public void subtaskFailed(int i, @Nullable Throwable throwable) {}
 
     @Override
     public void subtaskReset(int i, long l) {}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/HeadOperatorCoordinator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/HeadOperatorCoordinator.java
@@ -63,10 +63,16 @@ public class HeadOperatorCoordinator implements OperatorCoordinator, SharedProgr
     }
 
     @Override
-    public void resetToCheckpoint(long checkpointId, @Nullable byte[] bytes) {}
+    public void resetToCheckpoint(long checkpointId, @Nullable byte[] bytes) {
+        for (int i = 0; i < context.currentParallelism(); ++i) {
+            sharedProgressAligner.removeProgressInfo(context.getOperatorId());
+        }
+    }
 
     @Override
-    public void subtaskFailed(int subtaskIndex, @Nullable Throwable throwable) {}
+    public void subtaskFailed(int subtaskIndex, @Nullable Throwable throwable) {
+        sharedProgressAligner.removeProgressInfo(context.getOperatorId(), subtaskIndex);
+    }
 
     @Override
     public void handleEventFromOperator(int subtaskIndex, OperatorEvent operatorEvent) {

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/SharedProgressAligner.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/SharedProgressAligner.java
@@ -182,6 +182,24 @@ public class SharedProgressAligner {
                 checkpointId);
     }
 
+    public void removeProgressInfo(OperatorID operatorId) {
+        runInEventLoop(
+                () -> statusByEpoch.values().forEach(status -> status.remove(operatorId)),
+                "remove the progress information for {}",
+                operatorId);
+    }
+
+    public void removeProgressInfo(OperatorID operatorId, int subtaskIndex) {
+        runInEventLoop(
+                () ->
+                        statusByEpoch
+                                .values()
+                                .forEach(status -> status.remove(operatorId, subtaskIndex)),
+                "remove the progress information for {}-{}",
+                operatorId,
+                subtaskIndex);
+    }
+
     private void runInEventLoop(
             ThrowingRunnable<Throwable> action,
             String actionName,
@@ -232,6 +250,16 @@ public class SharedProgressAligner {
                             + "than the expected total parallelism "
                             + totalHeadParallelism);
             return reportedSubtasks.size() == totalHeadParallelism;
+        }
+
+        public void remove(OperatorID operatorID) {
+            reportedSubtasks
+                    .entrySet()
+                    .removeIf(entry -> entry.getKey().getOperatorId().equals(operatorID));
+        }
+
+        public void remove(OperatorID operatorID, int subtaskIndex) {
+            reportedSubtasks.remove(new OperatorInstanceID(subtaskIndex, operatorID));
         }
 
         public boolean isTerminated() {

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/SharedProgressAligner.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/SharedProgressAligner.java
@@ -20,6 +20,7 @@ package org.apache.flink.iteration.operator.coordinator;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.iteration.IterationID;
+import org.apache.flink.iteration.operator.event.CoordinatorCheckpointEvent;
 import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
 import org.apache.flink.iteration.operator.event.SubtaskAlignedEvent;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -31,12 +32,14 @@ import org.apache.flink.util.function.ThrowingRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -44,7 +47,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * The progress aligner shared between multiple {@link HeadOperatorCoordinator}. It maintains the
  * information for each round, once one round is aligned, it would notify all the register
- * consumers.
+ * listeners.
  */
 public class SharedProgressAligner {
 
@@ -63,7 +66,9 @@ public class SharedProgressAligner {
 
     private final Map<Integer, EpochStatus> statusByEpoch;
 
-    private final Map<OperatorID, Consumer<GloballyAlignedEvent>> alignedConsumers;
+    private final Map<OperatorID, SharedProgressAlignerListener> listeners;
+
+    private final Map<Long, CheckpointStatus> checkpointStatuses;
 
     public static SharedProgressAligner getOrCreate(
             IterationID iterationId,
@@ -93,29 +98,28 @@ public class SharedProgressAligner {
         this.executor = Objects.requireNonNull(executor);
 
         this.statusByEpoch = new HashMap<>();
-        this.alignedConsumers = new HashMap<>();
+        this.listeners = new HashMap<>();
+        this.checkpointStatuses = new HashMap<>();
     }
 
-    public void registerAlignedConsumer(
-            OperatorID operatorID, Consumer<GloballyAlignedEvent> alignedConsumer) {
+    public void registerAlignedListener(
+            OperatorID operatorID, SharedProgressAlignerListener alignedConsumer) {
         runInEventLoop(
-                () -> this.alignedConsumers.put(operatorID, alignedConsumer),
-                "Register consumer %s",
+                () -> this.listeners.put(operatorID, alignedConsumer),
+                "Register listeners %s",
                 operatorID.toHexString());
     }
 
-    public void unregisterConsumer(OperatorID operatorID) {
-        synchronized (this) {
-            runInEventLoop(
-                    () -> {
-                        this.alignedConsumers.remove(operatorID);
-                        if (alignedConsumers.isEmpty()) {
-                            instances.remove(iterationId);
-                        }
-                    },
-                    "Unregister consumer %s",
-                    operatorID.toHexString());
-        }
+    public void unregisterListener(OperatorID operatorID) {
+        runInEventLoop(
+                () -> {
+                    this.listeners.remove(operatorID);
+                    if (listeners.isEmpty()) {
+                        instances.remove(iterationId);
+                    }
+                },
+                "Unregister listeners %s",
+                operatorID.toHexString());
     }
 
     public void reportSubtaskProgress(
@@ -137,14 +141,45 @@ public class SharedProgressAligner {
                         GloballyAlignedEvent globallyAlignedEvent =
                                 new GloballyAlignedEvent(
                                         subtaskAlignedEvent.getEpoch(), roundStatus.isTerminated());
-                        for (Consumer<GloballyAlignedEvent> consumer : alignedConsumers.values()) {
-                            consumer.accept(globallyAlignedEvent);
+                        for (SharedProgressAlignerListener listeners : listeners.values()) {
+                            listeners.onAligned(globallyAlignedEvent);
                         }
                     }
                 },
                 "Report subtask %s-%d",
                 operatorId.toHexString(),
                 subtaskIndex);
+    }
+
+    public void requestCheckpoint(
+            long checkpointId,
+            int operatorParallelism,
+            CompletableFuture<byte[]> snapshotStateFuture) {
+        runInEventLoop(
+                () -> {
+                    CheckpointStatus checkpointStatus =
+                            checkpointStatuses.computeIfAbsent(
+                                    checkpointId,
+                                    ignored -> new CheckpointStatus(totalHeadParallelism));
+                    boolean aligned =
+                            checkpointStatus.notify(operatorParallelism, snapshotStateFuture);
+                    if (aligned) {
+                        CoordinatorCheckpointEvent checkpointEvent =
+                                new CoordinatorCheckpointEvent(checkpointId);
+                        for (SharedProgressAlignerListener listener : listeners.values()) {
+                            listener.onCheckpointAligned(checkpointEvent);
+                        }
+
+                        for (CompletableFuture<byte[]> stateFuture :
+                                checkpointStatus.getStateFutures()) {
+                            stateFuture.complete(new byte[0]);
+                        }
+
+                        checkpointStatuses.remove(checkpointId);
+                    }
+                },
+                "Coordinator report checkpoint %d",
+                checkpointId);
     }
 
     private void runInEventLoop(
@@ -170,8 +205,8 @@ public class SharedProgressAligner {
     }
 
     @VisibleForTesting
-    int getNumberConsumers() {
-        return alignedConsumers.size();
+    int getNumberListeners() {
+        return listeners.size();
     }
 
     private static class EpochStatus {
@@ -222,6 +257,30 @@ public class SharedProgressAligner {
             }
 
             return totalRecord == 0 || (hasCriteriaStream && totalCriteriaRecord == 0);
+        }
+    }
+
+    private static class CheckpointStatus {
+
+        private final long totalHeadParallelism;
+
+        private final List<CompletableFuture<byte[]>> stateFutures = new ArrayList<>();
+
+        private int notifiedCoordinatorParallelism;
+
+        private CheckpointStatus(long totalHeadParallelism) {
+            this.totalHeadParallelism = totalHeadParallelism;
+        }
+
+        public boolean notify(int parallelism, CompletableFuture<byte[]> stateFuture) {
+            stateFutures.add(stateFuture);
+            notifiedCoordinatorParallelism += parallelism;
+
+            return notifiedCoordinatorParallelism == totalHeadParallelism;
+        }
+
+        public List<CompletableFuture<byte[]>> getStateFutures() {
+            return stateFutures;
         }
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/SharedProgressAlignerListener.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/SharedProgressAlignerListener.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.operator.coordinator;
+
+import org.apache.flink.iteration.operator.event.CoordinatorCheckpointEvent;
+import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
+
+/** The listener of the {@link SharedProgressAligner}. */
+public interface SharedProgressAlignerListener {
+
+    void onAligned(GloballyAlignedEvent globallyAlignedEvent);
+
+    void onCheckpointAligned(CoordinatorCheckpointEvent coordinatorCheckpointEvent);
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/event/CoordinatorCheckpointEvent.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/event/CoordinatorCheckpointEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.operator.event;
+
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+
+import java.util.Objects;
+
+/** Coordinator received the request of checkpoints. */
+public class CoordinatorCheckpointEvent implements OperatorEvent {
+
+    private final long checkpointId;
+
+    public CoordinatorCheckpointEvent(long checkpointId) {
+        this.checkpointId = checkpointId;
+    }
+
+    public long getCheckpointId() {
+        return checkpointId;
+    }
+
+    @Override
+    public String toString() {
+        return "CoordinatorCheckpointEvent{" + "checkpointId=" + checkpointId + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CoordinatorCheckpointEvent)) {
+            return false;
+        }
+        CoordinatorCheckpointEvent that = (CoordinatorCheckpointEvent) o;
+        return checkpointId == that.checkpointId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(checkpointId);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorRecordProcessor.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorRecordProcessor.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.operator.headprocessor;
+
+import org.apache.flink.api.common.TaskInfo;
+import org.apache.flink.iteration.IterationRecord;
+import org.apache.flink.iteration.operator.HeadOperator;
+import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+
+/** The component to actually deal with the event received in the {@link HeadOperator}. */
+public interface HeadOperatorRecordProcessor {
+
+    void initializeState(HeadOperatorState headOperatorState) throws Exception;
+
+    void processElement(StreamRecord<IterationRecord<?>> record);
+
+    boolean processFeedbackElement(StreamRecord<IterationRecord<?>> record);
+
+    boolean onGloballyAligned(GloballyAlignedEvent globallyAlignedEvent);
+
+    HeadOperatorState snapshotState();
+
+    /** The context for {@link HeadOperatorRecordProcessor}. */
+    interface Context {
+
+        StreamConfig getStreamConfig();
+
+        TaskInfo getTaskInfo();
+
+        void output(StreamRecord<IterationRecord<?>> record);
+
+        void output(
+                OutputTag<IterationRecord<?>> outputTag, StreamRecord<IterationRecord<?>> record);
+
+        void broadcastOutput(StreamRecord<IterationRecord<?>> record);
+
+        void updateEpochToCoordinator(int epoch, long numFeedbackRecords);
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorRecordProcessor.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorRecordProcessor.java
@@ -22,14 +22,18 @@ import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.HeadOperator;
 import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
+import org.apache.flink.runtime.state.StatePartitionStreamProvider;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.OutputTag;
 
+import javax.annotation.Nullable;
+
 /** The component to actually deal with the event received in the {@link HeadOperator}. */
 public interface HeadOperatorRecordProcessor {
 
-    void initializeState(HeadOperatorState headOperatorState) throws Exception;
+    void initializeState(
+            HeadOperatorState headOperatorState, Iterable<StatePartitionStreamProvider> rawStates);
 
     void processElement(StreamRecord<IterationRecord<?>> record);
 
@@ -37,6 +41,7 @@ public interface HeadOperatorRecordProcessor {
 
     boolean onGloballyAligned(GloballyAlignedEvent globallyAlignedEvent);
 
+    @Nullable
     HeadOperatorState snapshotState();
 
     /** The context for {@link HeadOperatorRecordProcessor}. */

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorState.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorState.java
@@ -18,5 +18,35 @@
 
 package org.apache.flink.iteration.operator.headprocessor;
 
+import java.util.Map;
+
 /** The state entry for the head operator. */
-public class HeadOperatorState {}
+public class HeadOperatorState {
+
+    private Map<Integer, Long> numFeedbackRecordsEachRound;
+
+    private int latestRoundAligned;
+
+    private int latestRoundGloballyAligned;
+
+    public HeadOperatorState(
+            Map<Integer, Long> numFeedbackRecordsEachRound,
+            int latestRoundAligned,
+            int latestRoundGloballyAligned) {
+        this.numFeedbackRecordsEachRound = numFeedbackRecordsEachRound;
+        this.latestRoundAligned = latestRoundAligned;
+        this.latestRoundGloballyAligned = latestRoundGloballyAligned;
+    }
+
+    public Map<Integer, Long> getNumFeedbackRecordsEachRound() {
+        return numFeedbackRecordsEachRound;
+    }
+
+    public int getLatestRoundAligned() {
+        return latestRoundAligned;
+    }
+
+    public int getLatestRoundGloballyAligned() {
+        return latestRoundGloballyAligned;
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorState.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorState.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.operator.headprocessor;
+
+/** The state entry for the head operator. */
+public class HeadOperatorState {}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/RegularHeadOperatorRecordProcessor.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/RegularHeadOperatorRecordProcessor.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.operator.headprocessor;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.iteration.IterationRecord;
+import org.apache.flink.iteration.operator.OperatorUtils;
+import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Processes the event before we received the terminated global aligned event from the coordinator.
+ */
+public class RegularHeadOperatorRecordProcessor implements HeadOperatorRecordProcessor {
+
+    protected static final Logger LOG =
+            LoggerFactory.getLogger(RegularHeadOperatorRecordProcessor.class);
+
+    private final Context headOperatorContext;
+
+    private final StreamRecord<IterationRecord<?>> reusable;
+
+    private final Map<Integer, Long> numFeedbackRecordsPerEpoch;
+
+    private final String senderId;
+
+    public RegularHeadOperatorRecordProcessor(Context headOperatorContext) {
+        this.headOperatorContext = headOperatorContext;
+
+        this.reusable = new StreamRecord<>(null);
+        this.numFeedbackRecordsPerEpoch = new HashMap<>();
+
+        this.senderId =
+                OperatorUtils.getUniqueSenderId(
+                        headOperatorContext.getStreamConfig().getOperatorID(),
+                        headOperatorContext.getTaskInfo().getIndexOfThisSubtask());
+    }
+
+    @Override
+    public void initializeState(HeadOperatorState headOperatorState) throws Exception {}
+
+    @Override
+    public void processElement(StreamRecord<IterationRecord<?>> element) {
+        processRecord(element);
+    }
+
+    @Override
+    public boolean processFeedbackElement(StreamRecord<IterationRecord<?>> element) {
+        if (element.getValue().getType() == IterationRecord.Type.RECORD) {
+            numFeedbackRecordsPerEpoch.compute(
+                    element.getValue().getEpoch(), (epoch, count) -> count == null ? 1 : count + 1);
+        }
+
+        processRecord(element);
+
+        return false;
+    }
+
+    @Override
+    public boolean onGloballyAligned(GloballyAlignedEvent globallyAlignedEvent) {
+        LOG.info("Received global event {}", globallyAlignedEvent);
+
+        reusable.replace(
+                IterationRecord.newEpochWatermark(
+                        globallyAlignedEvent.isTerminated()
+                                ? Integer.MAX_VALUE
+                                : globallyAlignedEvent.getEpoch(),
+                        senderId),
+                0);
+        headOperatorContext.broadcastOutput(reusable);
+
+        return globallyAlignedEvent.isTerminated();
+    }
+
+    @Override
+    public HeadOperatorState snapshotState() {
+        return new HeadOperatorState();
+    }
+
+    @VisibleForTesting
+    public Map<Integer, Long> getNumFeedbackRecordsPerEpoch() {
+        return numFeedbackRecordsPerEpoch;
+    }
+
+    private void processRecord(StreamRecord<IterationRecord<?>> iterationRecord) {
+        switch (iterationRecord.getValue().getType()) {
+            case RECORD:
+                reusable.replace(iterationRecord.getValue(), iterationRecord.getTimestamp());
+                headOperatorContext.output(reusable);
+                break;
+            case EPOCH_WATERMARK:
+                LOG.info("Head Received epoch watermark {}", iterationRecord.getValue().getEpoch());
+                headOperatorContext.updateEpochToCoordinator(
+                        iterationRecord.getValue().getEpoch(),
+                        numFeedbackRecordsPerEpoch.getOrDefault(
+                                iterationRecord.getValue().getEpoch(), 0L));
+                break;
+        }
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/TerminatingHeadOperatorRecordProcessor.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/TerminatingHeadOperatorRecordProcessor.java
@@ -20,6 +20,7 @@ package org.apache.flink.iteration.operator.headprocessor;
 
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
+import org.apache.flink.runtime.state.StatePartitionStreamProvider;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -30,7 +31,9 @@ import org.apache.flink.util.FlinkRuntimeException;
 public class TerminatingHeadOperatorRecordProcessor implements HeadOperatorRecordProcessor {
 
     @Override
-    public void initializeState(HeadOperatorState headOperatorState) throws Exception {}
+    public void initializeState(
+            HeadOperatorState headOperatorState,
+            Iterable<StatePartitionStreamProvider> rawStates) {}
 
     @Override
     public void processElement(StreamRecord<IterationRecord<?>> record) {
@@ -55,6 +58,6 @@ public class TerminatingHeadOperatorRecordProcessor implements HeadOperatorRecor
 
     @Override
     public HeadOperatorState snapshotState() {
-        return new HeadOperatorState();
+        return null;
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/TerminatingHeadOperatorRecordProcessor.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/TerminatingHeadOperatorRecordProcessor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.operator.headprocessor;
+
+import org.apache.flink.iteration.IterationRecord;
+import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.FlinkRuntimeException;
+
+/**
+ * Processor used after we received terminated globally aligned event from the coordinator, but
+ * before we received the (Integer.MAX_VALUE + 1) from the feedback channel again.
+ */
+public class TerminatingHeadOperatorRecordProcessor implements HeadOperatorRecordProcessor {
+
+    @Override
+    public void initializeState(HeadOperatorState headOperatorState) throws Exception {}
+
+    @Override
+    public void processElement(StreamRecord<IterationRecord<?>> record) {
+        throw new FlinkRuntimeException(
+                "It is not possible to receive the element from normal input during terminating.");
+    }
+
+    @Override
+    public boolean processFeedbackElement(StreamRecord<IterationRecord<?>> record) {
+        if (record.getValue().getType() == IterationRecord.Type.EPOCH_WATERMARK) {
+            return record.getValue().getEpoch() == Integer.MAX_VALUE + 1;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean onGloballyAligned(GloballyAlignedEvent globallyAlignedEvent) {
+        throw new FlinkRuntimeException(
+                "It is not possible to receive the globally aligned event from normal input during terminating.");
+    }
+
+    @Override
+    public HeadOperatorState snapshotState() {
+        return new HeadOperatorState();
+    }
+}

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/IterationConstructionTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/IterationConstructionTest.java
@@ -378,7 +378,7 @@ public class IterationConstructionTest extends TestLogger {
                         /* 0 */ "Source: Variable -> input-Variable",
                         /* 1 */ "Source: Constant -> input-Constant",
                         /* 2 */ "Source: Termination -> input-Termination",
-                        /* 3 */ "head-Variable -> signal-change-typeinfo",
+                        /* 3 */ "head-Variable",
                         /* 4 */ "Replayer-Constant",
                         /* 5 */ "Processor -> output-SideOutput -> Sink: Sink",
                         /* 6 */ "Feedback",

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheSnapshotTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheSnapshotTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests the behavior of the {@link DataCacheSnapshot}. */
+@RunWith(Parameterized.class)
+public class DataCacheSnapshotTest extends TestLogger {
+
+    @ClassRule public static final TemporaryFolder CLASS_TEMPORARY_FOLDER = new TemporaryFolder();
+
+    private static MiniDFSCluster hdfsCluster;
+
+    private final FileSystem fileSystem;
+
+    private final Path basePath;
+
+    @BeforeClass
+    public static void createHDFS() throws Exception {
+        Assume.assumeTrue(!OperatingSystem.isWindows());
+
+        Configuration hdfsConfig = new Configuration();
+        hdfsConfig.set(
+                MiniDFSCluster.HDFS_MINIDFS_BASEDIR,
+                CLASS_TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+        hdfsCluster = new MiniDFSCluster.Builder(hdfsConfig).build();
+    }
+
+    @AfterClass
+    public static void destroyHDFS() {
+        if (hdfsCluster != null) {
+            hdfsCluster.shutdown();
+        }
+
+        hdfsCluster = null;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Object[][] testData() throws IOException {
+        return new Object[][] {new Object[] {"local"}, new Object[] {"hdfs"}};
+    }
+
+    public DataCacheSnapshotTest(String fileSystemType) throws IOException {
+        if (fileSystemType.equals("local")) {
+            fileSystem = FileSystem.getLocalFileSystem();
+            basePath = new Path("file://" + CLASS_TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+        } else if (fileSystemType.equals("hdfs")) {
+            fileSystem = new HadoopFileSystem(hdfsCluster.getNewFileSystemInstance(0));
+            basePath =
+                    new Path(hdfsCluster.getURI().toString() + "/" + UUID.randomUUID().toString());
+        } else {
+            throw new UnsupportedEncodingException("Unsupported fs type: " + fileSystemType);
+        }
+    }
+
+    @Test
+    public void testWithoutReaderPosition() throws Exception {
+        int[] numRecordsPerSegment = {100, 200, 300};
+        DataCacheWriter<Integer> writer = createWriterAndAddRecords(numRecordsPerSegment);
+        DataCacheSnapshot dataCacheSnapshot =
+                new DataCacheSnapshot(fileSystem, null, writer.getFinishSegments());
+        checkWriteAndRecoverAndReplay(numRecordsPerSegment, dataCacheSnapshot);
+    }
+
+    @Test
+    public void testWithReadPosition() throws Exception {
+        int[] numRecordsPerSegment = {100, 200, 300};
+        DataCacheWriter<Integer> writer = createWriterAndAddRecords(numRecordsPerSegment);
+        DataCacheSnapshot dataCacheSnapshot =
+                new DataCacheSnapshot(fileSystem, new Tuple2<>(0, 50), writer.getFinishSegments());
+        checkWriteAndRecoverAndReplay(numRecordsPerSegment, dataCacheSnapshot);
+    }
+
+    @Test
+    public void testSnapshotMultipleWritersIntoSingleStream() throws Exception {
+        int[] numRecordsPerSegment = {100, 200, 300};
+        DataCacheWriter<Integer> writer1 = createWriterAndAddRecords(numRecordsPerSegment);
+        DataCacheWriter<Integer> writer2 = createWriterAndAddRecords(numRecordsPerSegment);
+
+        checkWriteAndRecoverAndReplay(
+                numRecordsPerSegment,
+                new DataCacheSnapshot(fileSystem, null, writer1.getFinishSegments()),
+                new DataCacheSnapshot(fileSystem, null, writer2.getFinishSegments()));
+    }
+
+    private DataCacheWriter<Integer> createWriterAndAddRecords(int[] numRecordsPerSegment)
+            throws IOException {
+        DataCacheWriter<Integer> writer =
+                new DataCacheWriter<>(
+                        IntSerializer.INSTANCE,
+                        fileSystem,
+                        () -> new Path(basePath, "writer." + UUID.randomUUID().toString()));
+        int nextNumber = 0;
+        for (int numRecord : numRecordsPerSegment) {
+            for (int i = 0; i < numRecord; ++i) {
+                writer.addRecord(nextNumber++);
+            }
+            writer.finishCurrentSegment();
+        }
+        writer.finish();
+        return writer;
+    }
+
+    private void checkWriteAndRecoverAndReplay(
+            int[] numRecordsPerSegment, DataCacheSnapshot... dataCacheSnapshots) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        for (DataCacheSnapshot dataCacheSnapshot : dataCacheSnapshots) {
+            dataCacheSnapshot.writeTo(bos);
+        }
+
+        byte[] data = bos.toByteArray();
+
+        ByteArrayInputStream recoverInputStream = new ByteArrayInputStream(data);
+        for (DataCacheSnapshot dataCacheSnapshot : dataCacheSnapshots) {
+            checkRecover(dataCacheSnapshot, recoverInputStream);
+        }
+
+        ByteArrayInputStream replayInputStream = new ByteArrayInputStream(data);
+        for (DataCacheSnapshot dataCacheSnapshot : dataCacheSnapshots) {
+            checkReplay(dataCacheSnapshot, replayInputStream, numRecordsPerSegment);
+        }
+    }
+
+    private void checkRecover(DataCacheSnapshot dataCacheSnapshot, InputStream inputStream)
+            throws IOException {
+        DataCacheSnapshot copied =
+                DataCacheSnapshot.recover(
+                        inputStream,
+                        dataCacheSnapshot.getFileSystem(),
+                        () -> new Path(basePath, "writer." + UUID.randomUUID().toString()));
+        if (dataCacheSnapshot.getFileSystem().isDistributedFS()) {
+            assertEquals(dataCacheSnapshot.getSegments(), copied.getSegments());
+        } else {
+            assertEquals(readElements(dataCacheSnapshot), readElements(copied));
+        }
+
+        assertEquals(dataCacheSnapshot.getReaderPosition(), copied.getReaderPosition());
+    }
+
+    private void checkReplay(
+            DataCacheSnapshot dataCacheSnapshot,
+            InputStream inputStream,
+            int[] numRecordsPerSegment)
+            throws Exception {
+        List<Integer> elements = new ArrayList<>();
+        DataCacheSnapshot.replay(inputStream, IntSerializer.INSTANCE, fileSystem, elements::add);
+
+        int totalRecords = IntStream.of(numRecordsPerSegment).sum();
+        assertEquals(
+                IntStream.range(0, totalRecords).boxed().collect(Collectors.toList()), elements);
+    }
+
+    private List<Integer> readElements(DataCacheSnapshot dataCacheSnapshot) throws IOException {
+        DataCacheReader<Integer> reader =
+                new DataCacheReader<>(
+                        IntSerializer.INSTANCE,
+                        dataCacheSnapshot.getFileSystem(),
+                        dataCacheSnapshot.getSegments());
+        List<Integer> result = new ArrayList<>();
+        while (reader.hasNext()) {
+            result.add(reader.next());
+        }
+
+        return result;
+    }
+}

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/HeadOperatorTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/HeadOperatorTest.java
@@ -21,15 +21,20 @@ package org.apache.flink.iteration.operator;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.iteration.IterationID;
 import org.apache.flink.iteration.IterationRecord;
+import org.apache.flink.iteration.operator.event.CoordinatorCheckpointEvent;
 import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
 import org.apache.flink.iteration.operator.event.SubtaskAlignedEvent;
 import org.apache.flink.iteration.operator.headprocessor.RegularHeadOperatorRecordProcessor;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackChannel;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackChannelBroker;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -152,7 +157,7 @@ public class HeadOperatorTest extends TestLogger {
 
                                             while (RecordingHeadOperatorFactory.latestHeadOperator
                                                             .getStatus()
-                                                    == HeadOperator.HeadOperatorStatus.RUNNING) ;
+                                                    == HeadOperator.HeadOperatorStatus.RUNNING) {}
                                             putFeedbackRecords(
                                                     iterationId,
                                                     IterationRecord.newEpochWatermark(
@@ -190,6 +195,116 @@ public class HeadOperatorTest extends TestLogger {
                                     new StreamRecord<>(
                                             IterationRecord.newEpochWatermark(
                                                     Integer.MAX_VALUE,
+                                                    OperatorUtils.getUniqueSenderId(operatorId, 0)),
+                                            0)),
+                            new ArrayList<>(harness.getOutput()));
+                    return null;
+                });
+    }
+
+    @Test(timeout = 60000)
+    public void testHoldCheckpointTillCoordinatorNotified() throws Exception {
+        IterationID iterationId = new IterationID();
+        OperatorID operatorId = new OperatorID();
+
+        createHarnessAndRun(
+                iterationId,
+                operatorId,
+                null,
+                harness -> {
+                    CompletableFuture<Void> coordinatorResult =
+                            CompletableFuture.supplyAsync(
+                                    () -> {
+                                        try {
+                                            // Slight postpone the notification
+                                            Thread.sleep(2000);
+
+                                            harness.getStreamTask()
+                                                    .dispatchOperatorEvent(
+                                                            operatorId,
+                                                            new SerializedValue<>(
+                                                                    new GloballyAlignedEvent(
+                                                                            5, false)));
+                                            harness.getStreamTask()
+                                                    .dispatchOperatorEvent(
+                                                            operatorId,
+                                                            new SerializedValue<>(
+                                                                    new CoordinatorCheckpointEvent(
+                                                                            5)));
+                                            return null;
+                                        } catch (Throwable e) {
+                                            RecordingHeadOperatorFactory.latestHeadOperator
+                                                    .getMailboxExecutor()
+                                                    .execute(
+                                                            () -> {
+                                                                throw e;
+                                                            },
+                                                            "poison mail");
+                                            throw new CompletionException(e);
+                                        }
+                                    });
+
+                    CheckpointBarrier barrier =
+                            new CheckpointBarrier(
+                                    5,
+                                    5000,
+                                    CheckpointOptions.alignedNoTimeout(
+                                            CheckpointType.CHECKPOINT,
+                                            CheckpointStorageLocationReference.getDefault()));
+                    harness.processEvent(barrier);
+
+                    // There should be no exception
+                    coordinatorResult.get();
+
+                    // If the task do not hold, it would be likely snapshot state before received
+                    // the globally aligned event.
+                    assertEquals(
+                            Arrays.asList(
+                                    new StreamRecord<>(
+                                            IterationRecord.newEpochWatermark(
+                                                    5,
+                                                    OperatorUtils.getUniqueSenderId(operatorId, 0)),
+                                            0),
+                                    barrier),
+                            new ArrayList<>(harness.getOutput()));
+                    return null;
+                });
+    }
+
+    @Test(timeout = 60000)
+    public void testPostponeGloballyAlignedEventsAfterSnapshot() throws Exception {
+        IterationID iterationId = new IterationID();
+        OperatorID operatorId = new OperatorID();
+
+        createHarnessAndRun(
+                iterationId,
+                operatorId,
+                null,
+                harness -> {
+                    harness.getStreamTask()
+                            .dispatchOperatorEvent(
+                                    operatorId,
+                                    new SerializedValue<>(new CoordinatorCheckpointEvent(5)));
+                    harness.getStreamTask()
+                            .dispatchOperatorEvent(
+                                    operatorId,
+                                    new SerializedValue<>(new GloballyAlignedEvent(5, false)));
+                    CheckpointBarrier barrier =
+                            new CheckpointBarrier(
+                                    5,
+                                    5000,
+                                    CheckpointOptions.alignedNoTimeout(
+                                            CheckpointType.CHECKPOINT,
+                                            CheckpointStorageLocationReference.getDefault()));
+                    harness.processEvent(barrier);
+                    harness.processAll();
+
+                    assertEquals(
+                            Arrays.asList(
+                                    barrier,
+                                    new StreamRecord<>(
+                                            IterationRecord.newEpochWatermark(
+                                                    5,
                                                     OperatorUtils.getUniqueSenderId(operatorId, 0)),
                                             0)),
                             new ArrayList<>(harness.getOutput()));

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/HeadOperatorTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/HeadOperatorTest.java
@@ -25,9 +25,9 @@ import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
 import org.apache.flink.iteration.operator.event.SubtaskAlignedEvent;
 import org.apache.flink.iteration.operator.headprocessor.RegularHeadOperatorRecordProcessor;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.statefun.flink.core.feedback.FeedbackChannel;
@@ -38,11 +38,16 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarnessBuilder;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.FunctionWithException;
 
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,142 +67,171 @@ public class HeadOperatorTest extends TestLogger {
     @Test
     public void testForwardRecords() throws Exception {
         IterationID iterationId = new IterationID();
-        try (StreamTaskMailboxTestHarness<IterationRecord<Integer>> harness =
-                new StreamTaskMailboxTestHarnessBuilder<>(
-                                OneInputStreamTask::new,
-                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .setupOutputForSingletonOperatorChain(
-                                new RecordingHeadOperatorFactory(
-                                        iterationId, 0, false, 5, MockOperatorEventGateway::new))
-                        .build()) {
-            harness.processElement(new StreamRecord<>(IterationRecord.newRecord(1, 0), 2));
-            putFeedbackRecords(
-                    iterationId, 0, new StreamRecord<>(IterationRecord.newRecord(3, 1), 3));
-            harness.processAll();
-            harness.processElement(new StreamRecord<>(IterationRecord.newRecord(2, 0), 3));
-            putFeedbackRecords(
-                    iterationId, 0, new StreamRecord<>(IterationRecord.newRecord(4, 1), 4));
-            harness.processAll();
+        OperatorID operatorId = new OperatorID();
 
-            List<StreamRecord<IterationRecord<Integer>>> expectedOutput =
-                    Arrays.asList(
-                            new StreamRecord<>(IterationRecord.newRecord(1, 0), 2),
-                            new StreamRecord<>(IterationRecord.newRecord(3, 1), 3),
-                            new StreamRecord<>(IterationRecord.newRecord(2, 0), 3),
-                            new StreamRecord<>(IterationRecord.newRecord(4, 1), 4));
-            assertEquals(expectedOutput, new ArrayList<>(harness.getOutput()));
+        createHarnessAndRun(
+                iterationId,
+                operatorId,
+                null,
+                harness -> {
+                    harness.processElement(new StreamRecord<>(IterationRecord.newRecord(1, 0), 2));
+                    putFeedbackRecords(iterationId, IterationRecord.newRecord(3, 1), 3L);
+                    harness.processAll();
+                    harness.processElement(new StreamRecord<>(IterationRecord.newRecord(2, 0), 3));
+                    putFeedbackRecords(iterationId, IterationRecord.newRecord(4, 1), 4L);
+                    harness.processAll();
 
-            RegularHeadOperatorRecordProcessor recordProcessor =
-                    (RegularHeadOperatorRecordProcessor)
-                            RecordingHeadOperatorFactory.latestHeadOperator.getRecordProcessor();
+                    List<StreamRecord<IterationRecord<Integer>>> expectedOutput =
+                            Arrays.asList(
+                                    new StreamRecord<>(IterationRecord.newRecord(1, 0), 2),
+                                    new StreamRecord<>(IterationRecord.newRecord(3, 1), 3),
+                                    new StreamRecord<>(IterationRecord.newRecord(2, 0), 3),
+                                    new StreamRecord<>(IterationRecord.newRecord(4, 1), 4));
+                    assertEquals(expectedOutput, new ArrayList<>(harness.getOutput()));
 
-            assertEquals(2, (long) recordProcessor.getNumFeedbackRecordsPerEpoch().get(1));
-        }
+                    RegularHeadOperatorRecordProcessor recordProcessor =
+                            (RegularHeadOperatorRecordProcessor)
+                                    RecordingHeadOperatorFactory.latestHeadOperator
+                                            .getRecordProcessor();
+
+                    assertEquals(2, (long) recordProcessor.getNumFeedbackRecordsPerEpoch().get(1));
+
+                    return null;
+                });
     }
 
     @Test(timeout = 60000)
     public void testSynchronizingEpochWatermark() throws Exception {
         IterationID iterationId = new IterationID();
+        OperatorID operatorId = new OperatorID();
+
+        createHarnessAndRun(
+                iterationId,
+                operatorId,
+                null,
+                harness -> {
+                    harness.processElement(new StreamRecord<>(IterationRecord.newRecord(1, 0), 2));
+
+                    // We will start a new thread to simulate the operator coordinator thread
+                    CompletableFuture<Void> taskExecuteResult =
+                            CompletableFuture.supplyAsync(
+                                    () -> {
+                                        try {
+                                            RecordingOperatorEventGateway eventGateway =
+                                                    (RecordingOperatorEventGateway)
+                                                            RecordingHeadOperatorFactory
+                                                                    .latestHeadOperator
+                                                                    .getOperatorEventGateway();
+
+                                            // We should get the aligned event for round 0 on
+                                            // endInput
+                                            assertNextOperatorEvent(
+                                                    new SubtaskAlignedEvent(0, 0, false),
+                                                    eventGateway);
+                                            dispatchOperatorEvent(
+                                                    harness,
+                                                    operatorId,
+                                                    new GloballyAlignedEvent(0, false));
+
+                                            putFeedbackRecords(
+                                                    iterationId,
+                                                    IterationRecord.newRecord(4, 1),
+                                                    4L);
+                                            putFeedbackRecords(
+                                                    iterationId,
+                                                    IterationRecord.newEpochWatermark(1, "tail"),
+                                                    0L);
+
+                                            assertNextOperatorEvent(
+                                                    new SubtaskAlignedEvent(1, 1, false),
+                                                    eventGateway);
+                                            dispatchOperatorEvent(
+                                                    harness,
+                                                    operatorId,
+                                                    new GloballyAlignedEvent(1, true));
+
+                                            while (RecordingHeadOperatorFactory.latestHeadOperator
+                                                            .getStatus()
+                                                    == HeadOperator.HeadOperatorStatus.RUNNING) ;
+                                            putFeedbackRecords(
+                                                    iterationId,
+                                                    IterationRecord.newEpochWatermark(
+                                                            Integer.MAX_VALUE + 1, "tail"),
+                                                    null);
+
+                                            return null;
+                                        } catch (Throwable e) {
+                                            RecordingHeadOperatorFactory.latestHeadOperator
+                                                    .getMailboxExecutor()
+                                                    .execute(
+                                                            () -> {
+                                                                throw e;
+                                                            },
+                                                            "poison mail");
+                                            throw new CompletionException(e);
+                                        }
+                                    });
+
+                    // Mark the input as finished.
+                    harness.processEvent(EndOfData.INSTANCE);
+
+                    // There should be no exception
+                    taskExecuteResult.get();
+
+                    assertEquals(
+                            Arrays.asList(
+                                    new StreamRecord<>(IterationRecord.newRecord(1, 0), 2),
+                                    new StreamRecord<>(
+                                            IterationRecord.newEpochWatermark(
+                                                    0,
+                                                    OperatorUtils.getUniqueSenderId(operatorId, 0)),
+                                            0),
+                                    new StreamRecord<>(IterationRecord.newRecord(4, 1), 4),
+                                    new StreamRecord<>(
+                                            IterationRecord.newEpochWatermark(
+                                                    Integer.MAX_VALUE,
+                                                    OperatorUtils.getUniqueSenderId(operatorId, 0)),
+                                            0)),
+                            new ArrayList<>(harness.getOutput()));
+                    return null;
+                });
+    }
+
+    private <T> T createHarnessAndRun(
+            IterationID iterationId,
+            OperatorID operatorId,
+            @Nullable TaskStateSnapshot snapshot,
+            FunctionWithException<
+                            StreamTaskMailboxTestHarness<IterationRecord<Integer>>, T, Exception>
+                    runnable)
+            throws Exception {
         try (StreamTaskMailboxTestHarness<IterationRecord<Integer>> harness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 OneInputStreamTask::new,
                                 new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
                         .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .setTaskStateSnapshot(
+                                1, snapshot == null ? new TaskStateSnapshot() : snapshot)
                         .setupOutputForSingletonOperatorChain(
                                 new RecordingHeadOperatorFactory(
                                         iterationId,
                                         0,
                                         false,
                                         5,
-                                        RecordingOperatorEventGateway::new))
+                                        RecordingOperatorEventGateway::new),
+                                operatorId)
                         .build()) {
-
-            OperatorID operatorId = RecordingHeadOperatorFactory.latestHeadOperator.getOperatorID();
-            harness.processElement(new StreamRecord<>(IterationRecord.newRecord(1, 0), 2));
-
-            // We will start a new thread to simulate the operator coordinator thread
-            CompletableFuture<Void> taskExecuteResult =
-                    CompletableFuture.supplyAsync(
-                            () -> {
-                                try {
-                                    RecordingOperatorEventGateway eventGateway =
-                                            (RecordingOperatorEventGateway)
-                                                    RecordingHeadOperatorFactory.latestHeadOperator
-                                                            .getOperatorEventGateway();
-
-                                    // We should get the aligned event for round 0 on endInput
-                                    assertNextOperatorEvent(
-                                            new SubtaskAlignedEvent(0, 0, false), eventGateway);
-                                    harness.getStreamTask()
-                                            .dispatchOperatorEvent(
-                                                    operatorId,
-                                                    new SerializedValue<>(
-                                                            new GloballyAlignedEvent(0, false)));
-
-                                    putFeedbackRecords(
-                                            iterationId,
-                                            0,
-                                            new StreamRecord<>(IterationRecord.newRecord(4, 1), 4));
-                                    putFeedbackRecords(
-                                            iterationId,
-                                            0,
-                                            new StreamRecord<>(
-                                                    IterationRecord.newEpochWatermark(1, "tail"),
-                                                    0));
-
-                                    assertNextOperatorEvent(
-                                            new SubtaskAlignedEvent(1, 1, false), eventGateway);
-                                    harness.getStreamTask()
-                                            .dispatchOperatorEvent(
-                                                    operatorId,
-                                                    new SerializedValue<>(
-                                                            new GloballyAlignedEvent(1, true)));
-
-                                    while (RecordingHeadOperatorFactory.latestHeadOperator
-                                                    .getStatus()
-                                            == HeadOperator.HeadOperatorStatus.RUNNING) {}
-                                    putFeedbackRecords(
-                                            iterationId,
-                                            0,
-                                            new StreamRecord<>(
-                                                    IterationRecord.newEpochWatermark(
-                                                            Integer.MAX_VALUE + 1, "tail")));
-
-                                    return null;
-                                } catch (Throwable e) {
-                                    RecordingHeadOperatorFactory.latestHeadOperator
-                                            .getMailboxExecutor()
-                                            .execute(
-                                                    () -> {
-                                                        throw e;
-                                                    },
-                                                    "poison mail");
-                                    throw new CompletionException(e);
-                                }
-                            });
-
-            // Mark the input as finished.
-            harness.processEvent(EndOfData.INSTANCE);
-
-            // There should be no exception
-            taskExecuteResult.get();
-
-            assertEquals(
-                    Arrays.asList(
-                            new StreamRecord<>(IterationRecord.newRecord(1, 0), 2),
-                            new StreamRecord<>(
-                                    IterationRecord.newEpochWatermark(
-                                            0, OperatorUtils.getUniqueSenderId(operatorId, 0)),
-                                    0),
-                            new StreamRecord<>(IterationRecord.newRecord(4, 1), 4),
-                            new StreamRecord<>(
-                                    IterationRecord.newEpochWatermark(
-                                            Integer.MAX_VALUE,
-                                            OperatorUtils.getUniqueSenderId(operatorId, 0)),
-                                    0)),
-                    new ArrayList<>(harness.getOutput()));
+            return runnable.apply(harness);
         }
+    }
+
+    private static void dispatchOperatorEvent(
+            StreamTaskMailboxTestHarness<?> harness,
+            OperatorID operatorId,
+            OperatorEvent operatorEvent)
+            throws IOException, FlinkException {
+        harness.getStreamTask()
+                .dispatchOperatorEvent(operatorId, new SerializedValue<>(operatorEvent));
     }
 
     private static void assertNextOperatorEvent(
@@ -209,14 +243,17 @@ public class HeadOperatorTest extends TestLogger {
     }
 
     private static void putFeedbackRecords(
-            IterationID iterationId, int feedbackIndex, StreamRecord<IterationRecord<?>> record) {
+            IterationID iterationId, IterationRecord<?> record, @Nullable Long timestamp) {
         FeedbackChannel<StreamRecord<IterationRecord<?>>> feedbackChannel =
                 FeedbackChannelBroker.get()
                         .getChannel(
                                 OperatorUtils.<StreamRecord<IterationRecord<?>>>createFeedbackKey(
-                                                iterationId, feedbackIndex)
+                                                iterationId, 0)
                                         .withSubTaskIndex(0, 0));
-        feedbackChannel.put(record);
+        feedbackChannel.put(
+                timestamp == null
+                        ? new StreamRecord<>(record)
+                        : new StreamRecord<>(record, timestamp));
     }
 
     private static class RecordingOperatorEventGateway implements OperatorEventGateway {

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/InputOperatorTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/InputOperatorTest.java
@@ -34,7 +34,7 @@ public class InputOperatorTest extends TestLogger {
     @Test
     public void testWrapRecord() throws Exception {
         OneInputStreamOperatorTestHarness<Integer, IterationRecord<Integer>> testHarness =
-                new OneInputStreamOperatorTestHarness<>(new InputOperator<>(false));
+                new OneInputStreamOperatorTestHarness<>(new InputOperator<>());
         testHarness.open();
 
         ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
@@ -45,37 +45,5 @@ public class InputOperatorTest extends TestLogger {
 
         TestHarnessUtil.assertOutputEquals(
                 "Output was not correct", expectedOutput, testHarness.getOutput());
-    }
-
-    @Test
-    public void testInsertMaxEpochWatermarkIfSpecified() throws Exception {
-        OneInputStreamOperatorTestHarness<Integer, IterationRecord<Integer>> testHarness =
-                new OneInputStreamOperatorTestHarness<>(new InputOperator<>(true));
-        testHarness.open();
-
-        testHarness.endInput();
-
-        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
-        expectedOutput.add(
-                new StreamRecord<>(
-                        IterationRecord.newEpochWatermark(
-                                Integer.MAX_VALUE,
-                                OperatorUtils.getUniqueSenderId(
-                                        testHarness.getOperator().getOperatorID(), 0))));
-
-        TestHarnessUtil.assertOutputEquals(
-                "Output was not correct", expectedOutput, testHarness.getOutput());
-    }
-
-    @Test
-    public void testNotInsertMaxEpochWatermarkIfSpecified() throws Exception {
-        OneInputStreamOperatorTestHarness<Integer, IterationRecord<Integer>> testHarness =
-                new OneInputStreamOperatorTestHarness<>(new InputOperator<>(false));
-        testHarness.open();
-
-        testHarness.endInput();
-
-        TestHarnessUtil.assertOutputEquals(
-                "Output was not correct", new ConcurrentLinkedQueue<>(), testHarness.getOutput());
     }
 }

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/ReplayOperatorTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/ReplayOperatorTest.java
@@ -24,9 +24,9 @@ import org.apache.flink.iteration.config.IterationOptions;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarnessBuilder;
+import org.apache.flink.streaming.runtime.tasks.TwoInputStreamTask;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,9 +52,10 @@ public class ReplayOperatorTest {
 
         try (StreamTaskMailboxTestHarness<IterationRecord<Integer>> harness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
-                                OneInputStreamTask::new,
+                                TwoInputStreamTask::new,
                                 new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO), 2)
+                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO), 1)
+                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.VOID_TYPE_INFO), 1)
                         .setupOutputForSingletonOperatorChain(new ReplayOperator<>(), operatorId)
                         .buildUnrestored()) {
             harness.getStreamTask()
@@ -70,19 +71,16 @@ public class ReplayOperatorTest {
             for (int i = 0; i < numRecords; ++i) {
                 harness.processElement(new StreamRecord<>(IterationRecord.newRecord(i, 0)), 0, 0);
             }
+            harness.endInput(0, true);
             harness.processElement(
-                    new StreamRecord<>(
-                            IterationRecord.newEpochWatermark(Integer.MAX_VALUE, "sender0")),
-                    0,
-                    0);
-            harness.processElement(
-                    new StreamRecord<>(IterationRecord.newEpochWatermark(0, "sender1")), 0, 1);
+                    new StreamRecord<>(IterationRecord.newEpochWatermark(0, "sender1")), 1, 0);
             assertOutputAllRecordsAndEpochWatermark(harness.getOutput(), numRecords, operatorId, 0);
             harness.getOutput().clear();
 
             // The round 1
             harness.processElement(
-                    new StreamRecord<>(IterationRecord.newEpochWatermark(1, "sender1")), 0, 1);
+                    new StreamRecord<>(IterationRecord.newEpochWatermark(1, "sender1")), 1, 0);
+            // The output would be done asynchronously inside the ReplayerOperator.
             while (harness.getOutput().size() < numRecords + 1) {
                 Thread.sleep(500);
             }
@@ -91,7 +89,8 @@ public class ReplayOperatorTest {
 
             // The round 2
             harness.processElement(
-                    new StreamRecord<>(IterationRecord.newEpochWatermark(2, "sender1")), 0, 1);
+                    new StreamRecord<>(IterationRecord.newEpochWatermark(2, "sender1")), 1, 0);
+            // The output would be done asynchronously inside the ReplayerOperator.
             while (harness.getOutput().size() < numRecords + 1) {
                 Thread.sleep(500);
             }

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/allround/OneInputAllRoundWrapperOperatorTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/allround/OneInputAllRoundWrapperOperatorTest.java
@@ -21,12 +21,14 @@ package org.apache.flink.iteration.operator.allround;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.OperatorUtils;
+import org.apache.flink.iteration.operator.OperatorWrapper;
 import org.apache.flink.iteration.operator.WrapperOperatorFactory;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
@@ -38,7 +40,9 @@ import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
@@ -53,6 +57,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /** Tests the {@link OneInputAllRoundWrapperOperator}. */
 public class OneInputAllRoundWrapperOperatorTest extends TestLogger {
@@ -126,6 +131,71 @@ public class OneInputAllRoundWrapperOperatorTest extends TestLogger {
                             LifeCycle.FINISH,
                             LifeCycle.CLOSE),
                     LIFE_CYCLES);
+        }
+    }
+
+    @Test
+    public void testSnapshotAndRestore() throws Exception {
+        StreamOperatorFactory<IterationRecord<Integer>> wrapperFactory =
+                new RecordingOperatorFactory<>(
+                        SimpleOperatorFactory.of(new LifeCycleTrackingOneInputStreamOperator()),
+                        new AllRoundOperatorWrapper<>());
+        OperatorID operatorId = new OperatorID();
+
+        TaskStateSnapshot taskStateSnapshot = null;
+        try (StreamTaskMailboxTestHarness<IterationRecord<Integer>> harness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new,
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .setupOutputForSingletonOperatorChain(wrapperFactory, operatorId)
+                        .build()) {
+            harness.getTaskStateManager().getWaitForReportLatch().reset();
+            harness.processElement(
+                    new StreamRecord<>(IterationRecord.newEpochWatermark(5, "fake")));
+            harness.getStreamTask()
+                    .triggerCheckpointAsync(
+                            new CheckpointMetaData(2, 1000),
+                            CheckpointOptions.alignedNoTimeout(
+                                    CheckpointType.CHECKPOINT,
+                                    CheckpointStorageLocationReference.getDefault()));
+            harness.processAll();
+
+            harness.getTaskStateManager().getWaitForReportLatch().await();
+            taskStateSnapshot = harness.getTaskStateManager().getLastJobManagerTaskStateSnapshot();
+        }
+
+        assertNotNull(taskStateSnapshot);
+        try (StreamTaskMailboxTestHarness<IterationRecord<Integer>> harness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new,
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .setTaskStateSnapshot(2, taskStateSnapshot)
+                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .setupOutputForSingletonOperatorChain(wrapperFactory, operatorId)
+                        .build()) {
+            assertEquals(
+                    5,
+                    ((AbstractAllRoundWrapperOperator) RecordingOperatorFactory.latest)
+                            .getLatestEpochWatermark());
+        }
+    }
+
+    private static class RecordingOperatorFactory<OUT> extends WrapperOperatorFactory<OUT> {
+
+        static StreamOperator<?> latest = null;
+
+        public RecordingOperatorFactory(
+                StreamOperatorFactory<OUT> operatorFactory,
+                OperatorWrapper<OUT, IterationRecord<OUT>> wrapper) {
+            super(operatorFactory, wrapper);
+        }
+
+        @Override
+        public <T extends StreamOperator<IterationRecord<OUT>>> T createStreamOperator(
+                StreamOperatorParameters<IterationRecord<OUT>> parameters) {
+            latest = super.createStreamOperator(parameters);
+            return (T) latest;
         }
     }
 

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/coordinator/SharedProgressAlignerTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/coordinator/SharedProgressAlignerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.iteration.operator.coordinator;
 
 import org.apache.flink.iteration.IterationID;
+import org.apache.flink.iteration.operator.event.CoordinatorCheckpointEvent;
 import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
 import org.apache.flink.iteration.operator.event.SubtaskAlignedEvent;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -32,7 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -64,22 +65,22 @@ public class SharedProgressAlignerTest extends TestLogger {
     }
 
     @Test
-    public void testRegisterAndUnregisterConsumers() {
+    public void testRegisterAndUnregisterListeners() {
         IterationID iterationId = new IterationID();
         List<OperatorID> operatorIds = Arrays.asList(new OperatorID(), new OperatorID());
-        List<Consumer<GloballyAlignedEvent>> consumers =
-                Arrays.asList(new RecordingConsumer(), new RecordingConsumer());
+        List<SharedProgressAlignerListener> listeners =
+                Arrays.asList(new RecordingListener(), new RecordingListener());
         SharedProgressAligner aligner =
-                initializeAligner(iterationId, operatorIds, Arrays.asList(2, 3), consumers);
+                initializeAligner(iterationId, operatorIds, Arrays.asList(2, 3), listeners);
 
-        assertEquals(2, aligner.getNumberConsumers());
+        assertEquals(2, aligner.getNumberListeners());
 
-        aligner.unregisterConsumer(operatorIds.get(0));
-        assertEquals(1, aligner.getNumberConsumers());
+        aligner.unregisterListener(operatorIds.get(0));
+        assertEquals(1, aligner.getNumberListeners());
         assertTrue(SharedProgressAligner.getInstances().containsKey(iterationId));
 
-        aligner.unregisterConsumer(operatorIds.get(1));
-        assertEquals(0, aligner.getNumberConsumers());
+        aligner.unregisterListener(operatorIds.get(1));
+        assertEquals(0, aligner.getNumberListeners());
         assertFalse(SharedProgressAligner.getInstances().containsKey(iterationId));
     }
 
@@ -88,10 +89,10 @@ public class SharedProgressAlignerTest extends TestLogger {
         IterationID iterationId = new IterationID();
         List<OperatorID> operatorIds = Arrays.asList(new OperatorID(), new OperatorID());
         List<Integer> parallelisms = Arrays.asList(2, 3);
-        List<RecordingConsumer> consumers =
-                Arrays.asList(new RecordingConsumer(), new RecordingConsumer());
+        List<RecordingListener> listeners =
+                Arrays.asList(new RecordingListener(), new RecordingListener());
         SharedProgressAligner aligner =
-                initializeAligner(iterationId, operatorIds, parallelisms, consumers);
+                initializeAligner(iterationId, operatorIds, parallelisms, listeners);
 
         for (int i = 0; i < operatorIds.size(); ++i) {
             for (int j = 0; j < parallelisms.get(i); ++j) {
@@ -100,8 +101,8 @@ public class SharedProgressAlignerTest extends TestLogger {
             }
         }
 
-        checkRecordingConsumers(
-                Collections.singletonList(new GloballyAlignedEvent(2, false)), consumers);
+        this.checkGloballyAlignedEvents(
+                Collections.singletonList(new GloballyAlignedEvent(2, false)), listeners);
     }
 
     @Test
@@ -109,10 +110,10 @@ public class SharedProgressAlignerTest extends TestLogger {
         IterationID iterationId = new IterationID();
         List<OperatorID> operatorIds = Arrays.asList(new OperatorID(), new OperatorID());
         List<Integer> parallelisms = Arrays.asList(2, 3);
-        List<RecordingConsumer> consumers =
-                Arrays.asList(new RecordingConsumer(), new RecordingConsumer());
+        List<RecordingListener> listeners =
+                Arrays.asList(new RecordingListener(), new RecordingListener());
         SharedProgressAligner aligner =
-                initializeAligner(iterationId, operatorIds, parallelisms, consumers);
+                initializeAligner(iterationId, operatorIds, parallelisms, listeners);
 
         for (int i = 0; i < operatorIds.size(); ++i) {
             for (int j = 0; j < parallelisms.get(i); ++j) {
@@ -121,8 +122,8 @@ public class SharedProgressAlignerTest extends TestLogger {
             }
         }
 
-        checkRecordingConsumers(
-                Collections.singletonList(new GloballyAlignedEvent(2, true)), consumers);
+        this.checkGloballyAlignedEvents(
+                Collections.singletonList(new GloballyAlignedEvent(2, true)), listeners);
     }
 
     @Test
@@ -130,10 +131,10 @@ public class SharedProgressAlignerTest extends TestLogger {
         IterationID iterationId = new IterationID();
         List<OperatorID> operatorIds = Arrays.asList(new OperatorID(), new OperatorID());
         List<Integer> parallelisms = Arrays.asList(2, 3);
-        List<RecordingConsumer> consumers =
-                Arrays.asList(new RecordingConsumer(), new RecordingConsumer());
+        List<RecordingListener> listeners =
+                Arrays.asList(new RecordingListener(), new RecordingListener());
         SharedProgressAligner aligner =
-                initializeAligner(iterationId, operatorIds, parallelisms, consumers);
+                initializeAligner(iterationId, operatorIds, parallelisms, listeners);
 
         for (int i = 0; i < operatorIds.size(); ++i) {
             for (int j = 0; j < parallelisms.get(i); ++j) {
@@ -142,8 +143,8 @@ public class SharedProgressAlignerTest extends TestLogger {
             }
         }
 
-        checkRecordingConsumers(
-                Collections.singletonList(new GloballyAlignedEvent(0, false)), consumers);
+        this.checkGloballyAlignedEvents(
+                Collections.singletonList(new GloballyAlignedEvent(0, false)), listeners);
     }
 
     @Test
@@ -151,10 +152,10 @@ public class SharedProgressAlignerTest extends TestLogger {
         IterationID iterationId = new IterationID();
         List<OperatorID> operatorIds = Arrays.asList(new OperatorID(), new OperatorID());
         List<Integer> parallelisms = Arrays.asList(2, 3);
-        List<RecordingConsumer> consumers =
-                Arrays.asList(new RecordingConsumer(), new RecordingConsumer());
+        List<RecordingListener> listeners =
+                Arrays.asList(new RecordingListener(), new RecordingListener());
         SharedProgressAligner aligner =
-                initializeAligner(iterationId, operatorIds, parallelisms, consumers);
+                initializeAligner(iterationId, operatorIds, parallelisms, listeners);
 
         for (int i = 0; i < operatorIds.size(); ++i) {
             for (int j = 0; j < parallelisms.get(i); ++j) {
@@ -164,15 +165,46 @@ public class SharedProgressAlignerTest extends TestLogger {
             }
         }
 
-        checkRecordingConsumers(
-                Collections.singletonList(new GloballyAlignedEvent(2, true)), consumers);
+        this.checkGloballyAlignedEvents(
+                Collections.singletonList(new GloballyAlignedEvent(2, true)), listeners);
+    }
+
+    @Test
+    public void testSendEventsBeforeCompleteCheckpoint() {
+        IterationID iterationId = new IterationID();
+        List<OperatorID> operatorIds = Arrays.asList(new OperatorID(), new OperatorID());
+        List<Integer> parallelisms = Arrays.asList(2, 3);
+        List<RecordingListener> listeners =
+                Arrays.asList(new RecordingListener(), new RecordingListener());
+        SharedProgressAligner aligner =
+                initializeAligner(iterationId, operatorIds, parallelisms, listeners);
+
+        List<CompletableFuture<byte[]>> firstCheckpointStateFutures =
+                Arrays.asList(new CompletableFuture<>(), new CompletableFuture<>());
+        for (int i = 0; i < operatorIds.size(); ++i) {
+            // Operator 0 is the criteria stream
+            aligner.requestCheckpoint(1, parallelisms.get(i), firstCheckpointStateFutures.get(i));
+        }
+
+        List<CompletableFuture<byte[]>> secondCheckpointStateFutures =
+                Arrays.asList(new CompletableFuture<>(), new CompletableFuture<>());
+        for (int i = 0; i < operatorIds.size(); ++i) {
+            // Operator 0 is the criteria stream
+            aligner.requestCheckpoint(2, parallelisms.get(i), secondCheckpointStateFutures.get(i));
+        }
+
+        firstCheckpointStateFutures.forEach(future -> assertTrue(future.isDone()));
+        secondCheckpointStateFutures.forEach(future -> assertTrue(future.isDone()));
+        checkCoordinatorCheckpointEvents(
+                Arrays.asList(new CoordinatorCheckpointEvent(1), new CoordinatorCheckpointEvent(2)),
+                listeners);
     }
 
     private SharedProgressAligner initializeAligner(
             IterationID iterationId,
             List<OperatorID> operatorIds,
             List<Integer> parallelisms,
-            List<? extends Consumer<GloballyAlignedEvent>> consumers) {
+            List<? extends SharedProgressAlignerListener> listeners) {
 
         SharedProgressAligner aligner =
                 SharedProgressAligner.getOrCreate(
@@ -181,28 +213,43 @@ public class SharedProgressAlignerTest extends TestLogger {
                         new MockOperatorCoordinatorContext(operatorIds.get(0), parallelisms.get(0)),
                         DirectScheduledExecutorService::new);
 
-        for (int i = 0; i < consumers.size(); ++i) {
-            aligner.registerAlignedConsumer(operatorIds.get(i), consumers.get(i));
+        for (int i = 0; i < listeners.size(); ++i) {
+            aligner.registerAlignedListener(operatorIds.get(i), listeners.get(i));
         }
 
         return aligner;
     }
 
-    private void checkRecordingConsumers(
+    private void checkGloballyAlignedEvents(
             List<GloballyAlignedEvent> expectedGloballyAlignedEvents,
-            List<RecordingConsumer> consumers) {
-        for (RecordingConsumer consumer : consumers) {
+            List<RecordingListener> listeners) {
+        for (RecordingListener consumer : listeners) {
             assertEquals(expectedGloballyAlignedEvents, consumer.globallyAlignedEvents);
         }
     }
 
-    private static class RecordingConsumer implements Consumer<GloballyAlignedEvent> {
+    private void checkCoordinatorCheckpointEvents(
+            List<CoordinatorCheckpointEvent> expectedGloballyAlignedEvents,
+            List<RecordingListener> listeners) {
+        for (RecordingListener consumer : listeners) {
+            assertEquals(expectedGloballyAlignedEvents, consumer.checkpointEvents);
+        }
+    }
+
+    private static class RecordingListener implements SharedProgressAlignerListener {
 
         final List<GloballyAlignedEvent> globallyAlignedEvents = new ArrayList<>();
 
+        final List<CoordinatorCheckpointEvent> checkpointEvents = new ArrayList<>();
+
         @Override
-        public void accept(GloballyAlignedEvent globallyAlignedEvent) {
+        public void onAligned(GloballyAlignedEvent globallyAlignedEvent) {
             globallyAlignedEvents.add(globallyAlignedEvent);
+        }
+
+        @Override
+        public void onCheckpointAligned(CoordinatorCheckpointEvent coordinatorCheckpointEvent) {
+            checkpointEvents.add(coordinatorCheckpointEvent);
         }
     }
 }

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/progresstrack/OperatorEpochWatermarkTrackerTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/progresstrack/OperatorEpochWatermarkTrackerTest.java
@@ -59,6 +59,23 @@ public class OperatorEpochWatermarkTrackerTest extends TestLogger {
         assertEquals(Collections.singletonList(3), recordingProgressListener.notifications);
     }
 
+    @Test
+    public void testFinish() throws IOException {
+        RecordingProgressListener recordingProgressListener = new RecordingProgressListener();
+        int[] numberOfChannels = new int[] {2, 3};
+        OperatorEpochWatermarkTracker progressTracker =
+                new OperatorEpochWatermarkTracker(numberOfChannels, recordingProgressListener);
+        progressTracker.finish(0);
+
+        testOnEpochWatermark(
+                new int[] {0, 0, 1},
+                progressTracker,
+                recordingProgressListener,
+                new int[] {1, 1, 1},
+                new String[] {"1-1", "1-2", "1-3"},
+                3);
+    }
+
     private void testOnEpochWatermark(
             int[] expectedNumNotifications,
             OperatorEpochWatermarkTracker tracker,

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundCheckpointTest.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundCheckpointTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.iteration;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.iteration.DataStreamList;
+import org.apache.flink.iteration.IterationBodyResult;
+import org.apache.flink.iteration.Iterations;
+import org.apache.flink.iteration.compile.DraftExecutionEnvironment;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.test.iteration.operators.EpochRecord;
+import org.apache.flink.test.iteration.operators.FailingMap;
+import org.apache.flink.test.iteration.operators.IncrementEpochMap;
+import org.apache.flink.test.iteration.operators.OutputRecord;
+import org.apache.flink.test.iteration.operators.SequenceSource;
+import org.apache.flink.test.iteration.operators.TwoInputReduceAllRoundProcessFunction;
+import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.testutils.junit.SharedReference;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.test.iteration.UnboundedStreamIterationITCase.createMiniClusterConfiguration;
+import static org.junit.Assert.assertEquals;
+
+/** Tests checkpoints. */
+@RunWith(Parameterized.class)
+public class BoundedAllRoundCheckpointTest extends TestLogger {
+
+    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+
+    private SharedReference<List<OutputRecord<Integer>>> result;
+
+    @Parameterized.Parameter(0)
+    public int failoverCount;
+
+    @Parameterized.Parameter(1)
+    public boolean sync;
+
+    @Parameterized.Parameters(name = "failoverCount = {0}, sync = {1}")
+    public static Collection<Object[]> params() {
+        int[] failoverCounts = {1000, 4000, 8000, 15900};
+        boolean[] syncs = {true, false};
+
+        List<Object[]> result = new ArrayList<>();
+        for (int failoverCount : failoverCounts) {
+            for (boolean sync : syncs) {
+                result.add(new Object[] {failoverCount, sync});
+            }
+        }
+
+        return result;
+    }
+
+    @Before
+    public void setup() {
+        result = sharedObjects.add(new ArrayList<>());
+    }
+
+    @Test
+    public void testFailoverAndRestore() throws Exception {
+        try (MiniCluster miniCluster = new MiniCluster(createMiniClusterConfiguration(2, 2))) {
+            miniCluster.start();
+
+            // Create the test job
+            JobGraph jobGraph =
+                    createVariableAndConstantJobGraph(
+                            4, 1000, false, 0, sync, 4, failoverCount, new CollectSink(result));
+            miniCluster.executeJobBlocking(jobGraph);
+
+            Map<Integer, Tuple2<Integer, Integer>> roundsStat = new HashMap<>();
+            for (OutputRecord<Integer> output : result.get()) {
+                Tuple2<Integer, Integer> state =
+                        roundsStat.computeIfAbsent(
+                                output.getRound(), ignored -> new Tuple2<>(0, 0));
+                state.f0++;
+                state.f1 = output.getValue();
+            }
+
+            // 0 ~ 4 round and termination information
+            assertEquals(6, roundsStat.size());
+            for (int i = 0; i <= 4; ++i) {
+                // In this case we could only check the final result, the number of records is not
+                // deterministic.
+                assertEquals(4 * (0 + 999) * 1000 / 2, (int) roundsStat.get(i).f1);
+            }
+        }
+    }
+
+    static JobGraph createVariableAndConstantJobGraph(
+            int numSources,
+            int numRecordsPerSource,
+            boolean holdSource,
+            int period,
+            boolean sync,
+            int maxRound,
+            int failoverCount,
+            SinkFunction<OutputRecord<Integer>> sinkFunction) {
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(
+                        new Configuration() {
+                            {
+                                this.set(
+                                        ExecutionCheckpointingOptions
+                                                .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
+                                        true);
+                            }
+                        });
+        env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
+        env.setParallelism(1);
+        DataStream<EpochRecord> variableSource =
+                env.addSource(new DraftExecutionEnvironment.EmptySource<EpochRecord>() {})
+                        .setParallelism(numSources)
+                        .name("Variable");
+        DataStream<EpochRecord> constSource =
+                env.addSource(new SequenceSource(numRecordsPerSource, holdSource, period))
+                        .setParallelism(numSources)
+                        .name("Constant");
+        DataStreamList outputs =
+                Iterations.iterateUnboundedStreams(
+                        DataStreamList.of(variableSource),
+                        DataStreamList.of(constSource),
+                        (variableStreams, dataStreams) -> {
+                            SingleOutputStreamOperator<EpochRecord> reducer =
+                                    variableStreams
+                                            .<EpochRecord>get(0)
+                                            .connect(dataStreams.<EpochRecord>get(0))
+                                            .process(
+                                                    new TwoInputReduceAllRoundProcessFunction(
+                                                            sync, maxRound));
+                            DataStream<EpochRecord> failedMap =
+                                    reducer.map(new FailingMap(failoverCount));
+                            return new IterationBodyResult(
+                                    DataStreamList.of(
+                                            failedMap
+                                                    .map(new IncrementEpochMap())
+                                                    .setParallelism(numSources)),
+                                    DataStreamList.of(
+                                            reducer.getSideOutput(
+                                                    new OutputTag<OutputRecord<Integer>>(
+                                                            "output") {})));
+                        });
+        outputs.<OutputRecord<Integer>>get(0).addSink(sinkFunction);
+
+        return env.getStreamGraph().getJobGraph();
+    }
+
+    private static class CollectSink implements SinkFunction<OutputRecord<Integer>> {
+
+        private final SharedReference<List<OutputRecord<Integer>>> result;
+
+        private CollectSink(SharedReference<List<OutputRecord<Integer>>> result) {
+            this.result = result;
+        }
+
+        @Override
+        public void invoke(OutputRecord<Integer> value, Context context) throws Exception {
+            result.get().add(value);
+        }
+    }
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/UnboundedStreamIterationITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/UnboundedStreamIterationITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.iteration.operators.CollectSink;
 import org.apache.flink.test.iteration.operators.EpochRecord;
@@ -150,9 +151,11 @@ public class UnboundedStreamIterationITCase extends TestLogger {
         assertEquals(OutputRecord.Event.TERMINATED, result.get().take().getEvent());
     }
 
-    static MiniClusterConfiguration createMiniClusterConfiguration(int numTm, int numSlot) {
+    public static MiniClusterConfiguration createMiniClusterConfiguration(int numTm, int numSlot) {
         Configuration configuration = new Configuration();
         configuration.set(RestOptions.BIND_PORT, "18081-19091");
+        configuration.set(
+                ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
         return new MiniClusterConfiguration.Builder()
                 .setConfiguration(configuration)
                 .setNumTaskManagers(numTm)

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/operators/FailingMap.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/operators/FailingMap.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.iteration.operators;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+
+/** Map Function triggers failover at the first task and first round. */
+public class FailingMap extends RichMapFunction<EpochRecord, EpochRecord> {
+
+    private final int failingCount;
+
+    private int count;
+
+    public FailingMap(int failingCount) {
+        this.failingCount = failingCount;
+    }
+
+    @Override
+    public EpochRecord map(EpochRecord value) throws Exception {
+        count++;
+        if (getRuntimeContext().getIndexOfThisSubtask() == 0
+                && getRuntimeContext().getAttemptNumber() == 0
+                && count >= failingCount) {
+            throw new RuntimeException("Artificial Exception");
+        }
+
+        return value;
+    }
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/operators/TwoInputReduceAllRoundProcessFunction.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/operators/TwoInputReduceAllRoundProcessFunction.java
@@ -20,6 +20,9 @@ package org.apache.flink.test.iteration.operators;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.iteration.IterationListener;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.co.CoProcessFunction;
 import org.apache.flink.util.Collector;
 
@@ -28,7 +31,7 @@ import org.apache.flink.util.Collector;
  */
 public class TwoInputReduceAllRoundProcessFunction
         extends CoProcessFunction<EpochRecord, EpochRecord, EpochRecord>
-        implements IterationListener<EpochRecord> {
+        implements IterationListener<EpochRecord>, CheckpointedFunction {
 
     private final ReduceAllRoundProcessFunction reduceAllRoundProcessFunction;
 
@@ -77,5 +80,16 @@ public class TwoInputReduceAllRoundProcessFunction
 
         // Processing the first round of messages.
         reduceAllRoundProcessFunction.processRecord(record, ctx::output, out);
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext functionSnapshotContext) throws Exception {
+        reduceAllRoundProcessFunction.snapshotState(functionSnapshotContext);
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext functionInitializationContext)
+            throws Exception {
+        reduceAllRoundProcessFunction.initializeState(functionInitializationContext);
     }
 }


### PR DESCRIPTION
This PR implements the checkpoint mechanism for the iteration. The target of the checkpoint mechanism is to ensure
1. The record processing is consistent with the state, which is the same to the normal checkpoints without feedback edges.
2. The notification of epoch incremented is exactly-once. 

The checkpoints relies on the reference count mechanism to include the feedback records into snapshots. Besides, it also take cares of the state for the controller operator / all-round wrappers and per-round wrappers. At this version it introduce some limitation in that it does not allows for the all the operators inside the iteration to change parallelism after restart from checkpoint. For the long run, the condition could be relaxed to
1. Unbounded iteration could rescale freely.
2. Bounded iteration could rescale all-round / per-round operators if they are restored from a savepoint / external checkpoint taken after round 0 is fully finished. However, the controller operator (Head & Tail) could not support rescaling.