### PR TITLE
[hotfix] Add scala version as suffix of all modules

### DIFF
--- a/flink-ml-core/pom.xml
+++ b/flink-ml-core/pom.xml
@@ -28,13 +28,13 @@ under the License.
     <version>2.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>flink-ml-core</artifactId>
+  <artifactId>flink-ml-core_${scala.binary.version}</artifactId>
   <name>Flink ML : Core</name>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-ml-iteration</artifactId>
+      <artifactId>flink-ml-iteration_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/flink-ml-iteration/pom.xml
+++ b/flink-ml-iteration/pom.xml
@@ -28,7 +28,7 @@ under the License.
         <version>2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>flink-ml-iteration</artifactId>
+    <artifactId>flink-ml-iteration_${scala.binary.version}</artifactId>
     <name>Flink ML : Iteration</name>
 
     <properties>

--- a/flink-ml-lib/pom.xml
+++ b/flink-ml-lib/pom.xml
@@ -32,14 +32,14 @@ under the License.
   <dependencies>
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-ml-core</artifactId>
+      <artifactId>flink-ml-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-ml-iteration</artifactId>
+      <artifactId>flink-ml-iteration_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/flink-ml-tests/pom.xml
+++ b/flink-ml-tests/pom.xml
@@ -28,21 +28,21 @@ under the License.
         <version>2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>flink-ml-tests</artifactId>
+    <artifactId>flink-ml-tests_${scala.binary.version}</artifactId>
     <name>Flink ML : Tests</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-ml-iteration</artifactId>
+            <artifactId>flink-ml-iteration_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-ml-core</artifactId>
+            <artifactId>flink-ml-core_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/flink-ml-uber/pom.xml
+++ b/flink-ml-uber/pom.xml
@@ -37,13 +37,13 @@ under the License.
   <dependencies>
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-ml-core</artifactId>
+      <artifactId>flink-ml-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-ml-iteration</artifactId>
+      <artifactId>flink-ml-iteration_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This PR adds scala version as suffix of all flink-ml sub-modules.