### PR TITLE
[hotfix] Fix version and branch info of docs in release 2.0

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-baseURL = '//nightlies.apache.org/flink/flink-ml-docs-master'
+baseURL = '//nightlies.apache.org/flink/flink-ml-docs-release-2.0'
 languageCode = 'en-us'
 title = 'Apache Flink Machine Learning Library'
 enableGitInfo = false
@@ -38,10 +38,10 @@ pygmentsUseClasses = true
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version
-  VersionTitle = "2.0.0"
+  VersionTitle = "2.0"
 
   # The branch for this version of Apache Flink Machine Learning Library
-  Branch = "master"
+  Branch = "release-2.0"
 
   # The github repository for Apache Flink Machine Learning Library
   Repo = "//github.com/apache/flink-ml"
@@ -57,6 +57,7 @@ pygmentsUseClasses = true
   # of the menu
   MenuLinks = [
     ["Project Homepage", "//flink.apache.org"],
+    ["JavaDocs", "//nightlies.apache.org/flink/flink-ml-docs-release-2.0/api/java/"],
   ]
 
   PreviousDocs = []

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -33,7 +33,7 @@ build ML pipelines for both training and inference jobs.
 ## Try Flink ML
 
 If you’re interested in playing around with Flink ML, check out our [example
-codes](({{< ref "docs/try-flink-ml/quick-start" >}})). It provides a step by
+codes]({{< ref "docs/try-flink-ml/quick-start" >}}). It provides a step by
 step introduction to the APIs and guides you through real applications.
 
 <--->


### PR DESCRIPTION
## What is the purpose of the change
Fix version and branch info of docs in release 2.0

## Brief change log
- Change version number from `2.0.0` to `2.0`
- Change references to Flink ML Github repo from master branch to branch `release-2.0`

## Verifying this change
N/A

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)

## Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)