### PR TITLE
[FLINK-24722][iteration] Fixes the issues on supporting keyed stream

### DIFF
--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/AbstractAllRoundWrapperOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/AbstractAllRoundWrapperOperator.java
@@ -29,6 +29,7 @@ import org.apache.flink.iteration.IterationListener;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.AbstractWrapperOperator;
 import org.apache.flink.iteration.operator.OperatorStateUtils;
+import org.apache.flink.iteration.operator.OperatorUtils;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -84,7 +85,8 @@ public abstract class AbstractAllRoundWrapperOperator<T, S extends StreamOperato
                         StreamOperatorFactoryUtil.<T, S>createOperator(
                                         operatorFactory,
                                         (StreamTask) parameters.getContainingTask(),
-                                        parameters.getStreamConfig(),
+                                        OperatorUtils.createWrappedOperatorConfig(
+                                                parameters.getStreamConfig()),
                                         proxyOutput,
                                         parameters.getOperatorEventDispatcher())
                                 .f0;

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/OneInputAllRoundWrapperOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/OneInputAllRoundWrapperOperator.java
@@ -78,8 +78,10 @@ public class OneInputAllRoundWrapperOperator<IN, OUT>
 
     @Override
     public void setKeyContextElement(StreamRecord<IterationRecord<IN>> record) throws Exception {
-        reusedInput.replace(record.getValue().getValue(), record.getTimestamp());
-        wrappedOperator.setKeyContextElement(reusedInput);
+        if (record.getValue().getType() == IterationRecord.Type.RECORD) {
+            reusedInput.replace(record.getValue().getValue(), record.getTimestamp());
+            wrappedOperator.setKeyContextElement(reusedInput);
+        }
     }
 
     @Override

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/ProxyKeySelector.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/ProxyKeySelector.java
@@ -30,6 +30,10 @@ public class ProxyKeySelector<T, KEY> implements KeySelector<IterationRecord<T>,
         this.wrappedKeySelector = wrappedKeySelector;
     }
 
+    public KeySelector<T, KEY> getWrappedKeySelector() {
+        return wrappedKeySelector;
+    }
+
     @Override
     public KEY getKey(IterationRecord<T> record) throws Exception {
         return wrappedKeySelector.getKey(record.getValue());

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/ProxyStreamPartitioner.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/ProxyStreamPartitioner.java
@@ -44,6 +44,12 @@ public class ProxyStreamPartitioner<T> extends StreamPartitioner<IterationRecord
     }
 
     @Override
+    public void setup(int numberOfChannels) {
+        super.setup(numberOfChannels);
+        wrappedStreamPartitioner.setup(numberOfChannels);
+    }
+
+    @Override
     public StreamPartitioner<IterationRecord<T>> copy() {
         return new ProxyStreamPartitioner<>(wrappedStreamPartitioner.copy());
     }
@@ -86,5 +92,10 @@ public class ProxyStreamPartitioner<T> extends StreamPartitioner<IterationRecord
 
             return selectChannel(record);
         }
+    }
+
+    @Override
+    public String toString() {
+        return wrappedStreamPartitioner.toString();
     }
 }

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundStreamIterationITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundStreamIterationITCase.java
@@ -37,6 +37,7 @@ import org.apache.flink.test.iteration.operators.IncrementEpochMap;
 import org.apache.flink.test.iteration.operators.OutputRecord;
 import org.apache.flink.test.iteration.operators.RoundBasedTerminationCriteria;
 import org.apache.flink.test.iteration.operators.SequenceSource;
+import org.apache.flink.test.iteration.operators.StatefulProcessFunction;
 import org.apache.flink.test.iteration.operators.TwoInputReduceAllRoundProcessFunction;
 import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
@@ -130,6 +131,8 @@ public class BoundedAllRoundStreamIterationITCase extends TestLogger {
         // If termination criteria is created only with the constants streams, it would not have
         // records after the round 1 if the input is not replayed.
         int numOfRound = terminationCriteriaFollowsConstantsStreams ? 1 : 5;
+        assertEquals(numOfRound + 1, result.get().size());
+
         Map<Integer, Tuple2<Integer, Integer>> roundsStat =
                 computeRoundStat(
                         result.get(), OutputRecord.Event.EPOCH_WATERMARK_INCREMENTED, numOfRound);
@@ -184,9 +187,15 @@ public class BoundedAllRoundStreamIterationITCase extends TestLogger {
                                             .process(
                                                     new TwoInputReduceAllRoundProcessFunction(
                                                             sync, maxRound));
+
                             return new IterationBodyResult(
                                     DataStreamList.of(
-                                            reducer.map(new IncrementEpochMap())
+                                            reducer.keyBy(EpochRecord::getValue)
+                                                    .process(
+                                                            new StatefulProcessFunction<
+                                                                    EpochRecord>() {})
+                                                    .setParallelism(4)
+                                                    .map(new IncrementEpochMap())
                                                     .setParallelism(numSources)),
                                     DataStreamList.of(
                                             reducer.getSideOutput(
@@ -237,10 +246,16 @@ public class BoundedAllRoundStreamIterationITCase extends TestLogger {
                                             .process(
                                                     new TwoInputReduceAllRoundProcessFunction(
                                                             sync, maxRound));
+
+                            SingleOutputStreamOperator<EpochRecord> feedbackStream =
+                                    reducer.keyBy(EpochRecord::getValue)
+                                            .process(new StatefulProcessFunction<EpochRecord>() {})
+                                            .setParallelism(4)
+                                            .map(new IncrementEpochMap())
+                                            .setParallelism(numSources);
+
                             return new IterationBodyResult(
-                                    DataStreamList.of(
-                                            reducer.map(new IncrementEpochMap())
-                                                    .setParallelism(numSources)),
+                                    DataStreamList.of(feedbackStream),
                                     DataStreamList.of(
                                             reducer.getSideOutput(
                                                     new OutputTag<OutputRecord<Integer>>(

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundStreamIterationITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundStreamIterationITCase.java
@@ -190,7 +190,11 @@ public class BoundedAllRoundStreamIterationITCase extends TestLogger {
 
                             return new IterationBodyResult(
                                     DataStreamList.of(
-                                            reducer.keyBy(EpochRecord::getValue)
+                                            reducer.partitionCustom(
+                                                            (k, numPartitions) -> k % numPartitions,
+                                                            EpochRecord::getValue)
+                                                    .map(x -> x)
+                                                    .keyBy(EpochRecord::getValue)
                                                     .process(
                                                             new StatefulProcessFunction<
                                                                     EpochRecord>() {})
@@ -248,7 +252,11 @@ public class BoundedAllRoundStreamIterationITCase extends TestLogger {
                                                             sync, maxRound));
 
                             SingleOutputStreamOperator<EpochRecord> feedbackStream =
-                                    reducer.keyBy(EpochRecord::getValue)
+                                    reducer.partitionCustom(
+                                                    (k, numPartitions) -> k % numPartitions,
+                                                    EpochRecord::getValue)
+                                            .map(x -> x)
+                                            .keyBy(EpochRecord::getValue)
                                             .process(new StatefulProcessFunction<EpochRecord>() {})
                                             .setParallelism(4)
                                             .map(new IncrementEpochMap())

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundStreamIterationITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundStreamIterationITCase.java
@@ -125,7 +125,11 @@ public class BoundedPerRoundStreamIterationITCase extends TestLogger {
 
                             return new IterationBodyResult(
                                     DataStreamList.of(
-                                            reducer.keyBy(x -> x)
+                                            reducer.partitionCustom(
+                                                            (k, numPartitions) -> k % numPartitions,
+                                                            x -> x)
+                                                    .map(x -> x)
+                                                    .keyBy(x -> x)
                                                     .process(
                                                             new StatefulProcessFunction<
                                                                     Integer>() {})

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundStreamIterationITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundStreamIterationITCase.java
@@ -34,6 +34,7 @@ import org.apache.flink.test.iteration.operators.CollectSink;
 import org.apache.flink.test.iteration.operators.EpochRecord;
 import org.apache.flink.test.iteration.operators.OutputRecord;
 import org.apache.flink.test.iteration.operators.SequenceSource;
+import org.apache.flink.test.iteration.operators.StatefulProcessFunction;
 import org.apache.flink.test.iteration.operators.TwoInputReducePerRoundOperator;
 import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
@@ -123,7 +124,14 @@ public class BoundedPerRoundStreamIterationITCase extends TestLogger {
                                             .setParallelism(1);
 
                             return new IterationBodyResult(
-                                    DataStreamList.of(reducer.filter(x -> x < maxRound)),
+                                    DataStreamList.of(
+                                            reducer.keyBy(x -> x)
+                                                    .process(
+                                                            new StatefulProcessFunction<
+                                                                    Integer>() {})
+                                                    .setParallelism(4)
+                                                    .filter(x -> x < maxRound)
+                                                    .setParallelism(1)),
                                     DataStreamList.of(
                                             reducer.getSideOutput(
                                                     TwoInputReducePerRoundOperator.OUTPUT_TAG)),

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/UnboundedStreamIterationITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/UnboundedStreamIterationITCase.java
@@ -193,7 +193,11 @@ public class UnboundedStreamIterationITCase extends TestLogger {
                                             new ReduceAllRoundProcessFunction(sync, maxRound));
                             return new IterationBodyResult(
                                     DataStreamList.of(
-                                            reducer.keyBy(EpochRecord::getValue)
+                                            reducer.partitionCustom(
+                                                            (k, numPartitions) -> k % numPartitions,
+                                                            EpochRecord::getValue)
+                                                    .map(x -> x)
+                                                    .keyBy(EpochRecord::getValue)
                                                     .process(
                                                             new StatefulProcessFunction<
                                                                     EpochRecord>() {})
@@ -242,7 +246,11 @@ public class UnboundedStreamIterationITCase extends TestLogger {
                                                             sync, maxRound));
 
                             SingleOutputStreamOperator<EpochRecord> feedbackStream =
-                                    reducer.keyBy(EpochRecord::getValue)
+                                    reducer.partitionCustom(
+                                                    (k, numPartitions) -> k % numPartitions,
+                                                    EpochRecord::getValue)
+                                            .map(x -> x)
+                                            .keyBy(EpochRecord::getValue)
                                             .process(new StatefulProcessFunction<EpochRecord>() {})
                                             .setParallelism(4)
                                             .map(new IncrementEpochMap())

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/operators/StatefulProcessFunction.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/operators/StatefulProcessFunction.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.iteration.operators;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.util.Collector;
+
+/**
+ * This is a function that uses keyed state so that we could verify the correctness of using keyed
+ * stream inside the iteration.
+ */
+public class StatefulProcessFunction<T> extends KeyedProcessFunction<Integer, T, T> {
+
+    private ValueState<Integer> state;
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        this.state =
+                getRuntimeContext().getState(new ValueStateDescriptor<>("state", Integer.class));
+    }
+
+    @Override
+    public void processElement(T value, Context ctx, Collector<T> out) throws Exception {
+        if (state.value() == null) {
+            state.update(0);
+
+            // Trying registers a timer
+            ctx.timerService().registerEventTimeTimer(1000L);
+        } else {
+            state.update(state.value() + 1);
+        }
+
+        out.collect(value);
+    }
+}


### PR DESCRIPTION
This PR fixes that 
1. currently we also `setCurrentKey` for both normal records and control events (namely EpochWatermark), which might call NullPointerException. 
2. Currently for the wrapper and wrapped operators, we both uses the wrapped key selectors, which would cause errors if the wrapped operators need to process key. 
2. Not initialize the streampartitioner correctly.
3. Typo in getCurrentKey()