### PR TITLE
[FLINK-24842][iteration] Make outputs depends on tails for the iteration body

### DIFF
--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/Iterations.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/Iterations.java
@@ -253,16 +253,14 @@ public class Iterations {
                             headStreams.get(i).getParallelism()));
         }
 
-        List<DataStream<?>> tailsAndCriteriaTails = new ArrayList<>();
-
         DataStreamList tails = addTails(feedbackStreams, iterationId, 0);
         for (int i = 0; i < headStreams.size(); ++i) {
             String coLocationGroupKey = "co-" + iterationId.toHexString() + "-" + i;
             headStreams.get(i).getTransformation().setCoLocationGroupKey(coLocationGroupKey);
             tails.get(i).getTransformation().setCoLocationGroupKey(coLocationGroupKey);
         }
-        tailsAndCriteriaTails.addAll(tails.getDataStreams());
 
+        List<DataStream<?>> tailsAndCriteriaTails = new ArrayList<>(tails.getDataStreams());
         checkState(
                 mayHaveCriteria || iterationBodyResult.getTerminationCriteria() == null,
                 "The current iteration type does not support the termination criteria.");
@@ -374,7 +372,7 @@ public class Iterations {
         criteriaHeaders.get(0).getTransformation().setCoLocationGroupKey(coLocationGroupKey);
         criteriaTails.get(0).getTransformation().setCoLocationGroupKey(coLocationGroupKey);
 
-        // Now we notify all the head operators to count the criteria stream.
+        // Now we notify all the head operators to count the criteria streams.
         setCriteriaParallelism(headStreams, terminationCriteria.getParallelism());
         setCriteriaParallelism(criteriaHeaders, terminationCriteria.getParallelism());
 

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/OperatorWrapper.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/OperatorWrapper.java
@@ -35,6 +35,9 @@ public interface OperatorWrapper<T, R> extends Serializable {
             StreamOperatorParameters<R> operatorParameters,
             StreamOperatorFactory<T> operatorFactory);
 
+    Class<? extends StreamOperator> getStreamOperatorClass(
+            ClassLoader classLoader, StreamOperatorFactory<T> operatorFactory);
+
     <KEY> KeySelector<R, KEY> wrapKeySelector(KeySelector<T, KEY> keySelector);
 
     StreamPartitioner<R> wrapStreamPartitioner(StreamPartitioner<T> streamPartitioner);

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/WrapperOperatorFactory.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/WrapperOperatorFactory.java
@@ -48,7 +48,7 @@ public class WrapperOperatorFactory<OUT>
 
     @Override
     public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
-        return AbstractWrapperOperator.class;
+        return wrapper.getStreamOperatorClass(classLoader, operatorFactory);
     }
 
     @VisibleForTesting

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/AllRoundOperatorWrapper.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/allround/AllRoundOperatorWrapper.java
@@ -57,6 +57,23 @@ public class AllRoundOperatorWrapper<T> implements OperatorWrapper<T, IterationR
     }
 
     @Override
+    public Class<? extends StreamOperator> getStreamOperatorClass(
+            ClassLoader classLoader, StreamOperatorFactory<T> operatorFactory) {
+        Class<? extends StreamOperator> operatorClass =
+                operatorFactory.getStreamOperatorClass(getClass().getClassLoader());
+        if (OneInputStreamOperator.class.isAssignableFrom(operatorClass)) {
+            return OneInputAllRoundWrapperOperator.class;
+        } else if (TwoInputStreamOperator.class.isAssignableFrom(operatorClass)) {
+            return TwoInputAllRoundWrapperOperator.class;
+        } else if (MultipleInputStreamOperator.class.isAssignableFrom(operatorClass)) {
+            return MultipleInputAllRoundWrapperOperator.class;
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported operator class for all-round wrapper: " + operatorClass);
+        }
+    }
+
+    @Override
     public <KEY> KeySelector<IterationRecord<T>, KEY> wrapKeySelector(
             KeySelector<T, KEY> keySelector) {
         return new ProxyKeySelector<>(keySelector);

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/perround/PerRoundOperatorWrapper.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/perround/PerRoundOperatorWrapper.java
@@ -57,6 +57,23 @@ public class PerRoundOperatorWrapper<T> implements OperatorWrapper<T, IterationR
     }
 
     @Override
+    public Class<? extends StreamOperator> getStreamOperatorClass(
+            ClassLoader classLoader, StreamOperatorFactory<T> operatorFactory) {
+        Class<? extends StreamOperator> operatorClass =
+                operatorFactory.getStreamOperatorClass(getClass().getClassLoader());
+        if (OneInputStreamOperator.class.isAssignableFrom(operatorClass)) {
+            return OneInputPerRoundWrapperOperator.class;
+        } else if (TwoInputStreamOperator.class.isAssignableFrom(operatorClass)) {
+            return TwoInputPerRoundWrapperOperator.class;
+        } else if (MultipleInputStreamOperator.class.isAssignableFrom(operatorClass)) {
+            return MultipleInputPerRoundWrapperOperator.class;
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported operator class for all-round wrapper: " + operatorClass);
+        }
+    }
+
+    @Override
     public <KEY> KeySelector<IterationRecord<T>, KEY> wrapKeySelector(
             KeySelector<T, KEY> keySelector) {
         return new ProxyKeySelector<>(keySelector);

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/IterationConstructionTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/IterationConstructionTest.java
@@ -63,7 +63,7 @@ public class IterationConstructionTest extends TestLogger {
                 Arrays.asList(
                         /* 0 */ "Source: Variable -> input-Variable",
                         /* 1 */ "head-Variable",
-                        /* 2 */ "tail-head-Variable");
+                        /* 2 */ "tail-head-Variable -> filter-tail");
         List<Integer> expectedParallelisms = Arrays.asList(4, 4, 4);
 
         List<JobVertex> vertices = jobGraph.getVerticesSortedTopologicallyFromSources();
@@ -102,7 +102,7 @@ public class IterationConstructionTest extends TestLogger {
                         /* 0 */ "Source: Variable",
                         /* 1 */ "map -> input-map",
                         /* 2 */ "head-map",
-                        /* 3 */ "tail-head-map");
+                        /* 3 */ "tail-head-map -> filter-tail");
         List<Integer> expectedParallelisms = Arrays.asList(4, 2, 2, 2);
 
         List<JobVertex> vertices = jobGraph.getVerticesSortedTopologicallyFromSources();
@@ -191,12 +191,14 @@ public class IterationConstructionTest extends TestLogger {
                         /* 2 */ "Source: Constant -> input-Constant",
                         /* 3 */ "head-Variable0",
                         /* 4 */ "head-Variable1",
-                        /* 5 */ "Processor -> output-SideOutput -> Sink: Sink",
+                        /* 5 */ "Processor",
                         /* 6 */ "Feedback0",
-                        /* 7 */ "tail-Feedback0",
+                        /* 7 */ "tail-Feedback0 -> filter-tail",
                         /* 8 */ "Feedback1",
-                        /* 9 */ "tail-Feedback1");
-        List<Integer> expectedParallelisms = Arrays.asList(2, 3, 3, 2, 3, 4, 2, 2, 3, 3);
+                        /* 9 */ "tail-Feedback1 -> filter-tail",
+                        /* 10 */ "tail-map-SideOutput",
+                        /* 11 */ "output-SideOutput -> Sink: Sink");
+        List<Integer> expectedParallelisms = Arrays.asList(2, 3, 3, 2, 3, 4, 2, 2, 3, 3, 1, 4);
 
         JobGraph jobGraph = env.getStreamGraph().getJobGraph();
         List<JobVertex> vertices = jobGraph.getVerticesSortedTopologicallyFromSources();
@@ -286,17 +288,19 @@ public class IterationConstructionTest extends TestLogger {
                         /* 3 */ "Source: Termination -> input-Termination",
                         /* 4 */ "head-Variable0",
                         /* 5 */ "head-Variable1",
-                        /* 6 */ "Processor -> output-SideOutput -> Sink: Sink",
+                        /* 6 */ "Processor",
                         /* 7 */ "Feedback0",
-                        /* 8 */ "tail-Feedback0",
+                        /* 8 */ "tail-Feedback0 -> filter-tail",
                         /* 9 */ "Feedback1",
-                        /* 10 */ "tail-Feedback1",
+                        /* 10 */ "tail-Feedback1 -> filter-tail",
                         /* 11 */ "Termination",
                         /* 12 */ "head-Termination",
                         /* 13 */ "criteria-merge",
-                        /* 14 */ "tail-criteria-merge");
+                        /* 14 */ "tail-criteria-merge -> filter-tail",
+                        /* 15 */ "tail-map-SideOutput",
+                        /* 16 */ "output-SideOutput -> Sink: Sink");
         List<Integer> expectedParallelisms =
-                Arrays.asList(2, 3, 3, 5, 2, 3, 4, 2, 2, 3, 3, 5, 5, 5, 5);
+                Arrays.asList(2, 3, 3, 5, 2, 3, 4, 2, 2, 3, 3, 5, 5, 5, 5, 1, 4);
 
         JobGraph jobGraph = env.getStreamGraph().getJobGraph();
         List<JobVertex> vertices = jobGraph.getVerticesSortedTopologicallyFromSources();
@@ -380,14 +384,17 @@ public class IterationConstructionTest extends TestLogger {
                         /* 2 */ "Source: Termination -> input-Termination",
                         /* 3 */ "head-Variable",
                         /* 4 */ "Replayer-Constant",
-                        /* 5 */ "Processor -> output-SideOutput -> Sink: Sink",
+                        /* 5 */ "Processor",
                         /* 6 */ "Feedback",
-                        /* 7 */ "tail-Feedback",
+                        /* 7 */ "tail-Feedback -> filter-tail",
                         /* 8 */ "Termination",
                         /* 9 */ "head-Termination",
                         /* 10 */ "criteria-merge",
-                        /* 11 */ "tail-criteria-merge");
-        List<Integer> expectedParallelisms = Arrays.asList(2, 3, 5, 2, 3, 4, 2, 2, 5, 5, 5, 5);
+                        /* 11 */ "tail-criteria-merge -> filter-tail",
+                        /* 12 */ "tail-map-SideOutput",
+                        /* 13 */ "output-SideOutput -> Sink: Sink");
+        List<Integer> expectedParallelisms =
+                Arrays.asList(2, 3, 5, 2, 3, 4, 2, 2, 5, 5, 5, 5, 1, 4);
 
         JobGraph jobGraph = env.getStreamGraph().getJobGraph();
         List<JobVertex> vertices = jobGraph.getVerticesSortedTopologicallyFromSources();

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/DraftExecutionEnvironmentSwitchWrapperTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/compile/DraftExecutionEnvironmentSwitchWrapperTest.java
@@ -113,6 +113,12 @@ public class DraftExecutionEnvironmentSwitchWrapperTest extends TestLogger {
         }
 
         @Override
+        public Class<? extends StreamOperator> getStreamOperatorClass(
+                ClassLoader classLoader, StreamOperatorFactory<T> operatorFactory) {
+            return StreamMap.class;
+        }
+
+        @Override
         public <KEY> KeySelector<T, KEY> wrapKeySelector(KeySelector<T, KEY> keySelector) {
             return keySelector;
         }
@@ -139,6 +145,12 @@ public class DraftExecutionEnvironmentSwitchWrapperTest extends TestLogger {
                 StreamOperatorParameters<T> operatorParameters,
                 StreamOperatorFactory<T> operatorFactory) {
             return new StreamFilter<>((FilterFunction<T>) value -> true);
+        }
+
+        @Override
+        public Class<? extends StreamOperator> getStreamOperatorClass(
+                ClassLoader classLoader, StreamOperatorFactory<T> operatorFactory) {
+            return StreamFilter.class;
         }
 
         @Override

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/broadcast/BroadcastUtils.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/broadcast/BroadcastUtils.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.ml.common.broadcast;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.iteration.compile.DraftExecutionEnvironment;
 import org.apache.flink.ml.common.broadcast.operator.BroadcastVariableReceiverOperatorFactory;
@@ -40,6 +40,7 @@ import java.util.UUID;
 import java.util.function.Function;
 
 /** Utility class to support withBroadcast in DataStream. */
+@Internal
 public class BroadcastUtils {
     /**
      * supports withBroadcastStream in DataStream API. Broadcast data streams are available at all
@@ -62,7 +63,7 @@ public class BroadcastUtils {
      *     operator in this function, otherwise it raises an exception.
      * @return the output data stream.
      */
-    @PublicEvolving
+    @Internal
     public static <OUT> DataStream<OUT> withBroadcastStream(
             List<DataStream<?>> inputList,
             Map<String, DataStream<?>> bcStreams,

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/broadcast/operator/BroadcastWrapper.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/broadcast/operator/BroadcastWrapper.java
@@ -75,6 +75,21 @@ public class BroadcastWrapper<T> implements OperatorWrapper<T, T> {
     }
 
     @Override
+    public Class<? extends StreamOperator> getStreamOperatorClass(
+            ClassLoader classLoader, StreamOperatorFactory<T> operatorFactory) {
+        Class<? extends StreamOperator> operatorClass =
+                operatorFactory.getStreamOperatorClass(getClass().getClassLoader());
+        if (OneInputStreamOperator.class.isAssignableFrom(operatorClass)) {
+            return OneInputBroadcastWrapperOperator.class;
+        } else if (TwoInputStreamOperator.class.isAssignableFrom(operatorClass)) {
+            return TwoInputBroadcastWrapperOperator.class;
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported operator class for with-broadcast wrapper: " + operatorClass);
+        }
+    }
+
+    @Override
     public <KEY> KeySelector<T, KEY> wrapKeySelector(KeySelector<T, KEY> keySelector) {
         return keySelector;
     }


### PR DESCRIPTION
This PR forces that the outputs depends on all the tails.

If we want to allow users to use table api with the output of the iteration, since the table api would crop the stream graph and only leave the operators that the output depends on. However, for the iteration we always required the whole iteration participate for alignement