### PR TITLE
[FLINK-24810] Add Estimator and Model for the k-means clustering algorithm

### DIFF
--- a/flink-ml-api/src/main/java/org/apache/flink/ml/distance/DistanceMeasure.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/distance/DistanceMeasure.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.distance;
+
+import org.apache.flink.ml.linalg.Vector;
+
+import java.io.Serializable;
+
+/** Interface for measuring distance between two vectors. */
+public interface DistanceMeasure extends Serializable {
+
+    static DistanceMeasure getInstance(String distanceMeasure) {
+        if (distanceMeasure.equals(EuclideanDistanceMeasure.NAME)) {
+            return EuclideanDistanceMeasure.getInstance();
+        }
+        throw new IllegalArgumentException(
+                "distanceMeasure "
+                        + distanceMeasure
+                        + " is not recognized. Supported options: 'euclidean'.");
+    }
+
+    /**
+     * Measures the distance between two vectors.
+     *
+     * <p>Required: The two vectors should have the same dimension.
+     */
+    double distance(Vector v1, Vector v2);
+}

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/distance/EuclideanDistanceMeasure.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/distance/EuclideanDistanceMeasure.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.distance;
+
+import org.apache.flink.ml.linalg.Vector;
+
+/** Interface for measuring the Euclidean distance between two vectors. */
+public class EuclideanDistanceMeasure implements DistanceMeasure {
+
+    private static final EuclideanDistanceMeasure instance = new EuclideanDistanceMeasure();
+    public static final String NAME = "euclidean";
+
+    private EuclideanDistanceMeasure() {}
+
+    public static EuclideanDistanceMeasure getInstance() {
+        return instance;
+    }
+
+    @Override
+    public double distance(Vector v1, Vector v2) {
+        double squaredDistance = 0.0;
+
+        for (int i = 0; i < v1.size(); i++) {
+            double diff = v1.get(i) - v2.get(i);
+            squaredDistance += diff * diff;
+        }
+        return Math.sqrt(squaredDistance);
+    }
+}

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/DenseVector.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/DenseVector.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.linalg;
+
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfoFactory;
+
+import java.util.Arrays;
+
+/** A dense vector of double values. */
+@TypeInfo(DenseVectorTypeInfoFactory.class)
+public class DenseVector implements Vector {
+    public final double[] values;
+
+    public DenseVector(double[] values) {
+        this.values = values;
+    }
+
+    @Override
+    public int size() {
+        return values.length;
+    }
+
+    @Override
+    public double get(int i) {
+        return values[i];
+    }
+
+    @Override
+    public double[] toArray() {
+        return values;
+    }
+
+    @Override
+    public String toString() {
+        return Arrays.toString(values);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof DenseVector)) {
+            return false;
+        }
+        return Arrays.equals(values, ((DenseVector) obj).values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(values);
+    }
+}

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/Vector.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/Vector.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.linalg;
+
+import java.io.Serializable;
+
+/** A vector of double values. */
+public interface Vector extends Serializable {
+
+    /** Gets the size of the vector. */
+    int size();
+
+    /** Gets the value of the ith element. */
+    double get(int i);
+
+    /** Converts the instance to a double array. */
+    double[] toArray();
+}

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/Vectors.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/Vectors.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.linalg;
+
+/** Utility methods for instantiating Vector. */
+public class Vectors {
+
+    /** Creates a dense vector from its values. */
+    public static DenseVector dense(double... values) {
+        return new DenseVector(values);
+    }
+}

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorSerializer.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorSerializer.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.ml.linalg.typeinfo;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.ml.linalg.DenseVector;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/** Specialized serializer for {@code DenseVector}. */
+public final class DenseVectorSerializer extends TypeSerializerSingleton<DenseVector> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final double[] EMPTY = new double[0];
+
+    private static final DenseVectorSerializer INSTANCE = new DenseVectorSerializer();
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public DenseVector createInstance() {
+        return new DenseVector(EMPTY);
+    }
+
+    @Override
+    public DenseVector copy(DenseVector from) {
+        return new DenseVector(Arrays.copyOf(from.values, from.values.length));
+    }
+
+    @Override
+    public DenseVector copy(DenseVector from, DenseVector reuse) {
+        if (from.values.length == reuse.values.length) {
+            System.arraycopy(from.values, 0, reuse.values, 0, from.values.length);
+            return reuse;
+        }
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(DenseVector vector, DataOutputView target) throws IOException {
+        if (vector == null) {
+            throw new IllegalArgumentException("The vector must not be null.");
+        }
+
+        final int len = vector.values.length;
+        target.writeInt(len);
+        for (int i = 0; i < len; i++) {
+            target.writeDouble(vector.get(i));
+        }
+    }
+
+    @Override
+    public DenseVector deserialize(DataInputView source) throws IOException {
+        int len = source.readInt();
+        double[] values = new double[len];
+        for (int i = 0; i < len; i++) {
+            values[i] = source.readDouble();
+        }
+        return new DenseVector(values);
+    }
+
+    // Reads `len` double values from `source` into `dst`.
+    private static void readDoubleArray(double[] dst, DataInputView source, int len)
+            throws IOException {
+        for (int i = 0; i < len; i++) {
+            dst[i] = source.readDouble();
+        }
+    }
+
+    @Override
+    public DenseVector deserialize(DenseVector reuse, DataInputView source) throws IOException {
+        int len = source.readInt();
+        if (len == reuse.values.length) {
+            readDoubleArray(reuse.values, source, len);
+            return reuse;
+        }
+
+        double[] values = new double[len];
+        readDoubleArray(values, source, len);
+        return new DenseVector(values);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        final int len = source.readInt();
+        target.writeInt(len);
+        target.write(source, len * 8);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public TypeSerializerSnapshot<DenseVector> snapshotConfiguration() {
+        return new DenseVectorSerializerSnapshot();
+    }
+
+    /** Serializer configuration snapshot for compatibility and format evolution. */
+    @SuppressWarnings("WeakerAccess")
+    public static final class DenseVectorSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<DenseVector> {
+
+        public DenseVectorSerializerSnapshot() {
+            super(() -> INSTANCE);
+        }
+    }
+}

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorTypeInfo.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorTypeInfo.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.linalg.typeinfo;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.ml.linalg.DenseVector;
+
+/** A {@link TypeInformation} for the {@link DenseVector} type. */
+public class DenseVectorTypeInfo extends TypeInformation<DenseVector> {
+    private static final long serialVersionUID = 1L;
+
+    public static final DenseVectorTypeInfo INSTANCE = new DenseVectorTypeInfo();
+
+    public DenseVectorTypeInfo() {}
+
+    @Override
+    public int getArity() {
+        return 1;
+    }
+
+    @Override
+    public int getTotalFields() {
+        return 1;
+    }
+
+    @Override
+    public Class<DenseVector> getTypeClass() {
+        return DenseVector.class;
+    }
+
+    @Override
+    public boolean isBasicType() {
+        return false;
+    }
+
+    @Override
+    public boolean isTupleType() {
+        return false;
+    }
+
+    @Override
+    public boolean isKeyType() {
+        return false;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public TypeSerializer<DenseVector> createSerializer(ExecutionConfig executionConfig) {
+        return new DenseVectorSerializer();
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof DenseVectorTypeInfo;
+    }
+
+    @Override
+    public boolean canEqual(Object obj) {
+        return obj instanceof DenseVectorTypeInfo;
+    }
+
+    @Override
+    public String toString() {
+        return "DenseVectorType";
+    }
+}

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorTypeInfoFactory.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorTypeInfoFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.linalg.typeinfo;
+
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.ml.linalg.DenseVector;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Used by {@link TypeExtractor} to create a {@link TypeInformation} for implementations of {@link
+ * DenseVector}.
+ */
+public class DenseVectorTypeInfoFactory extends TypeInfoFactory<DenseVector> {
+
+    @Override
+    public TypeInformation<DenseVector> createTypeInfo(
+            Type t, Map<String, TypeInformation<?>> genericParameters) {
+
+        return new DenseVectorTypeInfo();
+    }
+}

--- a/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/StageTest.java
+++ b/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/StageTest.java
@@ -172,7 +172,7 @@ public class StageTest {
             throws IOException {
         for (Map.Entry<String, Object> entry : paramOverrides.entrySet()) {
             Param<?> param = stage.getParam(entry.getKey());
-            ReadWriteUtils.setStageParam(stage, param, entry.getValue());
+            ReadWriteUtils.setParam(stage, param, entry.getValue());
         }
 
         String tempDir = Files.createTempDirectory("").toString();

--- a/flink-ml-lib/pom.xml
+++ b/flink-ml-lib/pom.xml
@@ -38,11 +38,12 @@ under the License.
     </dependency>
 
     <dependency>
-    <groupId>org.apache.flink</groupId>
-    <artifactId>flink-ml-iteration</artifactId>
-    <version>${project.version}</version>
-    <scope>provided</scope>
-  </dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-ml-iteration</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-table-api-java</artifactId>
@@ -65,16 +66,19 @@ under the License.
     </dependency>
 
     <dependency>
-      <groupId>com.github.fommil.netlib</groupId>
-      <artifactId>core</artifactId>
-      <version>1.1.2</version>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-runtime_${scala.binary.version}</artifactId>
+      <version>${flink.version}</version>
+      <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-clients_${scala.binary.version}</artifactId>
+      <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
       <version>${flink.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.clustering.kmeans;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.MapPartitionFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.iteration.DataStreamList;
+import org.apache.flink.iteration.IterationBody;
+import org.apache.flink.iteration.IterationBodyResult;
+import org.apache.flink.iteration.IterationConfig;
+import org.apache.flink.iteration.IterationListener;
+import org.apache.flink.iteration.Iterations;
+import org.apache.flink.iteration.ReplayableDataStreamList;
+import org.apache.flink.ml.api.core.Estimator;
+import org.apache.flink.ml.common.datastream.EndOfStreamWindows;
+import org.apache.flink.ml.common.datastream.MapPartitionFunctionWrapper;
+import org.apache.flink.ml.common.iteration.ForwardInputsOfLastRound;
+import org.apache.flink.ml.common.iteration.TerminateOnMaxIterationNum;
+import org.apache.flink.ml.distance.DistanceMeasure;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.windowing.AllWindowFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.util.Collector;
+
+import org.apache.commons.collections.IteratorUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * An Estimator which implements the k-means clustering algorithm.
+ *
+ * <p>See https://en.wikipedia.org/wiki/K-means_clustering.
+ */
+public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMeans> {
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public KMeans() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public KMeansModel fit(Table... inputs) {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<DenseVector> points =
+                tEnv.toDataStream(inputs[0])
+                        .map(row -> (DenseVector) row.getField(getFeaturesCol()));
+
+        DataStream<DenseVector[]> initCentroids = selectRandomCentroids(points, getK(), getSeed());
+
+        IterationConfig config =
+                IterationConfig.newBuilder()
+                        .setOperatorLifeCycle(IterationConfig.OperatorLifeCycle.ALL_ROUND)
+                        .build();
+
+        IterationBody body =
+                new KMeansIterationBody(
+                        getMaxIter(), DistanceMeasure.getInstance(getDistanceMeasure()));
+
+        DataStream<DenseVector[]> finalCentroids =
+                Iterations.iterateBoundedStreamsUntilTermination(
+                                DataStreamList.of(initCentroids),
+                                ReplayableDataStreamList.notReplay(points),
+                                config,
+                                body)
+                        .get(0);
+
+        Table finalCentroidsTable = tEnv.fromDataStream(finalCentroids, KMeansModelData.SCHEMA);
+        KMeansModel model = new KMeansModel().setModelData(finalCentroidsTable);
+        ReadWriteUtils.updateExistingParams(model, paramMap);
+        return model;
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+
+    public static KMeans load(StreamExecutionEnvironment env, String path) throws IOException {
+        return ReadWriteUtils.loadStageParam(path);
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    private static class KMeansIterationBody implements IterationBody {
+        private final int maxIterationNum;
+        private final DistanceMeasure distanceMeasure;
+
+        public KMeansIterationBody(int maxIterationNum, DistanceMeasure distanceMeasure) {
+            this.maxIterationNum = maxIterationNum;
+            this.distanceMeasure = distanceMeasure;
+        }
+
+        @Override
+        public IterationBodyResult process(
+                DataStreamList variableStreams, DataStreamList dataStreams) {
+            DataStream<DenseVector[]> centroids = variableStreams.get(0);
+            DataStream<DenseVector> points = dataStreams.get(0);
+
+            DataStream<Integer> terminationCriteria =
+                    centroids.flatMap(new TerminateOnMaxIterationNum<>(maxIterationNum));
+
+            DataStream<Tuple2<Integer, DenseVector>> centroidIdAndPoints =
+                    points.connect(centroids.broadcast())
+                            .transform(
+                                    "SelectNearestCentroid",
+                                    new TupleTypeInfo<>(
+                                            BasicTypeInfo.INT_TYPE_INFO,
+                                            DenseVectorTypeInfo.INSTANCE),
+                                    new SelectNearestCentroidOperator(distanceMeasure));
+
+            AllWindowFunction<DenseVector, DenseVector[], TimeWindow> toList =
+                    new AllWindowFunction<DenseVector, DenseVector[], TimeWindow>() {
+                        @Override
+                        public void apply(
+                                TimeWindow timeWindow,
+                                Iterable<DenseVector> iterable,
+                                Collector<DenseVector[]> out) {
+                            List<DenseVector> centroids = IteratorUtils.toList(iterable.iterator());
+                            out.collect(centroids.toArray(new DenseVector[0]));
+                        }
+                    };
+
+            PerRoundSubBody perRoundSubBody =
+                    new PerRoundSubBody() {
+                        @Override
+                        public DataStreamList process(DataStreamList inputs) {
+                            DataStream<Tuple2<Integer, DenseVector>> centroidIdAndPoints =
+                                    inputs.get(0);
+                            DataStream<DenseVector[]> newCentroids =
+                                    centroidIdAndPoints
+                                            .map(new CountAppender())
+                                            .keyBy(t -> t.f0)
+                                            .window(EndOfStreamWindows.get())
+                                            .reduce(new CentroidAccumulator())
+                                            .map(new CentroidAverager())
+                                            .windowAll(EndOfStreamWindows.get())
+                                            .apply(toList);
+                            return DataStreamList.of(newCentroids);
+                        }
+                    };
+
+            DataStream<DenseVector[]> newCentroids =
+                    IterationBody.forEachRound(
+                                    DataStreamList.of(centroidIdAndPoints), perRoundSubBody)
+                            .get(0);
+            DataStream<DenseVector[]> finalCentroids =
+                    newCentroids.flatMap(new ForwardInputsOfLastRound<>());
+
+            return new IterationBodyResult(
+                    DataStreamList.of(newCentroids),
+                    DataStreamList.of(finalCentroids),
+                    terminationCriteria);
+        }
+    }
+
+    private static class CentroidAverager
+            implements MapFunction<Tuple3<Integer, DenseVector, Long>, DenseVector> {
+        @Override
+        public DenseVector map(Tuple3<Integer, DenseVector, Long> value) {
+            for (int i = 0; i < value.f1.size(); i++) {
+                value.f1.values[i] /= value.f2;
+            }
+            return value.f1;
+        }
+    }
+
+    private static class CentroidAccumulator
+            implements ReduceFunction<Tuple3<Integer, DenseVector, Long>> {
+        @Override
+        public Tuple3<Integer, DenseVector, Long> reduce(
+                Tuple3<Integer, DenseVector, Long> v1, Tuple3<Integer, DenseVector, Long> v2)
+                throws Exception {
+            for (int i = 0; i < v1.f1.size(); i++) {
+                v1.f1.values[i] += v2.f1.values[i];
+            }
+            return new Tuple3<>(v1.f0, v1.f1, v1.f2 + v2.f2);
+        }
+    }
+
+    private static class CountAppender
+            implements MapFunction<
+                    Tuple2<Integer, DenseVector>, Tuple3<Integer, DenseVector, Long>> {
+        @Override
+        public Tuple3<Integer, DenseVector, Long> map(Tuple2<Integer, DenseVector> value) {
+            return Tuple3.of(value.f0, value.f1, 1L);
+        }
+    }
+
+    private static class SelectNearestCentroidOperator
+            extends AbstractStreamOperator<Tuple2<Integer, DenseVector>>
+            implements TwoInputStreamOperator<
+                            DenseVector, DenseVector[], Tuple2<Integer, DenseVector>>,
+                    IterationListener<Tuple2<Integer, DenseVector>> {
+        private final DistanceMeasure distanceMeasure;
+        private ListState<DenseVector> points;
+        private ListState<DenseVector[]> centroids;
+
+        public SelectNearestCentroidOperator(DistanceMeasure distanceMeasure) {
+            this.distanceMeasure = distanceMeasure;
+        }
+
+        @Override
+        public void initializeState(StateInitializationContext context) throws Exception {
+            super.initializeState(context);
+            points =
+                    context.getOperatorStateStore()
+                            .getListState(new ListStateDescriptor<>("points", DenseVector.class));
+
+            TypeInformation<DenseVector[]> type =
+                    ObjectArrayTypeInfo.getInfoFor(DenseVectorTypeInfo.INSTANCE);
+            centroids =
+                    context.getOperatorStateStore()
+                            .getListState(new ListStateDescriptor<>("centroids", type));
+        }
+
+        @Override
+        public void processElement1(StreamRecord<DenseVector> streamRecord) throws Exception {
+            points.add(streamRecord.getValue());
+        }
+
+        @Override
+        public void processElement2(StreamRecord<DenseVector[]> streamRecord) throws Exception {
+            centroids.add(streamRecord.getValue());
+        }
+
+        @Override
+        public void onEpochWatermarkIncremented(
+                int epochWatermark, Context context, Collector<Tuple2<Integer, DenseVector>> out) {
+            // TODO: update onEpochWatermarkIncremented to throw Exception.
+            try {
+                List<DenseVector[]> list = IteratorUtils.toList(centroids.get().iterator());
+                if (list.size() != 1) {
+                    throw new RuntimeException(
+                            "The operator received "
+                                    + list.size()
+                                    + " list of centroids in this round");
+                }
+                DenseVector[] centroidValues = list.get(0);
+
+                for (DenseVector point : points.get()) {
+                    double minDistance = Double.MAX_VALUE;
+                    int closestCentroidId = -1;
+
+                    for (int i = 0; i < centroidValues.length; i++) {
+                        DenseVector centroid = centroidValues[i];
+                        double distance = distanceMeasure.distance(centroid, point);
+                        if (distance < minDistance) {
+                            minDistance = distance;
+                            closestCentroidId = i;
+                        }
+                    }
+
+                    output.collect(new StreamRecord<>(Tuple2.of(closestCentroidId, point)));
+                }
+                centroids.clear();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void onIterationTerminated(
+                Context context, Collector<Tuple2<Integer, DenseVector>> collector) {
+            points.clear();
+        }
+    }
+
+    public static DataStream<DenseVector[]> selectRandomCentroids(
+            DataStream<DenseVector> data, int k, long seed) {
+        OneInputStreamOperator<DenseVector, DenseVector[]> mapFunction =
+                new MapPartitionFunctionWrapper<>(
+                        new MapPartitionFunction<DenseVector, DenseVector[]>() {
+                            @Override
+                            public void mapPartition(
+                                    Iterable<DenseVector> iterable, Collector<DenseVector[]> out) {
+                                List<DenseVector> vectors = new ArrayList<>();
+                                for (DenseVector vector : iterable) {
+                                    vectors.add(vector);
+                                }
+                                Collections.shuffle(vectors, new Random(seed));
+                                out.collect(vectors.subList(0, k).toArray(new DenseVector[0]));
+                            }
+                        });
+        TypeInformation<DenseVector[]> type =
+                ObjectArrayTypeInfo.getInfoFor(DenseVectorTypeInfo.INSTANCE);
+        return data.transform("initRandom", type, mapFunction).setParallelism(1);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModel.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.clustering.kmeans;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.connector.file.src.FileSource;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.ml.api.core.Model;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.distance.DistanceMeasure;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.BasePathBucketAssigner;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** A Model which clusters data into k clusters using the model data computed by {@link KMeans}. */
+public class KMeansModel implements Model<KMeansModel>, KMeansModelParams<KMeansModel> {
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+    private Table centroidsTable;
+
+    public KMeansModel() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public KMeansModel setModelData(Table... inputs) {
+        centroidsTable = inputs[0];
+        return this;
+    }
+
+    @Override
+    public Table[] getModelData() {
+        return new Table[] {centroidsTable};
+    }
+
+    @Override
+    public Table[] transform(Table... inputs) {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<DenseVector[]> centroids =
+                tEnv.toDataStream(centroidsTable).map(row -> (DenseVector[]) row.getField("f0"));
+
+        String featureCol = getFeaturesCol();
+        String predictionCol = getPredictionCol();
+        DistanceMeasure distanceMeasure = DistanceMeasure.getInstance(getDistanceMeasure());
+
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(inputTypeInfo.getFieldTypes(), Types.INT),
+                        ArrayUtils.addAll(inputTypeInfo.getFieldNames(), predictionCol));
+
+        DataStream<Row> input = tEnv.toDataStream(inputs[0]);
+        DataStream<Row> output =
+                input.connect(centroids.broadcast())
+                        .transform(
+                                "SelectNearestCentroid",
+                                outputTypeInfo,
+                                new SelectNearestCentroidOperator(featureCol, distanceMeasure));
+
+        return new Table[] {tEnv.fromDataStream(output)};
+    }
+
+    private static class SelectNearestCentroidOperator extends AbstractStreamOperator<Row>
+            implements TwoInputStreamOperator<Row, DenseVector[], Row> {
+        private ListState<Row> inputs;
+        private ListState<DenseVector[]> centroids;
+
+        private final String featureCol;
+        private final DistanceMeasure distanceMeasure;
+
+        public SelectNearestCentroidOperator(String featureCol, DistanceMeasure distanceMeasure) {
+            this.featureCol = featureCol;
+            this.distanceMeasure = distanceMeasure;
+        }
+
+        @Override
+        public void initializeState(StateInitializationContext context) throws Exception {
+            super.initializeState(context);
+            inputs =
+                    context.getOperatorStateStore()
+                            .getListState(new ListStateDescriptor<>("points", Row.class));
+            TypeInformation<DenseVector[]> type =
+                    ObjectArrayTypeInfo.getInfoFor(DenseVectorTypeInfo.INSTANCE);
+            centroids =
+                    context.getOperatorStateStore()
+                            .getListState(new ListStateDescriptor<>("centroids", type));
+        }
+
+        @Override
+        public void processElement1(StreamRecord<Row> streamRecord) throws Exception {
+            inputs.add(streamRecord.getValue());
+        }
+
+        @Override
+        public void processElement2(StreamRecord<DenseVector[]> streamRecord) throws Exception {
+            centroids.add(streamRecord.getValue());
+        }
+
+        @Override
+        public void finish() throws Exception {
+            List<DenseVector[]> list = IteratorUtils.toList(centroids.get().iterator());
+            if (list.size() != 1) {
+                throw new RuntimeException(
+                        "The operator received "
+                                + list.size()
+                                + " list of centroids in this round");
+            }
+            DenseVector[] centroidValues = list.get(0);
+
+            for (Row input : inputs.get()) {
+                DenseVector point = (DenseVector) input.getField(featureCol);
+
+                double minDistance = Double.MAX_VALUE;
+                int closestCentroidId = -1;
+
+                for (int i = 0; i < centroidValues.length; i++) {
+                    DenseVector centroid = centroidValues[i];
+                    double distance = distanceMeasure.distance(centroid, point);
+                    if (distance < minDistance) {
+                        minDistance = distance;
+                        closestCentroidId = i;
+                    }
+                }
+
+                output.collect(new StreamRecord<>(Row.join(input, Row.of(closestCentroidId))));
+            }
+            inputs.clear();
+            centroids.clear();
+        }
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) centroidsTable).getTableEnvironment();
+
+        String dataPath = ReadWriteUtils.getDataPath(path);
+        FileSink<DenseVector[]> sink =
+                FileSink.forRowFormat(new Path(dataPath), new KMeansModelData.ModelDataEncoder())
+                        .withRollingPolicy(OnCheckpointRollingPolicy.build())
+                        .withBucketAssigner(new BasePathBucketAssigner<>())
+                        .build();
+        tEnv.toDataStream(centroidsTable)
+                .map(row -> (DenseVector[]) row.getField("f0"))
+                .sinkTo(sink);
+
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+
+    // TODO: Add INFO level logging.
+    public static KMeansModel load(StreamExecutionEnvironment env, String path) throws IOException {
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        Source<DenseVector[], ?, ?> source =
+                FileSource.forRecordStreamFormat(
+                                new KMeansModelData.ModelDataStreamFormat(),
+                                ReadWriteUtils.getDataPaths(path))
+                        .build();
+        KMeansModel model = ReadWriteUtils.loadStageParam(path);
+        DataStream<DenseVector[]> modelData =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "modelData");
+        return model.setModelData(tEnv.fromDataStream(modelData, KMeansModelData.SCHEMA));
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModelData.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.clustering.kmeans;
+
+import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.reader.SimpleStreamFormat;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Provides classes to save/load model data. */
+public class KMeansModelData {
+
+    public static final Schema SCHEMA =
+            Schema.newBuilder()
+                    .column("f0", DataTypes.ARRAY(DataTypes.of(DenseVector.class)))
+                    .build();
+
+    /** Encoder for the KMeans model data. */
+    public static class ModelDataEncoder implements Encoder<DenseVector[]> {
+        @Override
+        public void encode(DenseVector[] modelData, OutputStream outputStream) {
+            Kryo kryo = new Kryo();
+            Output output = new Output(outputStream);
+            List<double[]> convertedData = new ArrayList<>();
+            for (int i = 0; i < modelData.length; i++) {
+                convertedData.add(modelData[i].values);
+            }
+            kryo.writeObject(output, convertedData);
+            output.flush();
+        }
+    }
+
+    /** Decoder for the KMeans model data. */
+    public static class ModelDataStreamFormat extends SimpleStreamFormat<DenseVector[]> {
+        @Override
+        public Reader<DenseVector[]> createReader(Configuration config, FSDataInputStream stream) {
+            return new Reader<DenseVector[]>() {
+                private final Kryo kryo = new Kryo();
+                private final Input input = new Input(stream);
+
+                @Override
+                public DenseVector[] read() {
+                    if (input.eof()) {
+                        return null;
+                    }
+                    ArrayList<double[]> row = kryo.readObject(input, ArrayList.class);
+
+                    DenseVector[] result = new DenseVector[row.size()];
+                    for (int i = 0; i < result.length; i++) {
+                        result[i] = new DenseVector(row.get(i));
+                    }
+                    return result;
+                }
+
+                @Override
+                public void close() throws IOException {
+                    stream.close();
+                }
+            };
+        }
+
+        @Override
+        public TypeInformation<DenseVector[]> getProducedType() {
+            return ObjectArrayTypeInfo.getInfoFor(TypeInformation.of(DenseVector.class));
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModelParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModelParams.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.clustering.kmeans;
+
+import org.apache.flink.ml.common.param.HasDistanceMeasure;
+import org.apache.flink.ml.common.param.HasFeaturesCol;
+import org.apache.flink.ml.common.param.HasPredictionCol;
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+
+/**
+ * Params of KMeansModel.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface KMeansModelParams<T>
+        extends HasDistanceMeasure<T>, HasFeaturesCol<T>, HasPredictionCol<T> {
+
+    Param<Integer> K =
+            new IntParam("k", "The number of clusters to create.", 2, ParamValidators.gt(1));
+
+    default int getK() {
+        return get(K);
+    }
+
+    default T setK(int value) {
+        set(K, value);
+        return (T) this;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansParams.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.clustering.kmeans;
+
+import org.apache.flink.ml.common.param.HasMaxIter;
+import org.apache.flink.ml.common.param.HasSeed;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+
+/**
+ * Params of KMeans.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface KMeansParams<T> extends HasSeed<T>, HasMaxIter<T>, KMeansModelParams<T> {
+
+    Param<String> INIT_MODE =
+            new StringParam(
+                    "initMode",
+                    "The initialization algorithm. Supported options: 'random'.",
+                    "random",
+                    ParamValidators.inArray("random"));
+
+    default String getInitMode() {
+        return get(INIT_MODE);
+    }
+
+    default T setInitMode(String value) {
+        set(INIT_MODE, value);
+        return (T) this;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/datastream/EndOfStreamWindows.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/datastream/EndOfStreamWindows.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.datastream;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A {@link WindowAssigner} that assigns all elements of a bounded input stream into one window
+ * pane. The results are emitted once the input stream has ended.
+ */
+public class EndOfStreamWindows extends WindowAssigner<Object, TimeWindow> {
+
+    private static final EndOfStreamWindows INSTANCE = new EndOfStreamWindows();
+
+    private EndOfStreamWindows() {}
+
+    public static EndOfStreamWindows get() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Collection<TimeWindow> assignWindows(
+            Object element, long timestamp, WindowAssignerContext context) {
+        return Collections.singletonList(new TimeWindow(Long.MIN_VALUE, Long.MAX_VALUE));
+    }
+
+    @Override
+    public Trigger<Object, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
+        return EventTimeTrigger.create();
+    }
+
+    @Override
+    public String toString() {
+        return "EndOfStreamWindows()";
+    }
+
+    @Override
+    public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+        return new TimeWindow.Serializer();
+    }
+
+    @Override
+    public boolean isEventTime() {
+        return true;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/datastream/MapPartitionFunctionWrapper.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/datastream/MapPartitionFunctionWrapper.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.datastream;
+
+import org.apache.flink.api.common.functions.MapPartitionFunction;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * This utility class wraps a MapPartitionFunction into an OneInputStreamOperator so that a
+ * MapPartitionFunction can be applied on a DataStream via the DataStream::transform API.
+ *
+ * @param <IN> The class type of the input element.
+ * @param <OUT> The class type of the output element.
+ */
+public class MapPartitionFunctionWrapper<IN, OUT> extends AbstractStreamOperator<OUT>
+        implements OneInputStreamOperator<IN, OUT>, BoundedOneInput {
+    private final MapPartitionFunction<IN, OUT> mapPartitionFunc;
+    private ListState<IN> values;
+
+    public MapPartitionFunctionWrapper(MapPartitionFunction<IN, OUT> mapPartitionFunc) {
+        this.mapPartitionFunc = mapPartitionFunc;
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+        ListStateDescriptor<IN> descriptor =
+                new ListStateDescriptor<>(
+                        "input",
+                        getOperatorConfig().getTypeSerializerIn(0, getClass().getClassLoader()));
+        values = context.getOperatorStateStore().getListState(descriptor);
+    }
+
+    @Override
+    public void endInput() throws Exception {
+        mapPartitionFunc.mapPartition(values.get(), new TimestampedCollector<>(output));
+        values.clear();
+    }
+
+    @Override
+    public void processElement(StreamRecord<IN> input) throws Exception {
+        values.add(input.getValue());
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/datastream/TableUtils.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/datastream/TableUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.datastream;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.runtime.typeutils.ExternalTypeInfo;
+
+/** Utility class for table-related operations. */
+public class TableUtils {
+    // Constructs a RowTypeInfo from the given schema.
+    public static RowTypeInfo getRowTypeInfo(ResolvedSchema schema) {
+        TypeInformation<?>[] types = new TypeInformation<?>[schema.getColumnCount()];
+        String[] names = new String[schema.getColumnCount()];
+
+        for (int i = 0; i < schema.getColumnCount(); i++) {
+            Column column = schema.getColumn(i).get();
+            types[i] = ExternalTypeInfo.of(column.getDataType());
+            names[i] = column.getName();
+        }
+        return new RowTypeInfo(types, names);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/iteration/ForwardInputsOfLastRound.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/iteration/ForwardInputsOfLastRound.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.iteration;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.iteration.IterationListener;
+import org.apache.flink.util.Collector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A FlatMapFunction which forwards input values in the last round of the iteration to the output.
+ * Other input values will be dropped.
+ *
+ * @param <T> The class type of the input element.
+ */
+public class ForwardInputsOfLastRound<T> implements FlatMapFunction<T, T>, IterationListener<T> {
+    private List<T> valuesInLastEpoch = new ArrayList<>();
+    private List<T> valuesInCurrentEpoch = new ArrayList<>();
+
+    @Override
+    public void flatMap(T value, Collector<T> out) {
+        valuesInCurrentEpoch.add(value);
+    }
+
+    @Override
+    public void onEpochWatermarkIncremented(int epochWatermark, Context context, Collector<T> out) {
+        valuesInLastEpoch = valuesInCurrentEpoch;
+        valuesInCurrentEpoch = new ArrayList<>();
+    }
+
+    @Override
+    public void onIterationTerminated(Context context, Collector<T> out) {
+        for (T value : valuesInLastEpoch) {
+            out.collect(value);
+        }
+        if (!valuesInCurrentEpoch.isEmpty()) {
+            throw new IllegalStateException(
+                    "flatMap() is invoked since the last onEpochWatermarkIncremented callback");
+        }
+        valuesInLastEpoch.clear();
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/iteration/TerminateOnMaxIterationNum.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/iteration/TerminateOnMaxIterationNum.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.iteration;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.iteration.IterationListener;
+import org.apache.flink.util.Collector;
+
+/**
+ * A FlatMapFunction that emits values iff the iteration's epochWatermark does not exceed a certain
+ * threshold.
+ *
+ * <p>When the output of this FlatMapFunction is used as the termination criteria of an iteration
+ * body, the iteration will be executed for at most the given `numRounds` rounds.
+ *
+ * @param <T> The class type of the input element.
+ */
+public class TerminateOnMaxIterationNum<T>
+        implements FlatMapFunction<T, Integer>, IterationListener<Integer> {
+    private final int numRounds;
+
+    public TerminateOnMaxIterationNum(int numRounds) {
+        this.numRounds = numRounds;
+    }
+
+    @Override
+    public void flatMap(T integer, Collector<Integer> collector) {}
+
+    @Override
+    public void onEpochWatermarkIncremented(
+            int epochWatermark, Context context, Collector<Integer> out) {
+        if (epochWatermark <= numRounds - 2) {
+            out.collect(0);
+        }
+    }
+
+    @Override
+    public void onIterationTerminated(Context context, Collector<Integer> collector) {}
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasDistanceMeasure.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasDistanceMeasure.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.distance.EuclideanDistanceMeasure;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared distanceMeasure param. */
+public interface HasDistanceMeasure<T> extends WithParams<T> {
+    Param<String> DISTANCE_MEASURE =
+            new StringParam(
+                    "distanceMeasure",
+                    "The distance measure. Supported options: 'euclidean'.",
+                    EuclideanDistanceMeasure.NAME,
+                    ParamValidators.inArray(EuclideanDistanceMeasure.NAME));
+
+    default String getDistanceMeasure() {
+        return get(DISTANCE_MEASURE);
+    }
+
+    default T setDistanceMeasure(String value) {
+        set(DISTANCE_MEASURE, value);
+        return (T) this;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasFeaturesCol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasFeaturesCol.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared featuresCol param. */
+public interface HasFeaturesCol<T> extends WithParams<T> {
+    Param<String> FEATURES_COL =
+            new StringParam(
+                    "featuresCol", "Features column name.", "features", ParamValidators.notNull());
+
+    default String getFeaturesCol() {
+        return get(FEATURES_COL);
+    }
+
+    default T setFeaturesCol(String value) {
+        set(FEATURES_COL, value);
+        return (T) this;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMaxIter.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMaxIter.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared maxIter param. */
+public interface HasMaxIter<T> extends WithParams<T> {
+    Param<Integer> MAX_ITER =
+            new IntParam("maxIter", "Maximum number of iterations.", 20, ParamValidators.gtEq(0));
+
+    default int getMaxIter() {
+        return get(MAX_ITER);
+    }
+
+    default T setMaxIter(int value) {
+        set(MAX_ITER, value);
+        return (T) this;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasPredictionCol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasPredictionCol.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared featuresCol param. */
+public interface HasPredictionCol<T> extends WithParams<T> {
+    Param<String> PREDICTION_COL =
+            new StringParam(
+                    "predictionCol",
+                    "Prediction column name.",
+                    "prediction",
+                    ParamValidators.notNull());
+
+    default String getPredictionCol() {
+        return get(PREDICTION_COL);
+    }
+
+    default T setPredictionCol(String value) {
+        set(PREDICTION_COL, value);
+        return (T) this;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasSeed.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasSeed.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.LongParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared seed param. */
+public interface HasSeed<T> extends WithParams<T> {
+    Param<Long> SEED = new LongParam("seed", "The random seed.", null);
+
+    default long getSeed() {
+        Long seed = get(SEED);
+        if (seed != null) {
+            return seed;
+        }
+        return getClass().getName().hashCode();
+    }
+
+    default T setSeed(long value) {
+        set(SEED, value);
+        return (T) this;
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/KMeansTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/KMeansTest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.clustering;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.clustering.kmeans.KMeans;
+import org.apache.flink.ml.clustering.kmeans.KMeansModel;
+import org.apache.flink.ml.distance.EuclideanDistanceMeasure;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/** Tests KMeans and KMeansModel. */
+public class KMeansTest extends AbstractTestBase {
+    private static final List<DenseVector> DATA =
+            Arrays.asList(
+                    Vectors.dense(0.0, 0.0),
+                    Vectors.dense(0.0, 0.3),
+                    Vectors.dense(0.3, 0.0),
+                    Vectors.dense(9.0, 0.0),
+                    Vectors.dense(9.0, 0.6),
+                    Vectors.dense(9.6, 0.0));
+    private StreamExecutionEnvironment env;
+    private StreamTableEnvironment tEnv;
+    private Table dataTable;
+
+    @Before
+    public void before() {
+        Configuration config = new Configuration();
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.setParallelism(4);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        tEnv = StreamTableEnvironment.create(env);
+
+        Schema schema = Schema.newBuilder().column("f0", DataTypes.of(DenseVector.class)).build();
+        dataTable = tEnv.fromDataStream(env.fromCollection(DATA), schema).as("features");
+    }
+
+    // Executes the graph and returns a map which maps points to clusterId.
+    private static Map<DenseVector, Integer> executeAndCollect(
+            Table output, String featureCol, String predictionCol) throws Exception {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) output).getTableEnvironment();
+
+        DataStream<Tuple2<DenseVector, Integer>> stream =
+                tEnv.toDataStream(output)
+                        .map(
+                                new MapFunction<Row, Tuple2<DenseVector, Integer>>() {
+                                    @Override
+                                    public Tuple2<DenseVector, Integer> map(Row row) {
+                                        return Tuple2.of(
+                                                (DenseVector) row.getField(featureCol),
+                                                (Integer) row.getField(predictionCol));
+                                    }
+                                });
+
+        List<Tuple2<DenseVector, Integer>> pointsWithClusterId =
+                IteratorUtils.toList(stream.executeAndCollect());
+
+        Map<DenseVector, Integer> clusterIdByPoints = new HashMap<>();
+        for (Tuple2<DenseVector, Integer> entry : pointsWithClusterId) {
+            clusterIdByPoints.put(entry.f0, entry.f1);
+        }
+        return clusterIdByPoints;
+    }
+
+    private static void verifyClusteringResult(
+            Map<DenseVector, Integer> clusterIdByPoints, List<List<Integer>> groups) {
+        for (List<Integer> group : groups) {
+            for (int i = 1; i < group.size(); i++) {
+                assertEquals(
+                        clusterIdByPoints.get(DATA.get(group.get(0))),
+                        clusterIdByPoints.get(DATA.get(group.get(i))));
+            }
+        }
+    }
+
+    @Test
+    public void testParam() {
+        KMeans kmeans = new KMeans();
+        assertEquals("features", kmeans.getFeaturesCol());
+        assertEquals("prediction", kmeans.getPredictionCol());
+        assertEquals(EuclideanDistanceMeasure.NAME, kmeans.getDistanceMeasure());
+        assertEquals("random", kmeans.getInitMode());
+        assertEquals(2, kmeans.getK());
+        assertEquals(20, kmeans.getMaxIter());
+        assertEquals(KMeans.class.getName().hashCode(), kmeans.getSeed());
+
+        kmeans.setK(9)
+                .setFeaturesCol("test_feature")
+                .setPredictionCol("test_prediction")
+                .setK(3)
+                .setMaxIter(30)
+                .setSeed(100);
+
+        assertEquals("test_feature", kmeans.getFeaturesCol());
+        assertEquals("test_prediction", kmeans.getPredictionCol());
+        assertEquals(3, kmeans.getK());
+        assertEquals(30, kmeans.getMaxIter());
+        assertEquals(100, kmeans.getSeed());
+    }
+
+    @Test
+    public void testFeaturePredictionParam() throws Exception {
+        Table input = dataTable.as("test_feature");
+        KMeans kmeans =
+                new KMeans().setFeaturesCol("test_feature").setPredictionCol("test_prediction");
+        KMeansModel model = kmeans.fit(input);
+        Table output = model.transform(input)[0];
+
+        assertEquals(
+                Arrays.asList("test_feature", "test_prediction"),
+                output.getResolvedSchema().getColumnNames());
+        Map<DenseVector, Integer> clusterIdByPoints =
+                executeAndCollect(output, kmeans.getFeaturesCol(), kmeans.getPredictionCol());
+        verifyClusteringResult(
+                clusterIdByPoints, Arrays.asList(Arrays.asList(0, 1, 2), Arrays.asList(3, 4, 5)));
+    }
+
+    @Test
+    public void testFewerDistinctPointsThanCluster() throws Exception {
+        List<DenseVector> data =
+                Arrays.asList(
+                        Vectors.dense(0.0, 0.1), Vectors.dense(0.0, 0.1), Vectors.dense(0.0, 0.1));
+
+        Schema schema = Schema.newBuilder().column("f0", DataTypes.of(DenseVector.class)).build();
+        Table input = tEnv.fromDataStream(env.fromCollection(data), schema).as("features");
+
+        KMeans kmeans = new KMeans().setK(2);
+        KMeansModel model = kmeans.fit(input);
+        Table output = model.transform(input)[0];
+
+        Map<DenseVector, Integer> clusterIdByPoints =
+                executeAndCollect(output, kmeans.getFeaturesCol(), kmeans.getPredictionCol());
+        assertEquals(Collections.singleton(0), new HashSet<>(clusterIdByPoints.values()));
+    }
+
+    @Test
+    public void testFitAndPredict() throws Exception {
+        KMeans kmeans = new KMeans().setMaxIter(2).setK(2);
+        KMeansModel model = kmeans.fit(dataTable);
+        Table output = model.transform(dataTable)[0];
+
+        assertEquals(
+                Arrays.asList("features", "prediction"),
+                output.getResolvedSchema().getColumnNames());
+        Map<DenseVector, Integer> clusterIdByPoints =
+                executeAndCollect(output, kmeans.getFeaturesCol(), kmeans.getPredictionCol());
+        verifyClusteringResult(
+                clusterIdByPoints, Arrays.asList(Arrays.asList(0, 1, 2), Arrays.asList(3, 4, 5)));
+    }
+
+    @Test
+    public void testSaveLoadAndPredict() throws Exception {
+        String path = Files.createTempDirectory("").toString();
+
+        KMeans kmeans = new KMeans().setMaxIter(2).setK(2);
+        KMeansModel model = kmeans.fit(dataTable);
+
+        model.save(path);
+        env.execute();
+
+        KMeansModel loadedModel = KMeansModel.load(env, path);
+        Table output = loadedModel.transform(dataTable)[0];
+
+        assertEquals(
+                Arrays.asList("f0"),
+                loadedModel.getModelData()[0].getResolvedSchema().getColumnNames());
+        assertEquals(
+                Arrays.asList("features", "prediction"),
+                output.getResolvedSchema().getColumnNames());
+        Map<DenseVector, Integer> clusterIdByPoints =
+                executeAndCollect(output, kmeans.getFeaturesCol(), kmeans.getPredictionCol());
+        verifyClusteringResult(
+                clusterIdByPoints, Arrays.asList(Arrays.asList(0, 1, 2), Arrays.asList(3, 4, 5)));
+    }
+
+    @Test
+    public void testGetModelData() throws Exception {
+        KMeans kmeans = new KMeans().setMaxIter(2).setK(2);
+        KMeansModel modelA = kmeans.fit(dataTable);
+        Table modelData = modelA.getModelData()[0];
+
+        DataStream<DenseVector[]> output =
+                tEnv.toDataStream(modelData).map(row -> (DenseVector[]) row.getField("f0"));
+
+        assertEquals(Arrays.asList("f0"), modelData.getResolvedSchema().getColumnNames());
+        List<DenseVector[]> centroids = IteratorUtils.toList(output.executeAndCollect());
+        assertEquals(1, centroids.size());
+        assertEquals(2, centroids.get(0).length);
+        Arrays.sort(centroids.get(0), Comparator.comparingDouble(vector -> vector.get(0)));
+        assertArrayEquals(centroids.get(0)[0].values, new double[] {0.1, 0.1}, 1e-5);
+        assertArrayEquals(centroids.get(0)[1].values, new double[] {9.2, 0.2}, 1e-5);
+    }
+
+    @Test
+    public void testSetModelData() throws Exception {
+        KMeans kmeans = new KMeans().setMaxIter(2).setK(2);
+        KMeansModel modelA = kmeans.fit(dataTable);
+        Table modelData = modelA.getModelData()[0];
+
+        KMeansModel modelB = new KMeansModel().setModelData(modelData);
+        ReadWriteUtils.updateExistingParams(modelB, modelA.getParamMap());
+
+        Table output = modelB.transform(dataTable)[0];
+        Map<DenseVector, Integer> clusterIdByPoints =
+                executeAndCollect(output, kmeans.getFeaturesCol(), kmeans.getPredictionCol());
+
+        verifyClusteringResult(
+                clusterIdByPoints, Arrays.asList(Arrays.asList(0, 1, 2), Arrays.asList(3, 4, 5)));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the Estimator and Model classes for the KMeans algorithm.

## Brief change log

This PR mades the following changes:
- Added `KMeans`, `KMeansModel` and a few other supporting classes.
- Added `KMeansTest` to validate the behavior of `KMeans` and `KMeansModel`.

## Verifying this change

The changes are validated by unit tests in the `KMeansTest`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (Java doc)