### PR TITLE
 [FLINK-22915][FLIP-173] Updates the static load(...) method of Stage subclasses to take StreamExecutionEnvironment as parameter

### DIFF
--- a/flink-ml-api/pom.xml
+++ b/flink-ml-api/pom.xml
@@ -41,6 +41,13 @@ under the License.
 
     <dependency>
       <groupId>org.apache.flink</groupId>
+      <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+      <version>${flink.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.flink</groupId>
       <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
       <version>${flink.version}</version>
       <scope>test</scope>

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/api/core/Model.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/api/core/Model.java
@@ -35,7 +35,7 @@ public interface Model<T extends Model<T>> extends Transformer<T> {
      *
      * @param inputs a list of tables
      */
-    default void setModelData(Table... inputs) {
+    default T setModelData(Table... inputs) {
         throw new UnsupportedOperationException("this operation is not supported");
     }
 

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/api/core/Pipeline.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/api/core/Pipeline.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 
 import java.io.IOException;
@@ -111,8 +112,8 @@ public final class Pipeline implements Estimator<Pipeline, PipelineModel> {
         ReadWriteUtils.savePipeline(this, stages, path);
     }
 
-    public static Pipeline load(String path) throws IOException {
-        return new Pipeline(ReadWriteUtils.loadPipeline(path, Pipeline.class.getName()));
+    public static Pipeline load(StreamExecutionEnvironment env, String path) throws IOException {
+        return new Pipeline(ReadWriteUtils.loadPipeline(env, path, Pipeline.class.getName()));
     }
 
     /**

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/api/core/PipelineModel.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/api/core/PipelineModel.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 
 import java.io.IOException;
@@ -72,8 +73,10 @@ public final class PipelineModel implements Model<PipelineModel> {
         ReadWriteUtils.savePipeline(this, stages, path);
     }
 
-    public static PipelineModel load(String path) throws IOException {
-        return new PipelineModel(ReadWriteUtils.loadPipeline(path, PipelineModel.class.getName()));
+    public static PipelineModel load(StreamExecutionEnvironment env, String path)
+            throws IOException {
+        return new PipelineModel(
+                ReadWriteUtils.loadPipeline(env, path, PipelineModel.class.getName()));
     }
 
     /**

--- a/flink-ml-api/src/main/java/org/apache/flink/ml/api/core/Stage.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/api/core/Stage.java
@@ -31,14 +31,15 @@ import java.io.Serializable;
  *
  * <p>Each stage is with parameters, and requires a public empty constructor for restoration.
  *
+ * <p>NOTE: every Stage subclass should implement a static method with signature {@code static T
+ * load(StreamExecutionEnvironment env, String path)}, where {@code T} refers to the concrete
+ * subclass. This static method should instantiate a new stage instance based on the data read from
+ * the given path.
+ *
  * @param <T> The class type of the Stage implementation itself.
  */
 @PublicEvolving
 public interface Stage<T extends Stage<T>> extends WithParams<T>, Serializable {
     /** Saves this stage to the given path. */
     void save(String path) throws IOException;
-
-    // NOTE: every Stage subclass should implement a static method with signature "static T
-    // load(String path)", where T refers to the concrete subclass. This static method should
-    // instantiate a new stage instance based on the data from the given path.
 }

--- a/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/ExampleStages.java
+++ b/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/ExampleStages.java
@@ -89,11 +89,12 @@ public class ExampleStages {
         }
 
         @Override
-        public void setModelData(Table... inputs) {
+        public SumModel setModelData(Table... inputs) {
             StreamTableEnvironment tEnv =
                     (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
 
             modelData = tEnv.toDataStream(inputs[0], Integer.class);
+            return this;
         }
 
         @Override
@@ -131,8 +132,7 @@ public class ExampleStages {
             try (DataInputStream inputStream = new DataInputStream(new FileInputStream(dataFile))) {
                 StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
                 Table modelData = tEnv.fromDataStream(env.fromElements(inputStream.readInt()));
-                model.setModelData(modelData);
-                return model;
+                return model.setModelData(modelData);
             }
         }
     }
@@ -208,9 +208,7 @@ public class ExampleStages {
                             .setParallelism(1);
             try {
                 SumModel model = new SumModel();
-                model.setModelData(tEnv.fromDataStream(modelData));
-
-                return model;
+                return model.setModelData(tEnv.fromDataStream(modelData));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/ExampleStages.java
+++ b/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/ExampleStages.java
@@ -123,13 +123,12 @@ public class ExampleStages {
             }
         }
 
-        public static SumModel load(String path) throws IOException {
+        public static SumModel load(StreamExecutionEnvironment env, String path)
+                throws IOException {
             SumModel model = ReadWriteUtils.loadStageParam(path);
             File dataFile = Paths.get(path, "data", "delta").toFile();
 
             try (DataInputStream inputStream = new DataInputStream(new FileInputStream(dataFile))) {
-                StreamExecutionEnvironment env =
-                        StreamExecutionEnvironment.getExecutionEnvironment();
                 StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
                 Table modelData = tEnv.fromDataStream(env.fromElements(inputStream.readInt()));
                 model.setModelData(modelData);
@@ -222,7 +221,8 @@ public class ExampleStages {
             ReadWriteUtils.saveMetadata(this, path);
         }
 
-        public static SumEstimator load(String path) throws IOException {
+        public static SumEstimator load(StreamExecutionEnvironment env, String path)
+                throws IOException {
             return ReadWriteUtils.loadStageParam(path);
         }
     }

--- a/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/PipelineTest.java
+++ b/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/PipelineTest.java
@@ -69,12 +69,9 @@ public class PipelineTest extends AbstractTestBase {
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
         // Builds a PipelineModel that increments input value by 60. This PipelineModel consists of
         // three stages where each stage increments input value by 10, 20, and 30 respectively.
-        SumModel modelA = new SumModel();
-        modelA.setModelData(tEnv.fromValues(10));
-        SumModel modelB = new SumModel();
-        modelB.setModelData(tEnv.fromValues(20));
-        SumModel modelC = new SumModel();
-        modelC.setModelData(tEnv.fromValues(30));
+        SumModel modelA = new SumModel().setModelData(tEnv.fromValues(10));
+        SumModel modelB = new SumModel().setModelData(tEnv.fromValues(20));
+        SumModel modelC = new SumModel().setModelData(tEnv.fromValues(30));
 
         List<Stage<?>> stages = Arrays.asList(modelA, modelB, modelC);
         Model<?> model = new PipelineModel(stages);
@@ -97,10 +94,8 @@ public class PipelineTest extends AbstractTestBase {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
         // Builds a Pipeline that consists of a Model, an Estimator, and a model.
-        SumModel modelA = new SumModel();
-        modelA.setModelData(tEnv.fromValues(10));
-        SumModel modelB = new SumModel();
-        modelB.setModelData(tEnv.fromValues(30));
+        SumModel modelA = new SumModel().setModelData(tEnv.fromValues(10));
+        SumModel modelB = new SumModel().setModelData(tEnv.fromValues(30));
 
         List<Stage<?>> stages = Arrays.asList(modelA, new SumEstimator(), modelB);
         Estimator<?, ?> estimator = new Pipeline(stages);

--- a/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/PipelineTest.java
+++ b/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/PipelineTest.java
@@ -86,7 +86,7 @@ public class PipelineTest extends AbstractTestBase {
         Path tempDir = Files.createTempDirectory("PipelineTest");
         String path = Paths.get(tempDir.toString(), "testPipelineModelSaveLoad").toString();
         model.save(path);
-        Model<?> loadedModel = PipelineModel.load(path);
+        Model<?> loadedModel = PipelineModel.load(env, path);
 
         // Executes the loaded PipelineModel and verifies that it produces the expected output.
         executeAndCheckOutput(loadedModel, Arrays.asList(1, 2, 3), Arrays.asList(61, 62, 63));
@@ -112,7 +112,7 @@ public class PipelineTest extends AbstractTestBase {
         Path tempDir = Files.createTempDirectory("PipelineTest");
         String path = Paths.get(tempDir.toString(), "testPipeline").toString();
         estimator.save(path);
-        Estimator<?, ?> loadedEstimator = Pipeline.load(path);
+        Estimator<?, ?> loadedEstimator = Pipeline.load(env, path);
 
         // Executes the loaded Pipeline and verifies that it produces the expected output.
         executeAndCheckOutput(loadedEstimator, Arrays.asList(1, 2, 3), Arrays.asList(77, 78, 79));


### PR DESCRIPTION
## What is the purpose of the change

This PR updates the static load(...) method of Stage subclasses to take StreamExecutionEnvironment as parameter. This is because the static load method will need to create DataStream or Table instances to read model data.

This PR also updates Model::setModelData(...) to return the Model instance itself. This could improve usability by allowing users to do e.g. `return new KMeansModel().setModelData(...)`.

## Brief change log

This PR mades the following changes:
- Updated static load method of all `Stage` subclasses to take StreamExecutionEnvironment as parameter.
- Updated a few methods in the `ReadWriteUtils` to take StreamExecutionEnvironment as parameter.
- Updated Model::setModelData(...) to return the Model instance itself.

## Verifying this change

The changes are validated by the existing unit tests.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)