### PR TITLE
[hotfix] Update setup.py to throw error if python version > 3.8

### DIFF
--- a/flink-ml-python/setup.py
+++ b/flink-ml-python/setup.py
@@ -18,13 +18,14 @@
 import io
 import os
 import sys
+from platform import python_version
 from shutil import copytree, rmtree
 
 from setuptools import setup
 
-if sys.version_info < (3, 6):
-    print("Python versions prior to 3.6 are not supported for Flink ML.",
-          file=sys.stderr)
+if sys.version_info < (3, 6) or sys.version_info > (3, 8):
+    print("Only Python versions between 3.6 and 3.8 (inclusive) are supported for Flink ML. "
+          "The current Python version is %s." % python_version(), file=sys.stderr)
     sys.exit(-1)
 
 


### PR DESCRIPTION
## What is the purpose of the change

User should see more explicit error when installing `apache-flink-ml` with un-supported python version.

## Brief change log

Update setup.py to throw error if python version > 3.8.

## Verifying this change

Run `python3.9 setup.py` and verified that the output is `Only Python versions between 3.6 and 3.8 (inclusive) are supported for Flink ML. The current Python version is 3.9.2.`

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)
