### PR TITLE
[hotfix] Add scala suffix for dependencies in flink-ml-uber and flink-ml-lib as a dependency of flink-ml-uber

### DIFF
--- a/flink-ml-uber/pom.xml
+++ b/flink-ml-uber/pom.xml
@@ -46,6 +46,12 @@ under the License.
       <artifactId>flink-ml-iteration_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-ml-lib_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -63,8 +69,9 @@ under the License.
             <configuration>
               <artifactSet>
                 <includes combine.children="append">
-                  <include>org.apache.flink:flink-ml-core</include>
-                  <include>org.apache.flink:flink-ml-iteration</include>
+                  <include>org.apache.flink:flink-ml-core_${scala.binary.version}</include>
+                  <include>org.apache.flink:flink-ml-iteration_${scala.binary.version}</include>
+                  <include>org.apache.flink:flink-ml-lib_${scala.binary.version}</include>
                   <include>dev.ludovic.netlib:blas</include>
                 </includes>
               </artifactSet>


### PR DESCRIPTION
## What is the purpose of the change
- Add scala suffix for dependencies in flink-ml-uber and flink-ml-lib as a dependency of flink-ml-uber.

## Brief change log
- Add scala suffix for dependencies in flink-ml-uber
- Add flink-ml-lib as a dependency of flink-ml-uber

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (-)