### PR TITLE
[FLINK-26263] (followup) Check data size in LogisticRegression

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/AllReduceImpl.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/AllReduceImpl.java
@@ -37,7 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Applies all-reduce on a data stream where each partition contains only one double array.
+ * Applies all-reduce on a data stream where each partition contains up to only one double array.
  *
  * <p>AllReduce is a communication primitive widely used in MPI. In this implementation, all workers
  * do reduce on a partition of the whole data and they all get the final reduce result. In detail,
@@ -55,7 +55,7 @@ class AllReduceImpl {
 
     /**
      * Applies allReduceSum on the input data stream. The input data stream is supposed to contain
-     * one double array in each worker. The result data stream has the same parallelism as the
+     * up to one double array in each worker. The result data stream has the same parallelism as the
      * input, where each worker contains one double array that sums all of the double arrays in the
      * input data stream.
      *

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/DataStreamUtils.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/DataStreamUtils.java
@@ -35,9 +35,9 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 public class DataStreamUtils {
     /**
      * Applies allReduceSum on the input data stream. The input data stream is supposed to contain
-     * one double array in each partition. The result data stream has the same parallelism as the
-     * input, where each partition contains one double array that sums all of the double arrays in
-     * the input data stream.
+     * up to one double array in each partition. The result data stream has the same parallelism as
+     * the input, where each partition contains one double array that sums all of the double arrays
+     * in the input data stream.
      *
      * <p>Note that we throw exception when one of the following two cases happen:
      * <li>There exists one partition that contains more than one double array.


### PR DESCRIPTION
## What is the purpose of the change

- This is a followup of https://github.com/apache/flink-ml/pull/63

## Brief change log
- Put off the check of train data size and let each worker intanstiate variables even there is no input data.
- Get model dimension using parallelism 1.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)

