### PR TITLE
[FLINK-24354][FLIP-174] Updates WithParams::set(...) to throw Exception if the given param is not defined on this instance

### DIFF
--- a/flink-ml-api/src/main/java/org/apache/flink/ml/param/WithParams.java
+++ b/flink-ml-api/src/main/java/org/apache/flink/ml/param/WithParams.java
@@ -72,6 +72,14 @@ public interface WithParams<T> {
      */
     @SuppressWarnings("unchecked")
     default <V> T set(Param<V> param, V value) {
+        if (!getParamMap().containsKey(param)) {
+            throw new IllegalArgumentException(
+                    "Parameter "
+                            + param.name
+                            + " is not defined on the class "
+                            + getClass().getName());
+        }
+
         if (value != null && !param.clazz.isAssignableFrom(value.getClass())) {
             throw new ClassCastException(
                     "Parameter "

--- a/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/StageTest.java
+++ b/flink-ml-api/src/test/java/org/apache/flink/ml/api/core/StageTest.java
@@ -242,6 +242,18 @@ public class StageTest {
     }
 
     @Test
+    public void testSetUndefinedParam() {
+        MyStage stage = new MyStage();
+        Param<Integer> param = new IntParam("anotherIntParam", "Not defined on MyStage", 1);
+        try {
+            stage.set(param, 2);
+            Assert.fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains(MyStage.class.getName()));
+        }
+    }
+
+    @Test
     public void testParamSetInvalidValue() {
         MyStage stage = new MyStage();
         assertInvalidValue(stage, MyParams.INT_PARAM, 100);


### PR DESCRIPTION
## What is the purpose of the change

This PR updates WithParams::set(...) to throw Exception if the given param is not defined on this instance. This is because we don't have use-case where users will want to set a parameter not defined on the given Stage instance. 

## Brief change log

This PR mades the following changes:
- Updates WithParams::set(...) to throw Exception if the given param is not defined on this instance.

## Verifying this change

The change is tested by `StageTest::testSetUndefinedParam`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)