### PR TITLE
[FLINK-26443] Add benchmark framework for Flink ML

### DIFF
--- a/flink-ml-tests/pom.xml
+++ b/flink-ml-tests/pom.xml
@@ -60,5 +60,34 @@ under the License.
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-ml-lib_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/Benchmark.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/Benchmark.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark;
+
+import org.apache.flink.ml.api.Stage;
+
+/**
+ * A description of the {@link Stage} for benchmark. It is an encapsulation of {@link
+ * BenchmarkStage} and {@link BenchmarkParams}.
+ */
+public class Benchmark {
+    final BenchmarkStage<?> stage;
+    final BenchmarkParams params;
+
+    public Benchmark(BenchmarkStage<?> stage, BenchmarkParams params) {
+        this.stage = stage;
+        this.params = params;
+    }
+
+    @Override
+    public String toString() {
+        return "Benchmark{" + "stage=" + stage + ", params=" + params + '}';
+    }
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/BenchmarkContext.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/BenchmarkContext.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+/** All the context information needed to run a machine learning benchmark. */
+public class BenchmarkContext {
+    public final BenchmarkParams params;
+    public final StreamExecutionEnvironment env;
+
+    public BenchmarkContext(BenchmarkParams params, StreamExecutionEnvironment env) {
+        this.params = params;
+        this.env = env;
+    }
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/BenchmarkParams.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/BenchmarkParams.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+/** Wraps all possible parameters for ML benchmarks in a single class. */
+public class BenchmarkParams {
+    public long randomSeed = 2022L;
+    public long numExamples = 100;
+    public long numTestExamples = 10;
+    public int numPartitions = 3;
+    public int numFeatures = 10;
+    public double tol = 0.1;
+    public int maxIter = 10;
+    public int k = 5;
+    public int globalBatchSize = 100;
+    public double learningRate = 0.1;
+    public double reg = 0.01;
+
+    public BenchmarkParams() {}
+
+    public static BenchmarkParams fromParams(Map<String, Object> params) {
+        BenchmarkParams benchmarkParams = new BenchmarkParams();
+        for (Map.Entry<String, Object> nameAndVal : params.entrySet()) {
+            try {
+                Field field = benchmarkParams.getClass().getField(nameAndVal.getKey());
+                field.set(benchmarkParams, nameAndVal.getValue());
+            } catch (NoSuchFieldException | IllegalAccessException ignored) {
+            }
+        }
+        return benchmarkParams;
+    }
+
+    @Override
+    public String toString() {
+        return "BenchParams{"
+                + "randomSeed="
+                + randomSeed
+                + ", numExamples="
+                + numExamples
+                + ", numTestExamples="
+                + numTestExamples
+                + ", numPartitions="
+                + numPartitions
+                + ", numFeatures="
+                + numFeatures
+                + ", tol="
+                + tol
+                + ", maxIter="
+                + maxIter
+                + ", k="
+                + k
+                + ", globalBatchSize="
+                + globalBatchSize
+                + ", learningRate="
+                + learningRate
+                + ", reg="
+                + reg
+                + '}';
+    }
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/BenchmarkStage.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/BenchmarkStage.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark;
+
+import org.apache.flink.ml.api.Stage;
+import org.apache.flink.table.api.Table;
+
+/** Interface for specifying a machine learning algorithm (i.e., {@link Stage}) for benchmark. */
+public interface BenchmarkStage<S extends Stage<S>> {
+    /**
+     * Returns the input tables for training.
+     *
+     * @param context The context information of this benchmark.
+     * @return The train data.
+     */
+    Table[] getTrainData(BenchmarkContext context);
+
+    /**
+     * Returns the input tables for testing. It treats the training data as the test data by
+     * default.
+     *
+     * @param context The context information of this benchmark.
+     * @return The test data.
+     */
+    default Table[] getTestData(BenchmarkContext context) {
+        return getTrainData(context);
+    }
+
+    /**
+     * Returns the stage that is to be benchmarked.
+     *
+     * @param context The context information of this benchmark.
+     * @return The stage to be benchmarked.
+     */
+    Stage<S> getStage(BenchmarkContext context);
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/Constants.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/Constants.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark;
+
+/** Some constant values used for benchmark. */
+public class Constants {
+    public static final String FEATURE_COL = "feature";
+    public static final String LABEL_COL = "label";
+    public static final String PREDICT_COL = "prediction";
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/Main.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/Main.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark;
+
+import org.apache.flink.ml.api.AlgoOperator;
+import org.apache.flink.ml.api.Estimator;
+import org.apache.flink.ml.api.Model;
+import org.apache.flink.ml.api.Stage;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/** The main entrance of benchmark algorithms. */
+public class Main {
+    private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+    private static final String exampleConfig = "mlbench-demo.yaml";
+
+    public static void main(String[] args) throws Exception {
+        String configFile =
+                args.length > 0 ? args[0] : Main.class.getResource("/").getPath() + exampleConfig;
+        List<Benchmark> benchmarks = Utils.getMLBenchmarksFromFile(configFile);
+        for (Benchmark benchmark : benchmarks) {
+            runBenchmark(benchmark);
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static void runBenchmark(Benchmark benchmark) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        env.setParallelism(benchmark.params.numPartitions);
+        BenchmarkContext context = new BenchmarkContext(benchmark.params, env);
+
+        long startTime = System.currentTimeMillis();
+        LOG.info("Starts running " + benchmark + ", time: " + startTime);
+        BenchmarkStage<?> benchmarkStage = benchmark.stage;
+        Stage<?> mlStage = benchmarkStage.getStage(context);
+        Table[] trainData = benchmarkStage.getTrainData(context);
+        Table[] testData = benchmarkStage.getTestData(context);
+
+        if (mlStage instanceof Estimator) {
+            Model<?> m = ((Estimator) mlStage).fit(trainData);
+            Table[] predictions = m.transform(testData);
+            tEnv.toDataStream(predictions[0]).addSink(new DiscardingSink<>());
+            env.execute();
+        } else if (mlStage instanceof AlgoOperator) {
+            AlgoOperator<?> algoOperator = (AlgoOperator) mlStage;
+            Table[] predictions = algoOperator.transform(testData);
+            tEnv.toDataStream(predictions[0]).addSink(new DiscardingSink<>());
+            env.execute();
+        }
+        LOG.info(
+                "Finished running "
+                        + benchmark
+                        + ", duration(s): "
+                        + (System.currentTimeMillis() - startTime) / 1000);
+    }
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/Utils.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/Utils.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark;
+
+import org.apache.flink.ml.api.Model;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.ExpressionParser;
+
+import org.apache.flink.shaded.jackson2.org.yaml.snakeyaml.Yaml;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Utility class for benchmarks. */
+public class Utils {
+
+    /**
+     * Uses a given model data to transform the input tables, and assigns each data point with a
+     * label. The schema of the output table is "feature, label".
+     *
+     * @param model The true model.
+     * @param inputs The input tables to be transformed.
+     * @return The train data with labels assigned.
+     */
+    public static Table[] getTrainDataFromTrueModelAndData(Model<?> model, Table[] inputs) {
+        Table[] transformedResult = model.transform(inputs);
+        Table[] trainData = new Table[transformedResult.length];
+        for (int i = 0; i < transformedResult.length; i++) {
+            trainData[i] =
+                    transformedResult[i]
+                            .select(
+                                    ExpressionParser.parseExpressionList("feature, prediction")
+                                            .toArray(new Expression[0]))
+                            .as("feature", "label");
+        }
+        return trainData;
+    }
+
+    /**
+     * Parses the config of benchmarks from a yaml file.
+     *
+     * @param configFile The path of the yaml config file.
+     * @return The list of benchmarks to run.
+     * @throws IOException Throws exception if the config file does not exist.
+     */
+    @SuppressWarnings("unchecked")
+    public static List<Benchmark> getMLBenchmarksFromFile(String configFile) throws IOException {
+        String configString =
+                FileUtils.readFileToString(new File(configFile), StandardCharsets.UTF_8);
+        Map<?, ?> map = new Yaml().load(configString);
+
+        Map<String, Object> commonParams = (Map<String, Object>) map.get("common");
+        List<Map<String, String>> classNameAndParams =
+                (List<Map<String, String>>) map.get("benchmarks");
+        List<Benchmark> benchmarks = new ArrayList<>();
+        for (Map<?, ?> classNameAndParam : classNameAndParams) {
+            String name = classNameAndParam.get("name").toString();
+            Map<String, Object> algoParams = (Map<String, Object>) classNameAndParam.get("params");
+            for (Map.Entry<String, Object> kv : commonParams.entrySet()) {
+                if (!algoParams.containsKey(kv.getKey())) {
+                    algoParams.put(kv.getKey(), kv.getValue());
+                }
+            }
+            BenchmarkStage<?> benchmarkStage;
+            String benchmarkName = "org.apache.flink.ml.benchmark." + name + "Benchmark";
+            try {
+                benchmarkStage =
+                        (BenchmarkStage<?>)
+                                Class.forName(benchmarkName).getConstructor().newInstance();
+            } catch (IllegalAccessException
+                    | InstantiationException
+                    | ClassNotFoundException
+                    | NoSuchMethodException
+                    | InvocationTargetException e) {
+                throw new RuntimeException("Class not found: " + benchmarkName);
+            }
+            benchmarks.add(new Benchmark(benchmarkStage, BenchmarkParams.fromParams(algoParams)));
+        }
+
+        return benchmarks;
+    }
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/classification/LogisticRegressionBenchmark.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/classification/LogisticRegressionBenchmark.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark.classification;
+
+import org.apache.flink.ml.api.Stage;
+import org.apache.flink.ml.benchmark.BenchmarkContext;
+import org.apache.flink.ml.benchmark.BenchmarkStage;
+import org.apache.flink.ml.benchmark.Constants;
+import org.apache.flink.ml.benchmark.Utils;
+import org.apache.flink.ml.benchmark.data.DataGenerator;
+import org.apache.flink.ml.classification.logisticregression.LogisticRegression;
+import org.apache.flink.ml.classification.logisticregression.LogisticRegressionModel;
+import org.apache.flink.ml.classification.logisticregression.LogisticRegressionModelData;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+import java.util.Arrays;
+import java.util.Random;
+
+/** Benchmark test for {@link LogisticRegression}. */
+public class LogisticRegressionBenchmark implements BenchmarkStage<LogisticRegression> {
+
+    @Override
+    public Table[] getTrainData(BenchmarkContext context) {
+        DataStream<Vector> data =
+                DataGenerator.generateContinuousFeatures(
+                        context.env,
+                        context.params.numExamples,
+                        context.params.randomSeed,
+                        context.params.numPartitions,
+                        context.params.numFeatures);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(context.env);
+        Table trainTable = tEnv.fromDataStream(data).as(Constants.FEATURE_COL);
+
+        int modelDim = context.params.numFeatures;
+        double[] modelDataArray = new double[modelDim];
+        Random random = new Random(context.params.randomSeed);
+        Arrays.fill(modelDataArray, random.nextDouble());
+        DataStream<LogisticRegressionModelData> modelDataDataStream =
+                context.env.fromElements(
+                        new LogisticRegressionModelData(Vectors.dense(modelDataArray)));
+        Table modelData = tEnv.fromDataStream(modelDataDataStream);
+
+        LogisticRegressionModel model =
+                new LogisticRegressionModel()
+                        .setModelData(modelData)
+                        .setFeaturesCol(Constants.FEATURE_COL)
+                        .setPredictionCol(Constants.PREDICT_COL);
+        Table[] trainTables =
+                Utils.getTrainDataFromTrueModelAndData(model, new Table[] {trainTable});
+
+        return trainTables;
+    }
+
+    @Override
+    public Stage<LogisticRegression> getStage(BenchmarkContext context) {
+        return new LogisticRegression()
+                .setFeaturesCol(Constants.FEATURE_COL)
+                .setPredictionCol(Constants.PREDICT_COL)
+                .setLabelCol(Constants.LABEL_COL)
+                .setGlobalBatchSize(context.params.globalBatchSize)
+                .setLearningRate(context.params.learningRate)
+                .setReg(context.params.reg);
+    }
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/clustering/KMeansBenchmark.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/clustering/KMeansBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark.clustering;
+
+import org.apache.flink.ml.api.Stage;
+import org.apache.flink.ml.benchmark.BenchmarkContext;
+import org.apache.flink.ml.benchmark.BenchmarkStage;
+import org.apache.flink.ml.benchmark.Constants;
+import org.apache.flink.ml.benchmark.data.DataGenerator;
+import org.apache.flink.ml.clustering.kmeans.KMeans;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+/** Benchmark test for {@link KMeans}. */
+public class KMeansBenchmark implements BenchmarkStage<KMeans> {
+    @Override
+    public Table[] getTrainData(BenchmarkContext context) {
+        DataStream<Vector> data =
+                DataGenerator.generateContinuousFeatures(
+                        context.env,
+                        context.params.numExamples,
+                        context.params.randomSeed,
+                        context.params.numPartitions,
+                        context.params.numFeatures);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(context.env);
+        Table trainTable = tEnv.fromDataStream(data).as(Constants.FEATURE_COL);
+
+        return new Table[] {trainTable};
+    }
+
+    @Override
+    public Stage<KMeans> getStage(BenchmarkContext context) {
+        return new KMeans()
+                .setFeaturesCol(Constants.FEATURE_COL)
+                .setK(context.params.k)
+                .setMaxIter(context.params.maxIter)
+                .setSeed(context.params.randomSeed);
+    }
+}

--- a/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/data/DataGenerator.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/ml/benchmark/data/DataGenerator.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark.data;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.datagen.RandomGenerator;
+import org.apache.flink.util.NumberSequenceIterator;
+
+import java.util.Random;
+
+/** Utility class to generate synthetic data set for benchmark machine learning algorithms. */
+public class DataGenerator {
+
+    /**
+     * Generates data points with continuous features.
+     *
+     * @param env The execution environment instance.
+     * @param numExamples Number of examples to generate in total.
+     * @param seed The seed to generate seed on each partition.
+     * @param numPartitions Number of partitions to generate.
+     * @param numFeatures Number of features for each data point.
+     * @return The generated data set for benchmark.
+     */
+    public static DataStream<Vector> generateContinuousFeatures(
+            StreamExecutionEnvironment env,
+            long numExamples,
+            long seed,
+            int numPartitions,
+            int numFeatures) {
+        int[] featureArity = new int[numFeatures];
+        long[] seeds = new long[numPartitions];
+        Random random = new Random(seed);
+        for (int i = 0; i < numPartitions; i++) {
+            seeds[i] = random.nextLong();
+        }
+        return env.fromParallelCollection(
+                        new NumberSequenceIterator(1L, numExamples), BasicTypeInfo.LONG_TYPE_INFO)
+                .map(new GenerateFeatureFunction(featureArity, seeds))
+                .setParallelism(numPartitions);
+    }
+
+    private static class GenerateFeatureFunction extends RichMapFunction<Long, Vector> {
+        private final long[] allSeeds;
+        private final int[] featureArity;
+        private FeatureGenerator featureGenerator;
+
+        GenerateFeatureFunction(int[] featureArity, long[] allSeeds) {
+            this.allSeeds = allSeeds;
+            this.featureArity = featureArity;
+        }
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            super.open(parameters);
+            long seedOnThisPartition = allSeeds[getRuntimeContext().getIndexOfThisSubtask()];
+            featureGenerator = new FeatureGenerator(featureArity, seedOnThisPartition);
+        }
+
+        @Override
+        public Vector map(Long value) {
+            return featureGenerator.next();
+        }
+    }
+
+    /**
+     * Generates features according to the given feature arity and the random seed.
+     *
+     * <p>Each element in the given feature arity represents number of possible categorical values
+     * of that dimension. Zero indicates a continuous feature.
+     */
+    private static class FeatureGenerator extends RandomGenerator<Vector> {
+        final int[] featureArity;
+        final Random random;
+
+        public FeatureGenerator(int[] featureArity, long seed) {
+            this.featureArity = featureArity;
+            random = new Random(seed);
+        }
+
+        @Override
+        public Vector next() {
+            double[] features = new double[featureArity.length];
+            for (int i = 0; i < features.length; i++) {
+                if (featureArity[i] == 0) {
+                    features[i] = 2 * random.nextDouble() - 1;
+                } else {
+                    features[i] = random.nextInt(featureArity[i]);
+                }
+            }
+            return Vectors.dense(features);
+        }
+    }
+}

--- a/flink-ml-tests/src/test/resources/mlbench-demo.yaml
+++ b/flink-ml-tests/src/test/resources/mlbench-demo.yaml
@@ -1,0 +1,19 @@
+common:
+  numFeatures: 10
+  numExamples: 1000
+  numTestExamples: 100
+  numPartitions: 3
+  randomSeed: 1
+benchmarks:
+  - name: classification.LogisticRegression
+    params:
+      numExamples: 100
+      reg: 0.1
+      tol: 0.1
+      maxIter: 10
+  - name: clustering.KMeans
+    params:
+      numExamples: 100
+      k: 5
+      maxIter: 10
+      tol: 1e-4


### PR DESCRIPTION
## What is the purpose of the change
- Add a benchmark framework for Flink ML in flink-ml-tests. (This PR  borrows a lot of ideas from https://github.com/databricks/spark-sql-perf and https://github.com/alibaba/alink)

## Brief change log
- Adds a benchmark framework for Flink ML.
- Adds KMeansBenchmark and LogisticRegressionBenchmark as two examples.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (Java doc)