### PR TITLE
[hotfix] Fix nullpointer exception when broadcast variables are cleaned

### DIFF
--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/broadcast/BroadcastContext.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/broadcast/BroadcastContext.java
@@ -72,7 +72,7 @@ public class BroadcastContext {
     }
 
     @VisibleForTesting
-    public static void markCacheFinished(String key) {
+    public static void notifyCacheFinished(String key) {
         BROADCAST_VARIABLES.computeIfPresent(
                 key,
                 (k, v) -> {

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/common/broadcast/operator/BroadcastVariableReceiverOperatorTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/common/broadcast/operator/BroadcastVariableReceiverOperatorTest.java
@@ -20,15 +20,23 @@ package org.apache.flink.ml.common.broadcast.operator;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.iteration.config.IterationOptions;
 import org.apache.flink.ml.common.broadcast.BroadcastContext;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarnessBuilder;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,13 +44,15 @@ import java.util.List;
 /** Tests the {@link BroadcastVariableReceiverOperator}. */
 public class BroadcastVariableReceiverOperatorTest {
 
+    @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
     private static final String[] BROADCAST_NAMES = new String[] {"source1", "source2"};
 
     private static final TypeInformation<?>[] TYPE_INFORMATIONS =
             new TypeInformation[] {BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO};
 
     @Test
-    public void testCacheStreamOperator() throws Exception {
+    public void test() throws Exception {
         OperatorID operatorId = new OperatorID();
 
         try (StreamTaskMailboxTestHarness<Integer> harness =
@@ -71,6 +81,47 @@ public class BroadcastVariableReceiverOperatorTest {
             // check broadcast inputs after task finishes.
             compareLists(Arrays.asList(1, 2), cache1);
             compareLists(Arrays.asList(3, 4, 5), cache2);
+        }
+    }
+
+    @Test
+    public void testVariableCleanedBeforeSnapShot() throws Exception {
+        OperatorID operatorId = new OperatorID();
+
+        try (StreamTaskMailboxTestHarness<Integer> harness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                MultipleInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO)
+                        .setupOutputForSingletonOperatorChain(
+                                new BroadcastVariableReceiverOperatorFactory<>(
+                                        new String[] {BROADCAST_NAMES[0]},
+                                        new TypeInformation[] {TYPE_INFORMATIONS[0]}),
+                                operatorId)
+                        .buildUnrestored()) {
+            harness.getStreamTask()
+                    .getEnvironment()
+                    .getTaskManagerInfo()
+                    .getConfiguration()
+                    .set(
+                            IterationOptions.DATA_CACHE_PATH,
+                            "file://" + tempFolder.newFolder().getAbsolutePath());
+            harness.getStreamTask().restore();
+            harness.processElement(new StreamRecord<>(1, 2), 0);
+            harness.processElement(new StreamRecord<>(2, 3), 0);
+            harness.endInput();
+            // clean broadcast variables here.
+            BroadcastContext.remove(BROADCAST_NAMES[0] + "-" + 0);
+
+            harness.getStreamTask()
+                    .triggerCheckpointOnBarrier(
+                            new CheckpointMetaData(1, 2),
+                            CheckpointOptions.alignedNoTimeout(
+                                    CheckpointType.CHECKPOINT,
+                                    CheckpointStorageLocationReference.getDefault()),
+                            new CheckpointMetricsBuilder()
+                                    .setAlignmentDurationNanos(0)
+                                    .setBytesProcessedDuringAlignment(0));
+            harness.waitForTaskCompletion();
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change
This PR fixes the concurrency bug in the following case:

- Step1: BroadcastVariableReceiverOperator#endInput
- Step2: BroadcastVariableReceiverOperator#initializeState
- Step3: AbstractBroadcastWrapperOperator#close
- Step4: BroadcastVariableReceiverOperator#snapshot

In step4, we assumed that the broadcastVariable is still stored in `BroadcastContext`. However, it might have been removed by `AbstractBroadcastWrapperOperator` in Step3.

## Brief change log
- Fix bug in BroadcastVariableReceiverOperator.
- Add unit test in BroadcastVariableReceiverOperatorTest.


## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (-)

