### PR TITLE
[hotfix][FLIP-176] Updates onEpochWatermarkIncremented() and onIterationTerminated() to throw Exception

### DIFF
--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/IterationListener.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/IterationListener.java
@@ -46,7 +46,8 @@ public interface IterationListener<T> {
      *     the invocation of this method.
      * @param collector The collector for returning result values.
      */
-    void onEpochWatermarkIncremented(int epochWatermark, Context context, Collector<T> collector);
+    void onEpochWatermarkIncremented(int epochWatermark, Context context, Collector<T> collector)
+            throws Exception;
 
     /**
      * This callback is invoked after the execution of the iteration body has terminated.
@@ -56,7 +57,7 @@ public interface IterationListener<T> {
      *     the invocation of this method.
      * @param collector The collector for returning result values.
      */
-    void onIterationTerminated(Context context, Collector<T> collector);
+    void onIterationTerminated(Context context, Collector<T> collector) throws Exception;
 
     /**
      * Information available in an invocation of the callbacks defined in the

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/AbstractWrapperOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/AbstractWrapperOperator.java
@@ -123,8 +123,8 @@ public abstract class AbstractWrapperOperator<T>
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    protected void notifyEpochWatermarkIncrement(
-            IterationListener<?> listener, int epochWatermark) {
+    protected void notifyEpochWatermarkIncrement(IterationListener<?> listener, int epochWatermark)
+            throws Exception {
         if (epochWatermark != Integer.MAX_VALUE) {
             listener.onEpochWatermarkIncremented(
                     epochWatermark,

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/LogisticRegression.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/LogisticRegression.java
@@ -361,8 +361,8 @@ public class LogisticRegression
 
         @Override
         public void onEpochWatermarkIncremented(
-                int epochWatermark, Context context, Collector<double[]> collector) {
-            // TODO: let this method throws exception.
+                int epochWatermark, Context context, Collector<double[]> collector)
+                throws Exception {
             if (epochWatermark == 0) {
                 coefficient = new DenseVector(feedbackBuffer);
                 coefficientDim = coefficient.size();
@@ -372,12 +372,8 @@ public class LogisticRegression
                 updateModel();
             }
             Arrays.fill(gradient.values, 0);
-            try {
-                if (trainData == null) {
-                    trainData = IteratorUtils.toList(trainDataState.get().iterator());
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            if (trainData == null) {
+                trainData = IteratorUtils.toList(trainDataState.get().iterator());
             }
             miniBatchData = getMiniBatchData(trainData, localBatchSize);
             Tuple2<Double, Double> weightSumAndLossSum =

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
@@ -276,37 +276,33 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
 
         @Override
         public void onEpochWatermarkIncremented(
-                int epochWatermark, Context context, Collector<Tuple2<Integer, DenseVector>> out) {
-            // TODO: update onEpochWatermarkIncremented to throw Exception.
-            try {
-                List<DenseVector[]> list = IteratorUtils.toList(centroids.get().iterator());
-                if (list.size() != 1) {
-                    throw new RuntimeException(
-                            "The operator received "
-                                    + list.size()
-                                    + " list of centroids in this round");
-                }
-                DenseVector[] centroidValues = list.get(0);
-
-                for (DenseVector point : points.get()) {
-                    double minDistance = Double.MAX_VALUE;
-                    int closestCentroidId = -1;
-
-                    for (int i = 0; i < centroidValues.length; i++) {
-                        DenseVector centroid = centroidValues[i];
-                        double distance = distanceMeasure.distance(centroid, point);
-                        if (distance < minDistance) {
-                            minDistance = distance;
-                            closestCentroidId = i;
-                        }
-                    }
-
-                    output.collect(new StreamRecord<>(Tuple2.of(closestCentroidId, point)));
-                }
-                centroids.clear();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+                int epochWatermark, Context context, Collector<Tuple2<Integer, DenseVector>> out)
+                throws Exception {
+            List<DenseVector[]> list = IteratorUtils.toList(centroids.get().iterator());
+            if (list.size() != 1) {
+                throw new RuntimeException(
+                        "The operator received "
+                                + list.size()
+                                + " list of centroids in this round");
             }
+            DenseVector[] centroidValues = list.get(0);
+
+            for (DenseVector point : points.get()) {
+                double minDistance = Double.MAX_VALUE;
+                int closestCentroidId = -1;
+
+                for (int i = 0; i < centroidValues.length; i++) {
+                    DenseVector centroid = centroidValues[i];
+                    double distance = distanceMeasure.distance(centroid, point);
+                    if (distance < minDistance) {
+                        minDistance = distance;
+                        closestCentroidId = i;
+                    }
+                }
+
+                output.collect(new StreamRecord<>(Tuple2.of(closestCentroidId, point)));
+            }
+            centroids.clear();
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this PR is to simplify the experience of implementing `onEpochWatermarkIncremented()` and `onIterationTerminated()`.

## Brief change log

This PR updated `onEpochWatermarkIncremented()` and `onIterationTerminated()` to throw Exception.

## Verifying this change

The changes are validated by the existing unit tests.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)