### PR TITLE
[FLINK-24807][iteration] Fix the issues in checkpoints with iteration

### DIFF
--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheSnapshot.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheSnapshot.java
@@ -128,7 +128,7 @@ public class DataCacheSnapshot {
             if (isDistributedFS) {
                 List<Segment> segments = deserializeSegments(dis);
                 DataCacheReader<T> dataCacheReader =
-                        new DataCacheReader<T>(serializer, fileSystem, segments);
+                        new DataCacheReader<>(serializer, fileSystem, segments);
                 while (dataCacheReader.hasNext()) {
                     feedbackConsumer.processFeedback(dataCacheReader.next());
                 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheWriter.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheWriter.java
@@ -26,10 +26,9 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.function.SupplierWithException;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,23 +50,20 @@ public class DataCacheWriter<T> {
             FileSystem fileSystem,
             SupplierWithException<Path, IOException> pathGenerator)
             throws IOException {
-        this(serializer, fileSystem, pathGenerator, null);
+        this(serializer, fileSystem, pathGenerator, Collections.emptyList());
     }
 
     public DataCacheWriter(
             TypeSerializer<T> serializer,
             FileSystem fileSystem,
             SupplierWithException<Path, IOException> pathGenerator,
-            @Nullable List<Segment> writtenSegments)
+            List<Segment> priorFinishedSegments)
             throws IOException {
         this.serializer = serializer;
         this.fileSystem = fileSystem;
         this.pathGenerator = pathGenerator;
 
-        this.finishSegments = new ArrayList<>();
-        if (null != writtenSegments) {
-            finishSegments.addAll(writtenSegments);
-        }
+        this.finishSegments = new ArrayList<>(priorFinishedSegments);
 
         this.currentSegment = new SegmentWriter(pathGenerator.get());
     }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/ReplayOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/ReplayOperator.java
@@ -18,17 +18,24 @@
 
 package org.apache.flink.iteration.operator;
 
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.datacache.nonkeyed.DataCacheReader;
+import org.apache.flink.iteration.datacache.nonkeyed.DataCacheSnapshot;
 import org.apache.flink.iteration.datacache.nonkeyed.DataCacheWriter;
 import org.apache.flink.iteration.progresstrack.OperatorEpochWatermarkTracker;
 import org.apache.flink.iteration.progresstrack.OperatorEpochWatermarkTrackerFactory;
 import org.apache.flink.iteration.progresstrack.OperatorEpochWatermarkTrackerListener;
 import org.apache.flink.iteration.typeinfo.IterationRecordSerializer;
 import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StatePartitionStreamProvider;
+import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
@@ -36,12 +43,18 @@ import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.function.SupplierWithException;
+
+import org.apache.commons.collections.IteratorUtils;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.Collections;
+import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -60,11 +73,21 @@ public class ReplayOperator<T> extends AbstractStreamOperator<IterationRecord<T>
 
     private TypeSerializer<T> typeSerializer;
 
-    private Executor dataReplayerExecutor;
+    private MailboxExecutor mailboxExecutor;
 
     private DataCacheWriter<T> dataCacheWriter;
 
-    private AtomicReference<DataCacheReader<T>> currentDataCacheReader;
+    @Nullable private DataCacheReader<T> currentDataCacheReader;
+
+    private int currentEpoch;
+
+    // ------------- states -------------------
+
+    /** Stores the parallelism of the last run so that we could check if parallelism is changed. */
+    private ListState<Integer> parallelismState;
+
+    /** Stores the current epoch. */
+    private ListState<Integer> currentEpochState;
 
     @Override
     public void setup(
@@ -88,25 +111,11 @@ public class ReplayOperator<T> extends AbstractStreamOperator<IterationRecord<T>
                     (IterationRecordSerializer)
                             config.getTypeSerializerOut(getClass().getClassLoader());
             typeSerializer = iterationRecordSerializer.getInnerSerializer();
-            dataReplayerExecutor =
-                    Executors.newSingleThreadExecutor(
-                            runnable -> {
-                                Thread thread = new Thread(runnable);
-                                thread.setName(
-                                        "Replay-"
-                                                + getOperatorID()
-                                                + "-"
-                                                + containingTask.getIndexInSubtaskGroup());
-                                return thread;
-                            });
-            dataCacheWriter =
-                    new DataCacheWriter<>(
-                            typeSerializer,
-                            fileSystem,
-                            OperatorUtils.createDataCacheFileGenerator(
-                                    basePath, "replay", config.getOperatorID()));
 
-            currentDataCacheReader = new AtomicReference<>();
+            mailboxExecutor =
+                    containingTask
+                            .getMailboxExecutorFactory()
+                            .createExecutor(TaskMailbox.MIN_PRIORITY);
         } catch (Exception e) {
             ExceptionUtils.rethrow(e);
         }
@@ -115,6 +124,95 @@ public class ReplayOperator<T> extends AbstractStreamOperator<IterationRecord<T>
     @Override
     public void initializeState(StateInitializationContext context) throws Exception {
         super.initializeState(context);
+
+        parallelismState =
+                context.getOperatorStateStore()
+                        .getUnionListState(
+                                new ListStateDescriptor<>("parallelism", IntSerializer.INSTANCE));
+        OperatorStateUtils.getUniqueElement(parallelismState, "parallelism")
+                .ifPresent(
+                        oldParallelism ->
+                                checkState(
+                                        oldParallelism
+                                                == getRuntimeContext()
+                                                        .getNumberOfParallelSubtasks(),
+                                        "The Replay operator is recovered with parallelism changed from "
+                                                + oldParallelism
+                                                + " to "
+                                                + getRuntimeContext()
+                                                        .getNumberOfParallelSubtasks()));
+
+        currentEpochState =
+                context.getOperatorStateStore()
+                        .getListState(
+                                new ListStateDescriptor<Integer>("epoch", IntSerializer.INSTANCE));
+        OperatorStateUtils.getUniqueElement(currentEpochState, "epoch")
+                .ifPresent(epoch -> currentEpoch = epoch);
+
+        try {
+            SupplierWithException<Path, IOException> pathGenerator =
+                    OperatorUtils.createDataCacheFileGenerator(
+                            basePath, "replay", config.getOperatorID());
+
+            DataCacheSnapshot dataCacheSnapshot = null;
+            List<StatePartitionStreamProvider> rawStateInputs =
+                    IteratorUtils.toList(context.getRawOperatorStateInputs().iterator());
+            if (rawStateInputs.size() > 0) {
+                checkState(
+                        rawStateInputs.size() == 1,
+                        "Currently the replay operator does not support rescaling");
+
+                dataCacheSnapshot =
+                        DataCacheSnapshot.recover(
+                                rawStateInputs.get(0).getStream(), fileSystem, pathGenerator);
+            }
+
+            dataCacheWriter =
+                    new DataCacheWriter<>(
+                            typeSerializer,
+                            fileSystem,
+                            pathGenerator,
+                            dataCacheSnapshot == null
+                                    ? Collections.emptyList()
+                                    : dataCacheSnapshot.getSegments());
+
+            if (dataCacheSnapshot != null && dataCacheSnapshot.getReaderPosition() != null) {
+                currentDataCacheReader =
+                        new DataCacheReader<>(
+                                typeSerializer,
+                                fileSystem,
+                                dataCacheSnapshot.getSegments(),
+                                dataCacheSnapshot.getReaderPosition());
+            }
+
+        } catch (Exception e) {
+            throw new FlinkRuntimeException("Failed to replay the records", e);
+        }
+    }
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        super.snapshotState(context);
+
+        // Always clears the union list state before set value.
+        parallelismState.clear();
+        if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+            parallelismState.update(
+                    Collections.singletonList(getRuntimeContext().getNumberOfParallelSubtasks()));
+        }
+
+        currentEpochState.update(Collections.singletonList(currentEpoch));
+
+        dataCacheWriter.finishCurrentSegment();
+        DataCacheSnapshot dataCacheSnapshot =
+                new DataCacheSnapshot(
+                        fileSystem,
+                        currentDataCacheReader == null
+                                ? null
+                                : currentDataCacheReader.getPosition(),
+                        dataCacheWriter.getFinishSegments());
+        context.getRawOperatorStateOutput().startNewPartition();
+        dataCacheSnapshot.writeTo(context.getRawOperatorStateOutput());
     }
 
     @Override
@@ -149,6 +247,15 @@ public class ReplayOperator<T> extends AbstractStreamOperator<IterationRecord<T>
     public void endInput(int i) throws Exception {
         // The notification ranges from 1 to N while the track uses 0 to N -1.
         progressTracker.finish(i - 1);
+
+        // 1. If in the last checkpoint the epoch 0 is not finished, currentDataCacheReader must be
+        // null.
+        // 2. If in the last checkpoint the epoch 0 is finished and currentDataCacheReader is not
+        // null, then after failover we need to emit all the following records.
+        if (i == 1 && currentDataCacheReader != null) {
+            // We have to finish emit the following records.
+            replayRecords(currentDataCacheReader, currentEpoch);
+        }
     }
 
     @Override
@@ -156,48 +263,49 @@ public class ReplayOperator<T> extends AbstractStreamOperator<IterationRecord<T>
         if (epochWatermark == 0) {
             // No need to replay for the round 0, it is output directly.
             dataCacheWriter.finish();
-            output.collect(
-                    new StreamRecord<>(
-                            IterationRecord.newEpochWatermark(
-                                    epochWatermark,
-                                    OperatorUtils.getUniqueSenderId(
-                                            config.getOperatorID(),
-                                            getContainingTask().getIndexInSubtaskGroup()))));
+            emitEpochWatermark(epochWatermark);
             return;
         } else if (epochWatermark == Integer.MAX_VALUE) {
-            output.collect(
-                    new StreamRecord<>(
-                            IterationRecord.newEpochWatermark(
-                                    epochWatermark,
-                                    OperatorUtils.getUniqueSenderId(
-                                            config.getOperatorID(),
-                                            getContainingTask().getIndexInSubtaskGroup()))));
+            emitEpochWatermark(epochWatermark);
             return;
         }
 
-        checkState(currentDataCacheReader.get() == null, "Concurrent replay is not supported");
-        currentDataCacheReader.set(
+        // At this point, there would be no more inputs before we finish replaying all the data.
+        // Thus it is safe we implement ourself mailbox loop.
+        checkState(currentDataCacheReader == null, "Concurrent replay is not supported");
+        currentEpoch = epochWatermark;
+        currentDataCacheReader =
                 new DataCacheReader<>(
-                        typeSerializer, fileSystem, dataCacheWriter.getFinishSegments()));
-        dataReplayerExecutor.execute(
-                () -> {
-                    DataCacheReader<T> reader = currentDataCacheReader.get();
-                    StreamRecord<IterationRecord<T>> reusable =
-                            new StreamRecord<>(IterationRecord.newRecord(null, epochWatermark));
-                    while (reader.hasNext()) {
-                        T next = reader.next();
-                        reusable.getValue().setValue(next);
-                        output.collect(reusable);
-                    }
-                    currentDataCacheReader.set(null);
+                        typeSerializer, fileSystem, dataCacheWriter.getFinishSegments());
+        replayRecords(currentDataCacheReader, epochWatermark);
+    }
 
-                    reusable.replace(
-                            IterationRecord.newEpochWatermark(
-                                    epochWatermark,
-                                    OperatorUtils.getUniqueSenderId(
-                                            config.getOperatorID(),
-                                            getContainingTask().getIndexInSubtaskGroup())));
-                    output.collect(reusable);
-                });
+    private void replayRecords(DataCacheReader<T> dataCacheReader, int epoch) {
+        StreamRecord<IterationRecord<T>> reusable =
+                new StreamRecord<>(IterationRecord.newRecord(null, epoch));
+        while (dataCacheReader.hasNext()) {
+            // we first process the pending mail
+            while (mailboxExecutor.tryYield()) {
+                // Do nothing.
+            }
+
+            T next = dataCacheReader.next();
+            reusable.getValue().setValue(next);
+            output.collect(reusable);
+        }
+
+        currentDataCacheReader = null;
+
+        emitEpochWatermark(epoch);
+    }
+
+    private void emitEpochWatermark(int epoch) {
+        output.collect(
+                new StreamRecord<>(
+                        IterationRecord.newEpochWatermark(
+                                epoch,
+                                OperatorUtils.getUniqueSenderId(
+                                        config.getOperatorID(),
+                                        getContainingTask().getIndexInSubtaskGroup()))));
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/HeadOperatorCoordinator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/coordinator/HeadOperatorCoordinator.java
@@ -23,6 +23,7 @@ import org.apache.flink.iteration.operator.HeadOperator;
 import org.apache.flink.iteration.operator.event.CoordinatorCheckpointEvent;
 import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
 import org.apache.flink.iteration.operator.event.SubtaskAlignedEvent;
+import org.apache.flink.iteration.operator.event.TerminatingOnInitializeEvent;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
@@ -79,6 +80,8 @@ public class HeadOperatorCoordinator implements OperatorCoordinator, SharedProgr
         if (operatorEvent instanceof SubtaskAlignedEvent) {
             sharedProgressAligner.reportSubtaskProgress(
                     context.getOperatorId(), subtaskIndex, (SubtaskAlignedEvent) operatorEvent);
+        } else if (operatorEvent instanceof TerminatingOnInitializeEvent) {
+            sharedProgressAligner.notifyGloballyTerminating();
         } else {
             throw new UnsupportedOperationException("Not supported event: " + operatorEvent);
         }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/event/TerminatingOnInitializeEvent.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/event/TerminatingOnInitializeEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.operator.event;
+
+import org.apache.flink.iteration.operator.coordinator.HeadOperatorCoordinator;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+
+/**
+ * Notifies the {@link HeadOperatorCoordinator} that the status has been terminating on startup so
+ * that the coordinator would not emit {@link CoordinatorCheckpointEvent}.
+ */
+public class TerminatingOnInitializeEvent implements OperatorEvent {
+
+    public static final TerminatingOnInitializeEvent INSTANCE = new TerminatingOnInitializeEvent();
+
+    private TerminatingOnInitializeEvent() {}
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorRecordProcessor.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorRecordProcessor.java
@@ -59,5 +59,7 @@ public interface HeadOperatorRecordProcessor {
         void broadcastOutput(StreamRecord<IterationRecord<?>> record);
 
         void updateEpochToCoordinator(int epoch, long numFeedbackRecords);
+
+        void notifyTerminatingOnInitialize();
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorState.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorState.java
@@ -18,10 +18,14 @@
 
 package org.apache.flink.iteration.operator.headprocessor;
 
+import java.util.Collections;
 import java.util.Map;
 
 /** The state entry for the head operator. */
 public class HeadOperatorState {
+
+    public static final HeadOperatorState FINISHED_STATE =
+            new HeadOperatorState(Collections.emptyMap(), 0, 0);
 
     private Map<Integer, Long> numFeedbackRecordsEachRound;
 

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/TerminatingHeadOperatorRecordProcessor.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/TerminatingHeadOperatorRecordProcessor.java
@@ -30,10 +30,17 @@ import org.apache.flink.util.FlinkRuntimeException;
  */
 public class TerminatingHeadOperatorRecordProcessor implements HeadOperatorRecordProcessor {
 
+    private Context headOperatorContext;
+
+    public TerminatingHeadOperatorRecordProcessor(Context headOperatorContext) {
+        this.headOperatorContext = headOperatorContext;
+    }
+
     @Override
     public void initializeState(
-            HeadOperatorState headOperatorState,
-            Iterable<StatePartitionStreamProvider> rawStates) {}
+            HeadOperatorState headOperatorState, Iterable<StatePartitionStreamProvider> rawStates) {
+        headOperatorContext.notifyTerminatingOnInitialize();
+    }
 
     @Override
     public void processElement(StreamRecord<IterationRecord<?>> record) {
@@ -58,6 +65,6 @@ public class TerminatingHeadOperatorRecordProcessor implements HeadOperatorRecor
 
     @Override
     public HeadOperatorState snapshotState() {
-        return null;
+        return HeadOperatorState.FINISHED_STATE;
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/state/ProxyStateSnapshotContext.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/state/ProxyStateSnapshotContext.java
@@ -39,8 +39,7 @@ public class ProxyStateSnapshotContext implements StateSnapshotContext {
 
     @Override
     public OperatorStateCheckpointOutputStream getRawOperatorStateOutput() throws Exception {
-        throw new UnsupportedOperationException(
-                "Currently we do not support the raw keyed state inside the iteration.");
+        return wrappedContext.getRawOperatorStateOutput();
     }
 
     @Override

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/HeadOperatorTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/HeadOperatorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.event.CoordinatorCheckpointEvent;
 import org.apache.flink.iteration.operator.event.GloballyAlignedEvent;
 import org.apache.flink.iteration.operator.event.SubtaskAlignedEvent;
+import org.apache.flink.iteration.operator.event.TerminatingOnInitializeEvent;
 import org.apache.flink.iteration.operator.headprocessor.RegularHeadOperatorRecordProcessor;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
@@ -693,7 +694,7 @@ public class HeadOperatorTest extends TestLogger {
                             harness,
                             HeadOperator.HeadOperatorStatus.TERMINATING,
                             Collections.emptyList(),
-                            Collections.emptyList(),
+                            Collections.singletonList(TerminatingOnInitializeEvent.INSTANCE),
                             Collections.emptyMap(),
                             -1,
                             -1);

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/ReplayOperatorTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/operator/ReplayOperatorTest.java
@@ -19,21 +19,41 @@
 package org.apache.flink.iteration.operator;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.config.IterationOptions;
+import org.apache.flink.iteration.typeinfo.IterationRecordSerializer;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.writer.RecordOrEventCollectingResultPartitionWriter;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarnessBuilder;
 import org.apache.flink.streaming.runtime.tasks.TwoInputStreamTask;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.FunctionWithException;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Queue;
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -41,7 +61,7 @@ import java.util.stream.Stream;
 import static org.junit.Assert.assertEquals;
 
 /** Test the behavior of {@link ReplayOperator}. */
-public class ReplayOperatorTest {
+public class ReplayOperatorTest extends TestLogger {
 
     @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -50,12 +70,206 @@ public class ReplayOperatorTest {
         final int numRecords = 10;
         OperatorID operatorId = new OperatorID();
 
+        createHarnessAndRun(
+                operatorId,
+                null,
+                harness -> {
+                    // First round
+                    for (int i = 0; i < numRecords; ++i) {
+                        harness.processElement(
+                                new StreamRecord<>(IterationRecord.newRecord(i, 0)), 0, 0);
+                    }
+                    harness.endInput(0, true);
+                    harness.processElement(
+                            new StreamRecord<>(IterationRecord.newEpochWatermark(0, "sender1")),
+                            1,
+                            0);
+                    assertOutputAllRecordsAndEpochWatermark(
+                            harness.getOutput(), numRecords, operatorId, 0);
+                    harness.getOutput().clear();
+
+                    // The round 1
+                    harness.processElement(
+                            new StreamRecord<>(IterationRecord.newEpochWatermark(1, "sender1")),
+                            1,
+                            0);
+                    // The output would be done asynchronously inside the ReplayerOperator.
+                    while (harness.getOutput().size() < numRecords + 1) {
+                        Thread.sleep(500);
+                    }
+                    assertOutputAllRecordsAndEpochWatermark(
+                            harness.getOutput(), numRecords, operatorId, 1);
+                    harness.getOutput().clear();
+
+                    // The round 2
+                    harness.processElement(
+                            new StreamRecord<>(IterationRecord.newEpochWatermark(2, "sender1")),
+                            1,
+                            0);
+                    // The output would be done asynchronously inside the ReplayerOperator.
+                    while (harness.getOutput().size() < numRecords + 1) {
+                        Thread.sleep(500);
+                    }
+                    assertOutputAllRecordsAndEpochWatermark(
+                            harness.getOutput(), numRecords, operatorId, 2);
+                    return null;
+                });
+    }
+
+    @Test
+    public void testSnapshotAndRestoreOnFirstEpoch() throws Exception {
+        final int numRecords = 10;
+        OperatorID operatorId = new OperatorID();
+
+        List<Object> firstRoundOutput = new ArrayList<>();
+        List<Object> secondRoundOutput = new ArrayList<>();
+
+        TaskStateSnapshot snapshot =
+                createHarnessAndRun(
+                        operatorId,
+                        null,
+                        harness -> {
+                            harness.getTaskStateManager().getWaitForReportLatch().reset();
+
+                            for (int i = 0; i < numRecords / 2; ++i) {
+                                harness.processElement(
+                                        new StreamRecord<>(IterationRecord.newRecord(i, 0)), 0, 0);
+                            }
+
+                            harness.getStreamTask()
+                                    .triggerCheckpointAsync(
+                                            new CheckpointMetaData(2, 1000),
+                                            CheckpointOptions.alignedNoTimeout(
+                                                    CheckpointType.CHECKPOINT,
+                                                    CheckpointStorageLocationReference
+                                                            .getDefault()));
+                            harness.processAll();
+
+                            firstRoundOutput.addAll(harness.getOutput());
+
+                            harness.getTaskStateManager().getWaitForReportLatch().await();
+                            return harness.getTaskStateManager()
+                                    .getLastJobManagerTaskStateSnapshot();
+                        });
+
+        createHarnessAndRun(
+                operatorId,
+                snapshot,
+                harness -> {
+                    for (int i = numRecords / 2; i < numRecords; ++i) {
+                        harness.processElement(
+                                new StreamRecord<>(IterationRecord.newRecord(i, 0)), 0, 0);
+                    }
+                    harness.endInput(0, true);
+                    harness.processElement(
+                            new StreamRecord<>(IterationRecord.newEpochWatermark(0, "send-0")),
+                            1,
+                            0);
+                    harness.processAll();
+                    firstRoundOutput.addAll(harness.getOutput());
+
+                    // The second round
+                    harness.getOutput().clear();
+                    harness.processElement(
+                            new StreamRecord<>(IterationRecord.newEpochWatermark(1, "send-0")),
+                            1,
+                            0);
+                    secondRoundOutput.addAll(harness.getOutput());
+
+                    return null;
+                });
+
+        assertOutputAllRecordsAndEpochWatermark(firstRoundOutput, numRecords, operatorId, 0);
+        assertOutputAllRecordsAndEpochWatermark(secondRoundOutput, numRecords, operatorId, 1);
+    }
+
+    @Test
+    public void testSnapshotAndRestoreOnSecondEpoch() throws Exception {
+        final int numRecords = 10;
+        OperatorID operatorId = new OperatorID();
+
+        List<Object> firstRoundOutput = new ArrayList<>();
+        List<Object> secondRoundOutput = new ArrayList<>();
+
+        HookableOutput hookableOutput = new HookableOutput(numRecords + numRecords / 2);
+        TaskStateSnapshot snapshot =
+                createHarnessAndRun(
+                        operatorId,
+                        null,
+                        harness -> {
+                            harness.getTaskStateManager().getWaitForReportLatch().reset();
+
+                            for (int i = 0; i < numRecords; ++i) {
+                                harness.processElement(
+                                        new StreamRecord<>(IterationRecord.newRecord(i, 0)), 0, 0);
+                            }
+                            harness.endInput(0, true);
+                            harness.processElement(
+                                    new StreamRecord<>(
+                                            IterationRecord.newEpochWatermark(0, "send-0")),
+                                    1,
+                                    0);
+                            harness.processAll();
+                            firstRoundOutput.addAll(harness.getOutput());
+
+                            harness.getOutput().clear();
+                            harness.getTaskStateManager().getWaitForReportLatch().reset();
+                            // We have to simulate another thread insert checkpoint barrier
+                            hookableOutput.setRunnable(
+                                    () ->
+                                            harness.getStreamTask()
+                                                    .triggerCheckpointAsync(
+                                                            new CheckpointMetaData(2, 1000),
+                                                            CheckpointOptions.alignedNoTimeout(
+                                                                    CheckpointType.CHECKPOINT,
+                                                                    CheckpointStorageLocationReference
+                                                                            .getDefault())));
+                            // Slightly postpone the epoch watermark.
+                            harness.processElement(
+                                    new StreamRecord<>(
+                                            IterationRecord.newEpochWatermark(1, "send-0")),
+                                    1,
+                                    0);
+                            harness.processAll();
+                            secondRoundOutput.addAll(harness.getOutput());
+
+                            harness.getTaskStateManager().getWaitForReportLatch().await();
+                            return harness.getTaskStateManager()
+                                    .getLastJobManagerTaskStateSnapshot();
+                        },
+                        hookableOutput);
+
+        createHarnessAndRun(
+                operatorId,
+                snapshot,
+                harness -> {
+                    // In this case, we expected the input would finish immediately.
+                    harness.endInput(0, true);
+                    secondRoundOutput.addAll(harness.getOutput());
+                    return null;
+                });
+
+        assertOutputAllRecordsAndEpochWatermark(firstRoundOutput, numRecords, operatorId, 0);
+        assertOutputAllRecordsAndEpochWatermark(secondRoundOutput, numRecords, operatorId, 1);
+    }
+
+    private <T> T createHarnessAndRun(
+            OperatorID operatorId,
+            @Nullable TaskStateSnapshot snapshot,
+            FunctionWithException<
+                            StreamTaskMailboxTestHarness<IterationRecord<Integer>>, T, Exception>
+                    runnable,
+            ResultPartitionWriter... additionalOutput)
+            throws Exception {
         try (StreamTaskMailboxTestHarness<IterationRecord<Integer>> harness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 TwoInputStreamTask::new,
                                 new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
                         .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO), 1)
                         .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.VOID_TYPE_INFO), 1)
+                        .addAdditionalOutput(additionalOutput)
+                        .setTaskStateSnapshot(
+                                1, snapshot == null ? new TaskStateSnapshot() : snapshot)
                         .setupOutputForSingletonOperatorChain(new ReplayOperator<>(), operatorId)
                         .buildUnrestored()) {
             harness.getStreamTask()
@@ -66,40 +280,12 @@ public class ReplayOperatorTest {
                             IterationOptions.DATA_CACHE_PATH,
                             "file://" + tempFolder.newFolder().getAbsolutePath());
             harness.getStreamTask().restore();
-
-            // First round
-            for (int i = 0; i < numRecords; ++i) {
-                harness.processElement(new StreamRecord<>(IterationRecord.newRecord(i, 0)), 0, 0);
-            }
-            harness.endInput(0, true);
-            harness.processElement(
-                    new StreamRecord<>(IterationRecord.newEpochWatermark(0, "sender1")), 1, 0);
-            assertOutputAllRecordsAndEpochWatermark(harness.getOutput(), numRecords, operatorId, 0);
-            harness.getOutput().clear();
-
-            // The round 1
-            harness.processElement(
-                    new StreamRecord<>(IterationRecord.newEpochWatermark(1, "sender1")), 1, 0);
-            // The output would be done asynchronously inside the ReplayerOperator.
-            while (harness.getOutput().size() < numRecords + 1) {
-                Thread.sleep(500);
-            }
-            assertOutputAllRecordsAndEpochWatermark(harness.getOutput(), numRecords, operatorId, 1);
-            harness.getOutput().clear();
-
-            // The round 2
-            harness.processElement(
-                    new StreamRecord<>(IterationRecord.newEpochWatermark(2, "sender1")), 1, 0);
-            // The output would be done asynchronously inside the ReplayerOperator.
-            while (harness.getOutput().size() < numRecords + 1) {
-                Thread.sleep(500);
-            }
-            assertOutputAllRecordsAndEpochWatermark(harness.getOutput(), numRecords, operatorId, 2);
+            return runnable.apply(harness);
         }
     }
 
     private void assertOutputAllRecordsAndEpochWatermark(
-            Queue<Object> output, int numRecords, OperatorID operatorId, int round) {
+            Collection<Object> output, int numRecords, OperatorID operatorId, int round) {
         assertEquals(
                 Stream.concat(
                                 IntStream.range(0, numRecords)
@@ -116,6 +302,49 @@ public class ReplayOperatorTest {
                                                         OperatorUtils.getUniqueSenderId(
                                                                 operatorId, 0)))))
                         .collect(Collectors.toList()),
-                new ArrayList<>(output));
+                output.stream()
+                        .filter(e -> e.getClass() != CheckpointBarrier.class)
+                        .collect(Collectors.toList()));
+    }
+
+    private static class HookableOutput
+            extends RecordOrEventCollectingResultPartitionWriter<StreamElement> {
+
+        private int remainingRecordsToWait;
+
+        @Nullable private Runnable runnable;
+
+        public HookableOutput(int triggerCount) {
+            super(
+                    new ArrayDeque<>(),
+                    new StreamElementSerializer<>(
+                            new IterationRecordSerializer<>(IntSerializer.INSTANCE)));
+            this.remainingRecordsToWait = triggerCount;
+        }
+
+        public void setRunnable(Runnable runnable) {
+            this.runnable = runnable;
+        }
+
+        @Override
+        public void emitRecord(ByteBuffer record, int targetSubpartition) throws IOException {
+            super.emitRecord(record, targetSubpartition);
+            tryTrigger();
+        }
+
+        @Override
+        public void broadcastRecord(ByteBuffer record) throws IOException {
+            super.broadcastRecord(record);
+            tryTrigger();
+        }
+
+        private void tryTrigger() {
+            if (remainingRecordsToWait > 0) {
+                remainingRecordsToWait--;
+                if (remainingRecordsToWait == 0 && runnable != null) {
+                    runnable.run();
+                }
+            }
+        }
     }
 }

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundCheckpointITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundCheckpointITCase.java
@@ -60,7 +60,7 @@ import static org.junit.Assert.assertEquals;
 
 /** Tests checkpoints. */
 @RunWith(Parameterized.class)
-public class BoundedAllRoundCheckpointTest extends TestLogger {
+public class BoundedAllRoundCheckpointITCase extends TestLogger {
 
     @Rule public final SharedObjects sharedObjects = SharedObjects.create();
 

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundCheckpointITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundCheckpointITCase.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.test.iteration;
 
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.iteration.DataStreamList;
+import org.apache.flink.iteration.IterationBody;
 import org.apache.flink.iteration.IterationBodyResult;
+import org.apache.flink.iteration.IterationConfig;
 import org.apache.flink.iteration.Iterations;
-import org.apache.flink.iteration.compile.DraftExecutionEnvironment;
+import org.apache.flink.iteration.ReplayableDataStreamList;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.streaming.api.CheckpointingMode;
@@ -34,13 +37,11 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.test.iteration.operators.EpochRecord;
 import org.apache.flink.test.iteration.operators.FailingMap;
-import org.apache.flink.test.iteration.operators.IncrementEpochMap;
 import org.apache.flink.test.iteration.operators.OutputRecord;
 import org.apache.flink.test.iteration.operators.SequenceSource;
-import org.apache.flink.test.iteration.operators.TwoInputReduceAllRoundProcessFunction;
+import org.apache.flink.test.iteration.operators.TwoInputReducePerRoundOperator;
 import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
-import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
@@ -50,6 +51,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -60,7 +62,7 @@ import static org.junit.Assert.assertEquals;
 
 /** Tests checkpoints. */
 @RunWith(Parameterized.class)
-public class BoundedAllRoundCheckpointITCase extends TestLogger {
+public class BoundedPerRoundCheckpointITCase extends TestLogger {
 
     @Rule public final SharedObjects sharedObjects = SharedObjects.create();
 
@@ -69,22 +71,15 @@ public class BoundedAllRoundCheckpointITCase extends TestLogger {
     @Parameterized.Parameter(0)
     public int failoverCount;
 
-    @Parameterized.Parameter(1)
-    public boolean sync;
-
-    @Parameterized.Parameters(name = "failoverCount = {0}, sync = {1}")
+    @Parameterized.Parameters(name = "failoverCount = {0}")
     public static Collection<Object[]> params() {
-        int[] failoverCounts = {1000, 4000, 8000, 15900};
-        boolean[] syncs = {true, false};
-
-        List<Object[]> result = new ArrayList<>();
-        for (int failoverCount : failoverCounts) {
-            for (boolean sync : syncs) {
-                result.add(new Object[] {failoverCount, sync});
-            }
-        }
-
-        return result;
+        return Arrays.asList(
+                new Object[] {1000},
+                new Object[] {4000},
+                new Object[] {6123},
+                new Object[] {8000},
+                new Object[] {10875},
+                new Object[] {15900});
     }
 
     @Before
@@ -97,10 +92,10 @@ public class BoundedAllRoundCheckpointITCase extends TestLogger {
         try (MiniCluster miniCluster = new MiniCluster(createMiniClusterConfiguration(2, 2))) {
             miniCluster.start();
 
-            // Create the test job
+            // Creates the test job
             JobGraph jobGraph =
                     createVariableAndConstantJobGraph(
-                            4, 1000, false, 0, sync, 4, failoverCount, new CollectSink(result));
+                            4, 1000, 4, failoverCount, new CollectSink(result));
             miniCluster.executeJobBlocking(jobGraph);
 
             Map<Integer, Tuple2<Integer, Integer>> roundsStat = new HashMap<>();
@@ -112,9 +107,11 @@ public class BoundedAllRoundCheckpointITCase extends TestLogger {
                 state.f1 = output.getValue();
             }
 
+            System.out.println("Round state: " + roundsStat);
+
             // 0 ~ 4 round and termination information
-            assertEquals(6, roundsStat.size());
-            for (int i = 0; i <= 4; ++i) {
+            assertEquals(4, roundsStat.size());
+            for (int i = 0; i < 4; ++i) {
                 // In this case we could only check the final result, the number of records is not
                 // deterministic.
                 assertEquals(4 * (0 + 999) * 1000 / 2, (int) roundsStat.get(i).f1);
@@ -122,12 +119,10 @@ public class BoundedAllRoundCheckpointITCase extends TestLogger {
         }
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     static JobGraph createVariableAndConstantJobGraph(
             int numSources,
             int numRecordsPerSource,
-            boolean holdSource,
-            int period,
-            boolean sync,
             int maxRound,
             int failoverCount,
             SinkFunction<OutputRecord<Integer>> sinkFunction) {
@@ -143,37 +138,59 @@ public class BoundedAllRoundCheckpointITCase extends TestLogger {
                         });
         env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
         env.setParallelism(1);
-        DataStream<EpochRecord> variableSource =
-                env.addSource(new DraftExecutionEnvironment.EmptySource<EpochRecord>() {})
-                        .setParallelism(numSources)
+        DataStream<Integer> variableSource =
+                env.addSource(new SequenceSource(1, false, 0))
+                        .setParallelism(1)
+                        .map(EpochRecord::getValue)
+                        .setParallelism(1)
                         .name("Variable");
-        DataStream<EpochRecord> constSource =
-                env.addSource(new SequenceSource(numRecordsPerSource, holdSource, period))
+        DataStream<Integer> constSource =
+                env.addSource(new SequenceSource(numRecordsPerSource, false, 0))
+                        .setParallelism(numSources)
+                        .map(EpochRecord::getValue)
                         .setParallelism(numSources)
                         .name("Constant");
         DataStreamList outputs =
-                Iterations.iterateUnboundedStreams(
+                Iterations.iterateBoundedStreamsUntilTermination(
                         DataStreamList.of(variableSource),
-                        DataStreamList.of(constSource),
+                        ReplayableDataStreamList.replay(constSource),
+                        IterationConfig.newBuilder().build(),
                         (variableStreams, dataStreams) -> {
-                            SingleOutputStreamOperator<EpochRecord> reducer =
-                                    variableStreams
-                                            .<EpochRecord>get(0)
-                                            .connect(dataStreams.<EpochRecord>get(0))
-                                            .process(
-                                                    new TwoInputReduceAllRoundProcessFunction(
-                                                            sync, maxRound));
-                            DataStream<EpochRecord> failedMap =
-                                    reducer.map(new FailingMap(failoverCount) {});
+                            SingleOutputStreamOperator<Integer> reducer =
+                                    (SingleOutputStreamOperator)
+                                            IterationBody.forEachRound(
+                                                            DataStreamList.of(
+                                                                    variableStreams.get(0),
+                                                                    dataStreams
+                                                                            .<Integer>get(0)
+                                                                            .map(
+                                                                                    new FailingMap<
+                                                                                            Integer>(
+                                                                                            failoverCount) {})),
+                                                            (streams) -> {
+                                                                DataStream<Integer> variableStream =
+                                                                        streams.get(0);
+                                                                DataStream<Integer> constStream =
+                                                                        streams.get(1);
+                                                                return DataStreamList.of(
+                                                                        variableStream
+                                                                                .connect(
+                                                                                        constStream)
+                                                                                .transform(
+                                                                                        "Reducer",
+                                                                                        BasicTypeInfo
+                                                                                                .INT_TYPE_INFO,
+                                                                                        new TwoInputReducePerRoundOperator())
+                                                                                .setParallelism(1));
+                                                            })
+                                                    .get(0);
+
                             return new IterationBodyResult(
-                                    DataStreamList.of(
-                                            failedMap
-                                                    .map(new IncrementEpochMap())
-                                                    .setParallelism(numSources)),
+                                    DataStreamList.of(reducer.filter(x -> x < maxRound)),
                                     DataStreamList.of(
                                             reducer.getSideOutput(
-                                                    new OutputTag<OutputRecord<Integer>>(
-                                                            "output") {})));
+                                                    TwoInputReducePerRoundOperator.OUTPUT_TAG)),
+                                    reducer.filter(x -> x < maxRound).setParallelism(1));
                         });
         outputs.<OutputRecord<Integer>>get(0).addSink(sinkFunction);
 

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundCheckpointITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundCheckpointITCase.java
@@ -107,8 +107,6 @@ public class BoundedPerRoundCheckpointITCase extends TestLogger {
                 state.f1 = output.getValue();
             }
 
-            System.out.println("Round state: " + roundsStat);
-
             // 0 ~ 4 round and termination information
             assertEquals(4, roundsStat.size());
             for (int i = 0; i < 4; ++i) {

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundStreamIterationITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundStreamIterationITCase.java
@@ -103,7 +103,7 @@ public class BoundedPerRoundStreamIterationITCase extends TestLogger {
                         .setParallelism(numSources)
                         .map(EpochRecord::getValue)
                         .setParallelism(numSources)
-                        .name("Constants");
+                        .name("Constant");
 
         DataStreamList outputs =
                 Iterations.iterateBoundedStreamsUntilTermination(

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/operators/FailingMap.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/operators/FailingMap.java
@@ -21,7 +21,7 @@ package org.apache.flink.test.iteration.operators;
 import org.apache.flink.api.common.functions.RichMapFunction;
 
 /** Map Function triggers failover at the first task and first round. */
-public class FailingMap extends RichMapFunction<EpochRecord, EpochRecord> {
+public class FailingMap<T> extends RichMapFunction<T, T> {
 
     private final int failingCount;
 
@@ -32,7 +32,7 @@ public class FailingMap extends RichMapFunction<EpochRecord, EpochRecord> {
     }
 
     @Override
-    public EpochRecord map(EpochRecord value) throws Exception {
+    public T map(T value) throws Exception {
         count++;
         if (getRuntimeContext().getIndexOfThisSubtask() == 0
                 && getRuntimeContext().getAttemptNumber() == 0


### PR DESCRIPTION
We have met some more issues in supporting checkpoints with iteration:

1. Support snapshotting Replayer Operator and per-round wrapper.
2. Fix the issues that after head tasks finished, the coordinator continues emitting CoordinatorCheckpointEvent, which made the checkpoint fails due to events not sending.
3. Support raw operator state inside the iteration. 

Specially for the second point,  Currently the HeadCoordinator would emit CoordinatorCheckpointEvent to the tasks so that the GloballyAlignedEvent would not be interleave with the checkpoint barrier. However, if the tasks are finished and we continue emitting the event, the checkpoint would fail due to there are failed operator events. To address this issue, we would stop emitting CoordinatorCheckpointEvent after the head operator is terminating, namely it received the GloballyAlignedEvent marking terminating.

The third point is required since operators like `withBroadcast` might rely on raw operator state to snapshot the cached records. This is necessary since the normal operator state always resides in the memory, which might be not enough.