### PR TITLE
[FLINK-26263] Check data size in LogisticRegression

### DIFF
--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/LogisticRegression.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/LogisticRegression.java
@@ -363,6 +363,9 @@ public class LogisticRegression
         public void onEpochWatermarkIncremented(
                 int epochWatermark, Context context, Collector<double[]> collector)
                 throws Exception {
+            if (!trainDataState.get().iterator().hasNext()) {
+                return;
+            }
             if (epochWatermark == 0) {
                 coefficient = new DenseVector(feedbackBuffer);
                 coefficientDim = coefficient.size();

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/LogisticRegressionTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/LogisticRegressionTest.java
@@ -281,4 +281,16 @@ public class LogisticRegressionTest {
                     e.getCause().getCause().getMessage());
         }
     }
+
+    @Test
+    public void testMoreSubtaskThanData() throws Exception {
+        env.setParallelism(12);
+        LogisticRegression logisticRegression = new LogisticRegression().setWeightCol("weight");
+        Table output = logisticRegression.fit(binomialDataTable).transform(binomialDataTable)[0];
+        verifyPredictionResult(
+                output,
+                logisticRegression.getFeaturesCol(),
+                logisticRegression.getPredictionCol(),
+                logisticRegression.getRawPredictionCol());
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

- Add check for data size in LogisticRegression

## Brief change log

- Add an if condition in LogisticRegression to check train data size, and add an early exit if the data size is 0.
- Add test case to test when parallelism is bigger than data size

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)