### PR TITLE
[FLINK-25394] Upgrade log4j to 2.17.0 to address CVE-2021-45105

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ under the License.
     <target.java.version>1.8</target.java.version>
     <spotless.version>2.4.2</spotless.version>
     <slf4j.version>1.7.15</slf4j.version>
-    <log4j.version>2.12.1</log4j.version>
+    <log4j.version>2.17.0</log4j.version>
     <junit.version>4.12</junit.version>
     <flink.forkCount>1C</flink.forkCount>
     <flink.reuseForks>true</flink.reuseForks>


### PR DESCRIPTION
### Background:
As recently reported on apache.org

Apache Log4j2 versions 2.0-alpha1 through 2.16.0 did not protect from uncontrolled recursion from self-referential lookups. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data that contains a recursive lookup, resulting in a StackOverflowError that will terminate the process. This is also known as a DOS (Denial of Service) attack.