### PR TITLE
[FLINK-26313] Add Transformer and Estimator of OnlineKMeans 

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/api/Stage.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/api/Stage.java
@@ -40,6 +40,6 @@ import java.io.Serializable;
  */
 @PublicEvolving
 public interface Stage<T extends Stage<T>> extends WithParams<T>, Serializable {
-    /** Saves this stage to the given path. */
+    /** Saves the metadata and bounded data of this stage to the given path. */
     void save(String path) throws IOException;
 }

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/broadcast/BroadcastContext.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/broadcast/BroadcastContext.java
@@ -76,7 +76,7 @@ public class BroadcastContext {
         BROADCAST_VARIABLES.computeIfPresent(
                 key,
                 (k, v) -> {
-                    // sends an dummy email to avoid possible stuck.
+                    // sends a dummy email to avoid possible stuck.
                     if (null != v.mailboxExecutor) {
                         v.mailboxExecutor.execute(() -> {}, "empty mail");
                     }

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/distance/EuclideanDistanceMeasure.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/distance/EuclideanDistanceMeasure.java
@@ -19,6 +19,7 @@
 package org.apache.flink.ml.common.distance;
 
 import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.util.Preconditions;
 
 /** Interface for measuring the Euclidean distance between two vectors. */
 public class EuclideanDistanceMeasure implements DistanceMeasure {
@@ -32,8 +33,10 @@ public class EuclideanDistanceMeasure implements DistanceMeasure {
         return instance;
     }
 
+    // TODO: Improve distance calculation with BLAS.
     @Override
     public double distance(Vector v1, Vector v2) {
+        Preconditions.checkArgument(v1.size() == v2.size());
         double squaredDistance = 0.0;
 
         for (int i = 0; i < v1.size(); i++) {

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
@@ -36,6 +36,7 @@ import org.apache.flink.iteration.IterationConfig;
 import org.apache.flink.iteration.IterationListener;
 import org.apache.flink.iteration.Iterations;
 import org.apache.flink.iteration.ReplayableDataStreamList;
+import org.apache.flink.iteration.operator.OperatorStateUtils;
 import org.apache.flink.ml.api.Estimator;
 import org.apache.flink.ml.common.datastream.DataStreamUtils;
 import org.apache.flink.ml.common.datastream.EndOfStreamWindows;
@@ -69,6 +70,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 
 /**
@@ -104,7 +106,7 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
                 new KMeansIterationBody(
                         getMaxIter(), DistanceMeasure.getInstance(getDistanceMeasure()));
 
-        DataStream<DenseVector[]> finalCentroids =
+        DataStream<KMeansModelData> finalModelData =
                 Iterations.iterateBoundedStreamsUntilTermination(
                                 DataStreamList.of(initCentroids),
                                 ReplayableDataStreamList.notReplay(points),
@@ -112,8 +114,8 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
                                 body)
                         .get(0);
 
-        Table finalCentroidsTable = tEnv.fromDataStream(finalCentroids.map(KMeansModelData::new));
-        KMeansModel model = new KMeansModel().setModelData(finalCentroidsTable);
+        Table finalModelDataTable = tEnv.fromDataStream(finalModelData);
+        KMeansModel model = new KMeansModel().setModelData(finalModelDataTable);
         ReadWriteUtils.updateExistingParams(model, paramMap);
         return model;
     }
@@ -159,25 +161,13 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
                                             DenseVectorTypeInfo.INSTANCE),
                                     new SelectNearestCentroidOperator(distanceMeasure));
 
-            AllWindowFunction<DenseVector, DenseVector[], TimeWindow> toList =
-                    new AllWindowFunction<DenseVector, DenseVector[], TimeWindow>() {
-                        @Override
-                        public void apply(
-                                TimeWindow timeWindow,
-                                Iterable<DenseVector> iterable,
-                                Collector<DenseVector[]> out) {
-                            List<DenseVector> centroids = IteratorUtils.toList(iterable.iterator());
-                            out.collect(centroids.toArray(new DenseVector[0]));
-                        }
-                    };
-
             PerRoundSubBody perRoundSubBody =
                     new PerRoundSubBody() {
                         @Override
                         public DataStreamList process(DataStreamList inputs) {
                             DataStream<Tuple2<Integer, DenseVector>> centroidIdAndPoints =
                                     inputs.get(0);
-                            DataStream<DenseVector[]> newCentroids =
+                            DataStream<KMeansModelData> modelDataStream =
                                     centroidIdAndPoints
                                             .map(new CountAppender())
                                             .keyBy(t -> t.f0)
@@ -185,33 +175,55 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
                                             .reduce(new CentroidAccumulator())
                                             .map(new CentroidAverager())
                                             .windowAll(EndOfStreamWindows.get())
-                                            .apply(toList);
-                            return DataStreamList.of(newCentroids);
+                                            .apply(new ModelDataGenerator());
+                            return DataStreamList.of(modelDataStream);
                         }
                     };
-
-            DataStream<DenseVector[]> newCentroids =
+            DataStream<KMeansModelData> newModelData =
                     IterationBody.forEachRound(
                                     DataStreamList.of(centroidIdAndPoints), perRoundSubBody)
                             .get(0);
-            DataStream<DenseVector[]> finalCentroids =
-                    newCentroids.flatMap(new ForwardInputsOfLastRound<>());
+
+            DataStream<DenseVector[]> newCentroids =
+                    newModelData.map(x -> x.centroids).setParallelism(1);
+
+            DataStream<KMeansModelData> finalModelData =
+                    newModelData.flatMap(new ForwardInputsOfLastRound<>());
 
             return new IterationBodyResult(
                     DataStreamList.of(newCentroids),
-                    DataStreamList.of(finalCentroids),
+                    DataStreamList.of(finalModelData),
                     terminationCriteria);
         }
     }
 
-    private static class CentroidAverager
-            implements MapFunction<Tuple3<Integer, DenseVector, Long>, DenseVector> {
+    private static class ModelDataGenerator
+            implements AllWindowFunction<Tuple2<DenseVector, Double>, KMeansModelData, TimeWindow> {
         @Override
-        public DenseVector map(Tuple3<Integer, DenseVector, Long> value) {
+        public void apply(
+                TimeWindow timeWindow,
+                Iterable<Tuple2<DenseVector, Double>> iterable,
+                Collector<KMeansModelData> collector) {
+            List<Tuple2<DenseVector, Double>> list = IteratorUtils.toList(iterable.iterator());
+            DenseVector[] centroids = new DenseVector[list.size()];
+            DenseVector weights = new DenseVector(list.size());
+            for (int i = 0; i < list.size(); i++) {
+                centroids[i] = list.get(i).f0;
+                weights.values[i] = list.get(i).f1;
+            }
+            collector.collect(new KMeansModelData(centroids, weights));
+        }
+    }
+
+    private static class CentroidAverager
+            implements MapFunction<
+                    Tuple3<Integer, DenseVector, Long>, Tuple2<DenseVector, Double>> {
+        @Override
+        public Tuple2<DenseVector, Double> map(Tuple3<Integer, DenseVector, Long> value) {
             for (int i = 0; i < value.f1.size(); i++) {
                 value.f1.values[i] /= value.f2;
             }
-            return value.f1;
+            return Tuple2.of(value.f1, value.f2.doubleValue());
         }
     }
 
@@ -219,8 +231,7 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
             implements ReduceFunction<Tuple3<Integer, DenseVector, Long>> {
         @Override
         public Tuple3<Integer, DenseVector, Long> reduce(
-                Tuple3<Integer, DenseVector, Long> v1, Tuple3<Integer, DenseVector, Long> v2)
-                throws Exception {
+                Tuple3<Integer, DenseVector, Long> v1, Tuple3<Integer, DenseVector, Long> v2) {
             for (int i = 0; i < v1.f1.size(); i++) {
                 v1.f1.values[i] += v2.f1.values[i];
             }
@@ -278,28 +289,14 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
         public void onEpochWatermarkIncremented(
                 int epochWatermark, Context context, Collector<Tuple2<Integer, DenseVector>> out)
                 throws Exception {
-            List<DenseVector[]> list = IteratorUtils.toList(centroids.get().iterator());
-            if (list.size() != 1) {
-                throw new RuntimeException(
-                        "The operator received "
-                                + list.size()
-                                + " list of centroids in this round");
-            }
-            DenseVector[] centroidValues = list.get(0);
+            DenseVector[] centroidValues =
+                    Objects.requireNonNull(
+                            OperatorStateUtils.getUniqueElement(centroids, "centroids")
+                                    .orElse(null));
 
             for (DenseVector point : points.get()) {
-                double minDistance = Double.MAX_VALUE;
-                int closestCentroidId = -1;
-
-                for (int i = 0; i < centroidValues.length; i++) {
-                    DenseVector centroid = centroidValues[i];
-                    double distance = distanceMeasure.distance(centroid, point);
-                    if (distance < minDistance) {
-                        minDistance = distance;
-                        closestCentroidId = i;
-                    }
-                }
-
+                int closestCentroidId =
+                        findClosestCentroidId(centroidValues, point, distanceMeasure);
                 output.collect(new StreamRecord<>(Tuple2.of(closestCentroidId, point)));
             }
             centroids.clear();
@@ -310,6 +307,21 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
                 Context context, Collector<Tuple2<Integer, DenseVector>> collector) {
             points.clear();
         }
+    }
+
+    protected static int findClosestCentroidId(
+            DenseVector[] centroids, DenseVector point, DistanceMeasure distanceMeasure) {
+        double minDistance = Double.MAX_VALUE;
+        int closestCentroidId = -1;
+        for (int i = 0; i < centroids.length; i++) {
+            DenseVector centroid = centroids[i];
+            double distance = distanceMeasure.distance(centroid, point);
+            if (distance < minDistance) {
+                minDistance = distance;
+                closestCentroidId = i;
+            }
+        }
+        return closestCentroidId;
     }
 
     public static DataStream<DenseVector[]> selectRandomCentroids(

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModelParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModelParams.java
@@ -26,15 +26,14 @@ import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.param.ParamValidators;
 
 /**
- * Params of {@link KMeansModel}.
+ * Params of {@link KMeansModel} and {@link OnlineKMeansModel}.
  *
  * @param <T> The class type of this instance.
  */
 public interface KMeansModelParams<T>
         extends HasDistanceMeasure<T>, HasFeaturesCol<T>, HasPredictionCol<T> {
-
     Param<Integer> K =
-            new IntParam("k", "The number of clusters to create.", 2, ParamValidators.gt(1));
+            new IntParam("k", "The max number of clusters to create.", 2, ParamValidators.gt(1));
 
     default int getK() {
         return get(K);

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeans.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeans.java
@@ -1,0 +1,400 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.clustering.kmeans;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
+import org.apache.flink.iteration.DataStreamList;
+import org.apache.flink.iteration.IterationBody;
+import org.apache.flink.iteration.IterationBodyResult;
+import org.apache.flink.iteration.Iterations;
+import org.apache.flink.iteration.operator.OperatorStateUtils;
+import org.apache.flink.ml.api.Estimator;
+import org.apache.flink.ml.common.distance.DistanceMeasure;
+import org.apache.flink.ml.linalg.BLAS;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.windowing.AllWindowFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.windowing.windows.GlobalWindow;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.collections.IteratorUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OnlineKMeans extends the function of {@link KMeans}, supporting to train a K-Means model
+ * continuously according to an unbounded stream of train data.
+ *
+ * <p>OnlineKMeans makes updates with the "mini-batch" KMeans rule, generalized to incorporate
+ * forgetfulness (i.e. decay). After the centroids estimated on the current batch are acquired,
+ * OnlineKMeans computes the new centroids from the weighted average between the original and the
+ * estimated centroids. The weight of the estimated centroids is the number of points assigned to
+ * them. The weight of the original centroids is also the number of points, but additionally
+ * multiplying with the decay factor.
+ *
+ * <p>The decay factor scales the contribution of the clusters as estimated thus far. If the decay
+ * factor is 1, all batches are weighted equally. If the decay factor is 0, new centroids are
+ * determined entirely by recent data. Lower values correspond to more forgetting.
+ */
+public class OnlineKMeans
+        implements Estimator<OnlineKMeans, OnlineKMeansModel>, OnlineKMeansParams<OnlineKMeans> {
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+    private Table initModelDataTable;
+
+    public OnlineKMeans() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public OnlineKMeansModel fit(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+
+        DataStream<DenseVector> points =
+                tEnv.toDataStream(inputs[0]).map(new FeaturesExtractor(getFeaturesCol()));
+
+        DataStream<KMeansModelData> initModelData =
+                KMeansModelData.getModelDataStream(initModelDataTable);
+        initModelData.getTransformation().setParallelism(1);
+
+        IterationBody body =
+                new OnlineKMeansIterationBody(
+                        DistanceMeasure.getInstance(getDistanceMeasure()),
+                        getK(),
+                        getDecayFactor(),
+                        getGlobalBatchSize());
+
+        DataStream<KMeansModelData> onlineModelData =
+                Iterations.iterateUnboundedStreams(
+                                DataStreamList.of(initModelData), DataStreamList.of(points), body)
+                        .get(0);
+
+        Table onlineModelDataTable = tEnv.fromDataStream(onlineModelData);
+        OnlineKMeansModel model = new OnlineKMeansModel().setModelData(onlineModelDataTable);
+        ReadWriteUtils.updateExistingParams(model, paramMap);
+        return model;
+    }
+
+    /** Saves the metadata AND bounded model data table (if exists) to the given path. */
+    @Override
+    public void save(String path) throws IOException {
+        Preconditions.checkNotNull(
+                initModelDataTable, "Initial Model Data Table should have been set.");
+        ReadWriteUtils.saveMetadata(this, path);
+        ReadWriteUtils.saveModelData(
+                KMeansModelData.getModelDataStream(initModelDataTable),
+                path,
+                new KMeansModelData.ModelDataEncoder());
+    }
+
+    public static OnlineKMeans load(StreamExecutionEnvironment env, String path)
+            throws IOException {
+        OnlineKMeans onlineKMeans = ReadWriteUtils.loadStageParam(path);
+        DataStream<KMeansModelData> initModelDataStream =
+                ReadWriteUtils.loadModelData(env, path, new KMeansModelData.ModelDataDecoder());
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        onlineKMeans.initModelDataTable = tEnv.fromDataStream(initModelDataStream);
+        return onlineKMeans;
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    private static class OnlineKMeansIterationBody implements IterationBody {
+        private final DistanceMeasure distanceMeasure;
+        private final int k;
+        private final double decayFactor;
+        private final int batchSize;
+
+        public OnlineKMeansIterationBody(
+                DistanceMeasure distanceMeasure, int k, double decayFactor, int batchSize) {
+            this.distanceMeasure = distanceMeasure;
+            this.k = k;
+            this.decayFactor = decayFactor;
+            this.batchSize = batchSize;
+        }
+
+        @Override
+        public IterationBodyResult process(
+                DataStreamList variableStreams, DataStreamList dataStreams) {
+            DataStream<KMeansModelData> modelData = variableStreams.get(0);
+            DataStream<DenseVector> points = dataStreams.get(0);
+
+            int parallelism = points.getParallelism();
+
+            Preconditions.checkState(
+                    parallelism <= batchSize,
+                    "There are more subtasks in the training process than the number "
+                            + "of elements in each batch. Some subtasks might be idling forever.");
+
+            DataStream<KMeansModelData> newModelData =
+                    points.countWindowAll(batchSize)
+                            .apply(new GlobalBatchCreator())
+                            .flatMap(new GlobalBatchSplitter(parallelism))
+                            .rebalance()
+                            .connect(modelData.broadcast())
+                            .transform(
+                                    "ModelDataLocalUpdater",
+                                    TypeInformation.of(KMeansModelData.class),
+                                    new ModelDataLocalUpdater(distanceMeasure, k, decayFactor))
+                            .setParallelism(parallelism)
+                            .countWindowAll(parallelism)
+                            .reduce(new ModelDataGlobalReducer());
+
+            return new IterationBodyResult(
+                    DataStreamList.of(newModelData), DataStreamList.of(modelData));
+        }
+    }
+
+    /**
+     * Operator that collects a KMeansModelData from each upstream subtask, and outputs the weight
+     * average of collected model data.
+     */
+    private static class ModelDataGlobalReducer implements ReduceFunction<KMeansModelData> {
+        @Override
+        public KMeansModelData reduce(KMeansModelData modelData, KMeansModelData newModelData) {
+            DenseVector weights = modelData.weights;
+            DenseVector[] centroids = modelData.centroids;
+            DenseVector newWeights = newModelData.weights;
+            DenseVector[] newCentroids = newModelData.centroids;
+
+            int k = newCentroids.length;
+            int dim = newCentroids[0].size();
+
+            for (int i = 0; i < k; i++) {
+                for (int j = 0; j < dim; j++) {
+                    centroids[i].values[j] =
+                            (centroids[i].values[j] * weights.values[i]
+                                            + newCentroids[i].values[j] * newWeights.values[i])
+                                    / Math.max(weights.values[i] + newWeights.values[i], 1e-16);
+                }
+                weights.values[i] += newWeights.values[i];
+            }
+
+            return new KMeansModelData(centroids, weights);
+        }
+    }
+
+    /**
+     * An operator that updates KMeans model data locally. It mainly does the following operations.
+     *
+     * <ul>
+     *   <li>Finds the closest centroid id (cluster) of the input points.
+     *   <li>Computes the new centroids from the average of input points that belongs to the same
+     *       cluster.
+     *   <li>Computes the weighted average of current and new centroids. The weight of a new
+     *       centroid is the number of input points that belong to this cluster. The weight of a
+     *       current centroid is its original weight scaled by $ decayFactor / parallelism $.
+     *   <li>Generates new model data from the weighted average of centroids, and the sum of
+     *       weights.
+     * </ul>
+     */
+    private static class ModelDataLocalUpdater extends AbstractStreamOperator<KMeansModelData>
+            implements TwoInputStreamOperator<DenseVector[], KMeansModelData, KMeansModelData> {
+        private final DistanceMeasure distanceMeasure;
+        private final int k;
+        private final double decayFactor;
+        private ListState<DenseVector[]> localBatchDataState;
+        private ListState<KMeansModelData> modelDataState;
+
+        private ModelDataLocalUpdater(DistanceMeasure distanceMeasure, int k, double decayFactor) {
+            this.distanceMeasure = distanceMeasure;
+            this.k = k;
+            this.decayFactor = decayFactor;
+        }
+
+        @Override
+        public void initializeState(StateInitializationContext context) throws Exception {
+            super.initializeState(context);
+
+            TypeInformation<DenseVector[]> type =
+                    ObjectArrayTypeInfo.getInfoFor(DenseVectorTypeInfo.INSTANCE);
+            localBatchDataState =
+                    context.getOperatorStateStore()
+                            .getListState(new ListStateDescriptor<>("localBatch", type));
+
+            modelDataState =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>("modelData", KMeansModelData.class));
+        }
+
+        @Override
+        public void processElement1(StreamRecord<DenseVector[]> pointsRecord) throws Exception {
+            localBatchDataState.add(pointsRecord.getValue());
+            alignAndComputeModelData();
+        }
+
+        @Override
+        public void processElement2(StreamRecord<KMeansModelData> modelDataRecord)
+                throws Exception {
+            Preconditions.checkArgument(modelDataRecord.getValue().centroids.length == k);
+            modelDataState.add(modelDataRecord.getValue());
+            alignAndComputeModelData();
+        }
+
+        private void alignAndComputeModelData() throws Exception {
+            if (!modelDataState.get().iterator().hasNext()
+                    || !localBatchDataState.get().iterator().hasNext()) {
+                return;
+            }
+
+            KMeansModelData modelData =
+                    OperatorStateUtils.getUniqueElement(modelDataState, "modelData").get();
+            DenseVector[] centroids = modelData.centroids;
+            DenseVector weights = modelData.weights;
+            modelDataState.clear();
+
+            List<DenseVector[]> pointsList =
+                    IteratorUtils.toList(localBatchDataState.get().iterator());
+            DenseVector[] points = pointsList.remove(0);
+            localBatchDataState.update(pointsList);
+
+            int dim = centroids[0].size();
+            int parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
+
+            // Computes new centroids.
+            DenseVector[] sums = new DenseVector[k];
+            int[] counts = new int[k];
+
+            for (int i = 0; i < k; i++) {
+                sums[i] = new DenseVector(dim);
+            }
+            for (DenseVector point : points) {
+                int closestCentroidId =
+                        KMeans.findClosestCentroidId(centroids, point, distanceMeasure);
+                counts[closestCentroidId]++;
+                BLAS.axpy(1.0, point, sums[closestCentroidId]);
+            }
+
+            // Considers weight and decay factor when updating centroids.
+            BLAS.scal(decayFactor / parallelism, weights);
+            for (int i = 0; i < k; i++) {
+                if (counts[i] == 0) {
+                    continue;
+                }
+
+                DenseVector centroid = centroids[i];
+                weights.values[i] = weights.values[i] + counts[i];
+                double lambda = counts[i] / weights.values[i];
+
+                BLAS.scal(1.0 - lambda, centroid);
+                BLAS.axpy(lambda / counts[i], sums[i], centroid);
+            }
+
+            output.collect(new StreamRecord<>(new KMeansModelData(centroids, weights)));
+        }
+    }
+
+    private static class FeaturesExtractor implements MapFunction<Row, DenseVector> {
+        private final String featuresCol;
+
+        private FeaturesExtractor(String featuresCol) {
+            this.featuresCol = featuresCol;
+        }
+
+        @Override
+        public DenseVector map(Row row) {
+            return (DenseVector) row.getField(featuresCol);
+        }
+    }
+
+    /**
+     * An operator that splits a global batch into evenly-sized local batches, and distributes them
+     * to downstream operator.
+     */
+    private static class GlobalBatchSplitter
+            implements FlatMapFunction<DenseVector[], DenseVector[]> {
+        private final int downStreamParallelism;
+
+        private GlobalBatchSplitter(int downStreamParallelism) {
+            this.downStreamParallelism = downStreamParallelism;
+        }
+
+        @Override
+        public void flatMap(DenseVector[] values, Collector<DenseVector[]> collector) {
+            int div = values.length / downStreamParallelism;
+            int mod = values.length % downStreamParallelism;
+
+            int offset = 0;
+            int i = 0;
+
+            int size = div + 1;
+            for (; i < mod; i++) {
+                collector.collect(Arrays.copyOfRange(values, offset, offset + size));
+                offset += size;
+            }
+
+            size = div;
+            for (; i < downStreamParallelism; i++) {
+                collector.collect(Arrays.copyOfRange(values, offset, offset + size));
+                offset += size;
+            }
+        }
+    }
+
+    private static class GlobalBatchCreator
+            implements AllWindowFunction<DenseVector, DenseVector[], GlobalWindow> {
+        @Override
+        public void apply(
+                GlobalWindow timeWindow,
+                Iterable<DenseVector> iterable,
+                Collector<DenseVector[]> collector) {
+            List<DenseVector> points = IteratorUtils.toList(iterable.iterator());
+            collector.collect(points.toArray(new DenseVector[0]));
+        }
+    }
+
+    /**
+     * Sets the initial model data of the online training process with the provided model data
+     * table.
+     */
+    public OnlineKMeans setInitialModelData(Table initModelDataTable) {
+        this.initModelDataTable = initModelDataTable;
+        return this;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeansModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeansModel.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.clustering.kmeans;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.ml.api.Model;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.common.distance.DistanceMeasure;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * OnlineKMeansModel can be regarded as an advanced {@link KMeansModel} operator which can update
+ * model data in a streaming format, using the model data provided by {@link OnlineKMeans}.
+ */
+public class OnlineKMeansModel
+        implements Model<OnlineKMeansModel>, KMeansModelParams<OnlineKMeansModel> {
+    public static final String MODEL_DATA_VERSION_GAUGE_KEY = "modelDataVersion";
+
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+    private Table modelDataTable;
+
+    public OnlineKMeansModel() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public OnlineKMeansModel setModelData(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        modelDataTable = inputs[0];
+        return this;
+    }
+
+    @Override
+    public Table[] getModelData() {
+        return new Table[] {modelDataTable};
+    }
+
+    @Override
+    public Table[] transform(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(inputTypeInfo.getFieldTypes(), Types.INT),
+                        ArrayUtils.addAll(inputTypeInfo.getFieldNames(), getPredictionCol()));
+
+        DataStream<Row> predictionResult =
+                tEnv.toDataStream(inputs[0])
+                        .connect(KMeansModelData.getModelDataStream(modelDataTable).broadcast())
+                        .transform(
+                                "PredictLabelOperator",
+                                outputTypeInfo,
+                                new PredictLabelOperator(
+                                        inputTypeInfo,
+                                        getFeaturesCol(),
+                                        DistanceMeasure.getInstance(getDistanceMeasure()),
+                                        getK()));
+
+        return new Table[] {tEnv.fromDataStream(predictionResult)};
+    }
+
+    /** A utility operator used for prediction. */
+    private static class PredictLabelOperator extends AbstractStreamOperator<Row>
+            implements TwoInputStreamOperator<Row, KMeansModelData, Row> {
+        private final RowTypeInfo inputTypeInfo;
+
+        private final String featuresCol;
+
+        private final DistanceMeasure distanceMeasure;
+
+        private final int k;
+
+        private DenseVector[] centroids;
+
+        // TODO: replace this with a complete solution of reading first model data from unbounded
+        // model data stream before processing the first predict data.
+        private ListState<Row> bufferedPointsState;
+
+        /**
+         * Basic implementation of the model data version with the following rules.
+         *
+         * <ul>
+         *   <li>Negative value is regarded as illegal value.
+         *   <li>Zero value means the version has not been initialized yet.
+         *   <li>Positive value represents valid version.
+         * </ul>
+         */
+        // TODO: replace this simple implementation of model data version with the formal API to
+        // track model version after its design is settled.
+        private int modelDataVersion = 0;
+
+        public PredictLabelOperator(
+                RowTypeInfo inputTypeInfo,
+                String featuresCol,
+                DistanceMeasure distanceMeasure,
+                int k) {
+            this.inputTypeInfo = inputTypeInfo;
+            this.featuresCol = featuresCol;
+            this.distanceMeasure = distanceMeasure;
+            this.k = k;
+        }
+
+        @Override
+        public void initializeState(StateInitializationContext context) throws Exception {
+            super.initializeState(context);
+
+            bufferedPointsState =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>("bufferedPoints", inputTypeInfo));
+        }
+
+        @Override
+        public void open() throws Exception {
+            super.open();
+
+            getRuntimeContext()
+                    .getMetricGroup()
+                    .gauge(
+                            MODEL_DATA_VERSION_GAUGE_KEY,
+                            (Gauge<String>) () -> Integer.toString(modelDataVersion));
+        }
+
+        @Override
+        public void processElement1(StreamRecord<Row> streamRecord) throws Exception {
+            Row dataPoint = streamRecord.getValue();
+            if (centroids == null) {
+                bufferedPointsState.add(dataPoint);
+                return;
+            }
+            DenseVector point = (DenseVector) dataPoint.getField(featuresCol);
+            int closestCentroidId = KMeans.findClosestCentroidId(centroids, point, distanceMeasure);
+            output.collect(new StreamRecord<>(Row.join(dataPoint, Row.of(closestCentroidId))));
+        }
+
+        @Override
+        public void processElement2(StreamRecord<KMeansModelData> streamRecord) throws Exception {
+            KMeansModelData modelData = streamRecord.getValue();
+            Preconditions.checkArgument(modelData.centroids.length <= k);
+            centroids = modelData.centroids;
+            modelDataVersion++;
+            for (Row dataPoint : bufferedPointsState.get()) {
+                processElement1(new StreamRecord<>(dataPoint));
+            }
+            bufferedPointsState.clear();
+        }
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    /**
+     * Saves the metadata to the given path.
+     *
+     * <p>NOTE: the unbounded model data table will not be saved. Model data needs be explicitly
+     * exported with {@link OnlineKMeansModel#getModelData()}.
+     */
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+
+    // TODO: Add INFO level logging.
+    public static OnlineKMeansModel load(StreamExecutionEnvironment env, String path)
+            throws IOException {
+        return ReadWriteUtils.loadStageParam(path);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeansParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeansParams.java
@@ -18,31 +18,19 @@
 
 package org.apache.flink.ml.clustering.kmeans;
 
-import org.apache.flink.ml.common.param.HasMaxIter;
+import org.apache.flink.ml.common.param.HasBatchStrategy;
+import org.apache.flink.ml.common.param.HasDecayFactor;
+import org.apache.flink.ml.common.param.HasGlobalBatchSize;
 import org.apache.flink.ml.common.param.HasSeed;
-import org.apache.flink.ml.param.Param;
-import org.apache.flink.ml.param.ParamValidators;
-import org.apache.flink.ml.param.StringParam;
 
 /**
- * Params of {@link KMeans}.
+ * Params of {@link OnlineKMeans}.
  *
  * @param <T> The class type of this instance.
  */
-public interface KMeansParams<T> extends HasSeed<T>, HasMaxIter<T>, KMeansModelParams<T> {
-    Param<String> INIT_MODE =
-            new StringParam(
-                    "initMode",
-                    "The initialization algorithm. Supported options: 'random'.",
-                    "random",
-                    ParamValidators.inArray("random"));
-
-    default String getInitMode() {
-        return get(INIT_MODE);
-    }
-
-    default T setInitMode(String value) {
-        set(INIT_MODE, value);
-        return (T) this;
-    }
-}
+public interface OnlineKMeansParams<T>
+        extends HasBatchStrategy<T>,
+                HasGlobalBatchSize<T>,
+                HasDecayFactor<T>,
+                HasSeed<T>,
+                KMeansModelParams<T> {}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasBatchStrategy.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasBatchStrategy.java
@@ -16,33 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.clustering.kmeans;
+package org.apache.flink.ml.common.param;
 
-import org.apache.flink.ml.common.param.HasMaxIter;
-import org.apache.flink.ml.common.param.HasSeed;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.param.ParamValidators;
 import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
 
-/**
- * Params of {@link KMeans}.
- *
- * @param <T> The class type of this instance.
- */
-public interface KMeansParams<T> extends HasSeed<T>, HasMaxIter<T>, KMeansModelParams<T> {
-    Param<String> INIT_MODE =
+/** Interface for the shared batch strategy param. */
+public interface HasBatchStrategy<T> extends WithParams<T> {
+    /** Strategy to create mini batches with a fixed batch size. */
+    String COUNT_STRATEGY = "count";
+
+    Param<String> BATCH_STRATEGY =
             new StringParam(
-                    "initMode",
-                    "The initialization algorithm. Supported options: 'random'.",
-                    "random",
-                    ParamValidators.inArray("random"));
+                    "batchStrategy",
+                    "Strategy to create mini batch from online train data.",
+                    COUNT_STRATEGY,
+                    ParamValidators.inArray(COUNT_STRATEGY));
 
-    default String getInitMode() {
-        return get(INIT_MODE);
-    }
-
-    default T setInitMode(String value) {
-        set(INIT_MODE, value);
-        return (T) this;
+    default String getBatchStrategy() {
+        return get(BATCH_STRATEGY);
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasDecayFactor.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasDecayFactor.java
@@ -16,33 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.clustering.kmeans;
+package org.apache.flink.ml.common.param;
 
-import org.apache.flink.ml.common.param.HasMaxIter;
-import org.apache.flink.ml.common.param.HasSeed;
+import org.apache.flink.ml.param.DoubleParam;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.param.ParamValidators;
-import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
 
-/**
- * Params of {@link KMeans}.
- *
- * @param <T> The class type of this instance.
- */
-public interface KMeansParams<T> extends HasSeed<T>, HasMaxIter<T>, KMeansModelParams<T> {
-    Param<String> INIT_MODE =
-            new StringParam(
-                    "initMode",
-                    "The initialization algorithm. Supported options: 'random'.",
-                    "random",
-                    ParamValidators.inArray("random"));
+/** Interface for the shared decay factor param. */
+public interface HasDecayFactor<T> extends WithParams<T> {
+    Param<Double> DECAY_FACTOR =
+            new DoubleParam(
+                    "decayFactor",
+                    "The forgetfulness of the previous centroids.",
+                    0.,
+                    ParamValidators.inRange(0, 1));
 
-    default String getInitMode() {
-        return get(INIT_MODE);
+    default double getDecayFactor() {
+        return get(DECAY_FACTOR);
     }
 
-    default T setInitMode(String value) {
-        set(INIT_MODE, value);
-        return (T) this;
+    default T setDecayFactor(Double value) {
+        return set(DECAY_FACTOR, value);
     }
 }

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/OnlineKMeansTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/OnlineKMeansTest.java
@@ -1,0 +1,498 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.clustering;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.ml.clustering.kmeans.KMeans;
+import org.apache.flink.ml.clustering.kmeans.KMeansModel;
+import org.apache.flink.ml.clustering.kmeans.KMeansModelData;
+import org.apache.flink.ml.clustering.kmeans.OnlineKMeans;
+import org.apache.flink.ml.clustering.kmeans.OnlineKMeansModel;
+import org.apache.flink.ml.common.distance.EuclideanDistanceMeasure;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
+import org.apache.flink.ml.util.InMemorySinkFunction;
+import org.apache.flink.ml.util.InMemorySourceFunction;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.testutils.InMemoryReporter;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.flink.ml.clustering.KMeansTest.groupFeaturesByPrediction;
+import static org.junit.Assert.assertEquals;
+
+/** Tests {@link OnlineKMeans} and {@link OnlineKMeansModel}. */
+public class OnlineKMeansTest extends TestLogger {
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private static final DenseVector[] trainData1 =
+            new DenseVector[] {
+                Vectors.dense(10.0, 0.0),
+                Vectors.dense(10.0, 0.3),
+                Vectors.dense(10.3, 0.0),
+                Vectors.dense(-10.0, 0.0),
+                Vectors.dense(-10.0, 0.6),
+                Vectors.dense(-10.6, 0.0)
+            };
+    private static final DenseVector[] trainData2 =
+            new DenseVector[] {
+                Vectors.dense(10.0, 100.0),
+                Vectors.dense(10.0, 100.3),
+                Vectors.dense(10.3, 100.0),
+                Vectors.dense(-10.0, -100.0),
+                Vectors.dense(-10.0, -100.6),
+                Vectors.dense(-10.6, -100.0)
+            };
+    private static final DenseVector[] predictData =
+            new DenseVector[] {
+                Vectors.dense(10.0, 10.0),
+                Vectors.dense(10.3, 10.0),
+                Vectors.dense(10.0, 10.3),
+                Vectors.dense(-10.0, 10.0),
+                Vectors.dense(-10.3, 10.0),
+                Vectors.dense(-10.0, 10.3)
+            };
+    private static final List<Set<DenseVector>> expectedGroups1 =
+            Arrays.asList(
+                    new HashSet<>(
+                            Arrays.asList(
+                                    Vectors.dense(10.0, 10.0),
+                                    Vectors.dense(10.3, 10.0),
+                                    Vectors.dense(10.0, 10.3))),
+                    new HashSet<>(
+                            Arrays.asList(
+                                    Vectors.dense(-10.0, 10.0),
+                                    Vectors.dense(-10.3, 10.0),
+                                    Vectors.dense(-10.0, 10.3))));
+    private static final List<Set<DenseVector>> expectedGroups2 =
+            Collections.singletonList(
+                    new HashSet<>(
+                            Arrays.asList(
+                                    Vectors.dense(10.0, 10.0),
+                                    Vectors.dense(10.3, 10.0),
+                                    Vectors.dense(10.0, 10.3),
+                                    Vectors.dense(-10.0, 10.0),
+                                    Vectors.dense(-10.3, 10.0),
+                                    Vectors.dense(-10.0, 10.3))));
+
+    private static final int defaultParallelism = 4;
+    private static final int numTaskManagers = 2;
+    private static final int numSlotsPerTaskManager = 2;
+
+    private int currentModelDataVersion;
+
+    private InMemorySourceFunction<DenseVector> trainSource;
+    private InMemorySourceFunction<DenseVector> predictSource;
+    private InMemorySinkFunction<Row> outputSink;
+    private InMemorySinkFunction<KMeansModelData> modelDataSink;
+
+    // TODO: creates static mini cluster once for whole test class after dependency upgrades to
+    // Flink 1.15.
+    private InMemoryReporter reporter;
+    private MiniCluster miniCluster;
+    private StreamExecutionEnvironment env;
+    private StreamTableEnvironment tEnv;
+
+    private Table offlineTrainTable;
+    private Table onlineTrainTable;
+    private Table onlinePredictTable;
+
+    @Before
+    public void before() throws Exception {
+        currentModelDataVersion = 0;
+
+        trainSource = new InMemorySourceFunction<>();
+        predictSource = new InMemorySourceFunction<>();
+        outputSink = new InMemorySinkFunction<>();
+        modelDataSink = new InMemorySinkFunction<>();
+
+        Configuration config = new Configuration();
+        config.set(RestOptions.BIND_PORT, "18081-19091");
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        reporter = InMemoryReporter.create();
+        reporter.addToConfiguration(config);
+
+        miniCluster =
+                new MiniCluster(
+                        new MiniClusterConfiguration.Builder()
+                                .setConfiguration(config)
+                                .setNumTaskManagers(numTaskManagers)
+                                .setNumSlotsPerTaskManager(numSlotsPerTaskManager)
+                                .build());
+        miniCluster.start();
+
+        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.setParallelism(defaultParallelism);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        tEnv = StreamTableEnvironment.create(env);
+
+        offlineTrainTable = tEnv.fromDataStream(env.fromElements(trainData1)).as("features");
+        onlineTrainTable =
+                tEnv.fromDataStream(env.addSource(trainSource, DenseVectorTypeInfo.INSTANCE))
+                        .as("features");
+        onlinePredictTable =
+                tEnv.fromDataStream(env.addSource(predictSource, DenseVectorTypeInfo.INSTANCE))
+                        .as("features");
+    }
+
+    @After
+    public void after() throws Exception {
+        miniCluster.close();
+    }
+
+    /**
+     * Performs transform() on the provided model with predictTable, and adds sinks for
+     * OnlineKMeansModel's transform output and model data.
+     */
+    private void transformAndOutputData(OnlineKMeansModel onlineModel) {
+        Table outputTable = onlineModel.transform(onlinePredictTable)[0];
+        tEnv.toDataStream(outputTable).addSink(outputSink);
+
+        Table modelDataTable = onlineModel.getModelData()[0];
+        KMeansModelData.getModelDataStream(modelDataTable).addSink(modelDataSink);
+    }
+
+    /** Blocks the thread until Model has set up init model data. */
+    private void waitInitModelDataSetup() throws InterruptedException {
+        while (reporter.findMetrics(OnlineKMeansModel.MODEL_DATA_VERSION_GAUGE_KEY).size()
+                < defaultParallelism) {
+            Thread.sleep(100);
+        }
+        waitModelDataUpdate();
+    }
+
+    /** Blocks the thread until the Model has received the next model-data-update event. */
+    @SuppressWarnings("unchecked")
+    private void waitModelDataUpdate() throws InterruptedException {
+        do {
+            int tmpModelDataVersion =
+                    reporter.findMetrics(OnlineKMeansModel.MODEL_DATA_VERSION_GAUGE_KEY).values()
+                            .stream()
+                            .map(x -> Integer.parseInt(((Gauge<String>) x).getValue()))
+                            .min(Integer::compareTo)
+                            .get();
+            if (tmpModelDataVersion == currentModelDataVersion) {
+                Thread.sleep(100);
+            } else {
+                currentModelDataVersion = tmpModelDataVersion;
+                break;
+            }
+        } while (true);
+    }
+
+    /**
+     * Inserts default predict data to the predict queue, fetches the prediction results, and
+     * asserts that the grouping result is as expected.
+     *
+     * @param expectedGroups A list containing sets of features, which is the expected group result
+     * @param featuresCol Name of the column in the table that contains the features
+     * @param predictionCol Name of the column in the table that contains the prediction result
+     */
+    private void predictAndAssert(
+            List<Set<DenseVector>> expectedGroups, String featuresCol, String predictionCol)
+            throws Exception {
+        predictSource.addAll(OnlineKMeansTest.predictData);
+        List<Row> rawResult = outputSink.poll(OnlineKMeansTest.predictData.length);
+        List<Set<DenseVector>> actualGroups =
+                groupFeaturesByPrediction(rawResult, featuresCol, predictionCol);
+        Assert.assertTrue(CollectionUtils.isEqualCollection(expectedGroups, actualGroups));
+    }
+
+    @Test
+    public void testParam() {
+        OnlineKMeans onlineKMeans = new OnlineKMeans();
+        Assert.assertEquals("features", onlineKMeans.getFeaturesCol());
+        Assert.assertEquals("prediction", onlineKMeans.getPredictionCol());
+        Assert.assertEquals("count", onlineKMeans.getBatchStrategy());
+        Assert.assertEquals(EuclideanDistanceMeasure.NAME, onlineKMeans.getDistanceMeasure());
+        Assert.assertEquals(32, onlineKMeans.getGlobalBatchSize());
+        Assert.assertEquals(0., onlineKMeans.getDecayFactor(), 1e-5);
+        Assert.assertEquals(OnlineKMeans.class.getName().hashCode(), onlineKMeans.getSeed());
+
+        onlineKMeans
+                .setFeaturesCol("test_feature")
+                .setPredictionCol("test_prediction")
+                .setGlobalBatchSize(5)
+                .setDecayFactor(0.25)
+                .setSeed(100);
+
+        Assert.assertEquals("test_feature", onlineKMeans.getFeaturesCol());
+        Assert.assertEquals("test_prediction", onlineKMeans.getPredictionCol());
+        Assert.assertEquals("count", onlineKMeans.getBatchStrategy());
+        Assert.assertEquals(EuclideanDistanceMeasure.NAME, onlineKMeans.getDistanceMeasure());
+        Assert.assertEquals(5, onlineKMeans.getGlobalBatchSize());
+        Assert.assertEquals(0.25, onlineKMeans.getDecayFactor(), 1e-5);
+        Assert.assertEquals(100, onlineKMeans.getSeed());
+    }
+
+    @Test
+    public void testFitAndPredict() throws Exception {
+        OnlineKMeans onlineKMeans =
+                new OnlineKMeans()
+                        .setFeaturesCol("features")
+                        .setPredictionCol("prediction")
+                        .setGlobalBatchSize(6)
+                        .setInitialModelData(
+                                KMeansModelData.generateRandomModelData(env, 2, 2, 0.0, 0));
+        OnlineKMeansModel onlineModel = onlineKMeans.fit(onlineTrainTable);
+        transformAndOutputData(onlineModel);
+
+        miniCluster.submitJob(env.getStreamGraph().getJobGraph());
+        waitInitModelDataSetup();
+
+        trainSource.addAll(trainData1);
+        waitModelDataUpdate();
+        predictAndAssert(
+                expectedGroups1, onlineKMeans.getFeaturesCol(), onlineKMeans.getPredictionCol());
+
+        trainSource.addAll(trainData2);
+        waitModelDataUpdate();
+        predictAndAssert(
+                expectedGroups2, onlineKMeans.getFeaturesCol(), onlineKMeans.getPredictionCol());
+    }
+
+    @Test
+    public void testInitWithKMeans() throws Exception {
+        KMeans kMeans = new KMeans().setFeaturesCol("features").setPredictionCol("prediction");
+        KMeansModel model = kMeans.fit(offlineTrainTable);
+
+        OnlineKMeans onlineKMeans =
+                new OnlineKMeans()
+                        .setFeaturesCol("features")
+                        .setPredictionCol("prediction")
+                        .setGlobalBatchSize(6)
+                        .setInitialModelData(model.getModelData()[0]);
+
+        OnlineKMeansModel onlineModel = onlineKMeans.fit(onlineTrainTable);
+        transformAndOutputData(onlineModel);
+
+        miniCluster.submitJob(env.getStreamGraph().getJobGraph());
+        waitInitModelDataSetup();
+        predictAndAssert(
+                expectedGroups1, onlineKMeans.getFeaturesCol(), onlineKMeans.getPredictionCol());
+
+        trainSource.addAll(trainData2);
+        waitModelDataUpdate();
+        predictAndAssert(
+                expectedGroups2, onlineKMeans.getFeaturesCol(), onlineKMeans.getPredictionCol());
+    }
+
+    @Test
+    public void testDecayFactor() throws Exception {
+        KMeans kMeans = new KMeans().setFeaturesCol("features").setPredictionCol("prediction");
+        KMeansModel model = kMeans.fit(offlineTrainTable);
+
+        OnlineKMeans onlineKMeans =
+                new OnlineKMeans()
+                        .setFeaturesCol("features")
+                        .setPredictionCol("prediction")
+                        .setGlobalBatchSize(6)
+                        .setDecayFactor(0.5)
+                        .setInitialModelData(model.getModelData()[0]);
+        OnlineKMeansModel onlineModel = onlineKMeans.fit(onlineTrainTable);
+        transformAndOutputData(onlineModel);
+
+        miniCluster.submitJob(env.getStreamGraph().getJobGraph());
+        modelDataSink.poll();
+
+        trainSource.addAll(trainData2);
+        KMeansModelData actualModelData = modelDataSink.poll();
+
+        KMeansModelData expectedModelData =
+                new KMeansModelData(
+                        new DenseVector[] {
+                            Vectors.dense(-10.2, -200.2 / 3), Vectors.dense(10.1, 200.3 / 3)
+                        },
+                        Vectors.dense(4.5, 4.5));
+
+        Assert.assertArrayEquals(
+                expectedModelData.weights.values, actualModelData.weights.values, 1e-5);
+        Assert.assertEquals(expectedModelData.centroids.length, actualModelData.centroids.length);
+        Arrays.sort(actualModelData.centroids, Comparator.comparingDouble(vector -> vector.get(0)));
+        for (int i = 0; i < expectedModelData.centroids.length; i++) {
+            Assert.assertArrayEquals(
+                    expectedModelData.centroids[i].values,
+                    actualModelData.centroids[i].values,
+                    1e-5);
+        }
+    }
+
+    @Test
+    public void testBatchSizeLessThanParallelism() {
+        OnlineKMeans onlineKMeans =
+                new OnlineKMeans()
+                        .setFeaturesCol("features")
+                        .setPredictionCol("prediction")
+                        .setGlobalBatchSize(2)
+                        .setInitialModelData(
+                                KMeansModelData.generateRandomModelData(env, 2, 2, 0.0, 0));
+
+        try {
+            onlineKMeans.fit(onlineTrainTable);
+            Assert.fail("Expected IllegalStateException");
+        } catch (Exception e) {
+            Throwable exception = e;
+            while (exception.getCause() != null) {
+                exception = exception.getCause();
+            }
+            assertEquals(IllegalStateException.class, exception.getClass());
+            assertEquals(
+                    "There are more subtasks in the training process than the number "
+                            + "of elements in each batch. Some subtasks might be idling forever.",
+                    exception.getMessage());
+        }
+    }
+
+    @Test
+    public void testSaveAndReload() throws Exception {
+        KMeans kMeans = new KMeans().setFeaturesCol("features").setPredictionCol("prediction");
+        KMeansModel model = kMeans.fit(offlineTrainTable);
+
+        OnlineKMeans onlineKMeans =
+                new OnlineKMeans()
+                        .setFeaturesCol("features")
+                        .setPredictionCol("prediction")
+                        .setGlobalBatchSize(6)
+                        .setInitialModelData(model.getModelData()[0]);
+
+        String savePath = tempFolder.newFolder().getAbsolutePath();
+        onlineKMeans.save(savePath);
+        miniCluster.executeJobBlocking(env.getStreamGraph().getJobGraph());
+        OnlineKMeans loadedOnlineKMeans = OnlineKMeans.load(env, savePath);
+
+        OnlineKMeansModel onlineModel = loadedOnlineKMeans.fit(onlineTrainTable);
+
+        String modelSavePath = tempFolder.newFolder().getAbsolutePath();
+        onlineModel.save(modelSavePath);
+        OnlineKMeansModel loadedOnlineModel = OnlineKMeansModel.load(env, modelSavePath);
+        loadedOnlineModel.setModelData(onlineModel.getModelData());
+
+        transformAndOutputData(loadedOnlineModel);
+
+        miniCluster.submitJob(env.getStreamGraph().getJobGraph());
+        waitInitModelDataSetup();
+        predictAndAssert(
+                expectedGroups1, onlineKMeans.getFeaturesCol(), onlineKMeans.getPredictionCol());
+
+        trainSource.addAll(trainData2);
+        waitModelDataUpdate();
+        predictAndAssert(
+                expectedGroups2, onlineKMeans.getFeaturesCol(), onlineKMeans.getPredictionCol());
+    }
+
+    @Test
+    public void testGetModelData() throws Exception {
+        OnlineKMeans onlineKMeans =
+                new OnlineKMeans()
+                        .setFeaturesCol("features")
+                        .setPredictionCol("prediction")
+                        .setGlobalBatchSize(6)
+                        .setInitialModelData(
+                                KMeansModelData.generateRandomModelData(env, 2, 2, 0.0, 0));
+        OnlineKMeansModel onlineModel = onlineKMeans.fit(onlineTrainTable);
+        transformAndOutputData(onlineModel);
+
+        miniCluster.submitJob(env.getStreamGraph().getJobGraph());
+        modelDataSink.poll();
+
+        trainSource.addAll(trainData1);
+        KMeansModelData actualModelData = modelDataSink.poll();
+
+        KMeansModelData expectedModelData =
+                new KMeansModelData(
+                        new DenseVector[] {Vectors.dense(-10.2, 0.2), Vectors.dense(10.1, 0.1)},
+                        Vectors.dense(3, 3));
+
+        Assert.assertArrayEquals(
+                expectedModelData.weights.values, actualModelData.weights.values, 1e-5);
+        Assert.assertEquals(expectedModelData.centroids.length, actualModelData.centroids.length);
+        Arrays.sort(actualModelData.centroids, Comparator.comparingDouble(vector -> vector.get(0)));
+        for (int i = 0; i < expectedModelData.centroids.length; i++) {
+            Assert.assertArrayEquals(
+                    expectedModelData.centroids[i].values,
+                    actualModelData.centroids[i].values,
+                    1e-5);
+        }
+    }
+
+    @Test
+    public void testSetModelData() throws Exception {
+        KMeansModelData modelData1 =
+                new KMeansModelData(
+                        new DenseVector[] {Vectors.dense(10.1, 0.1), Vectors.dense(-10.2, 0.2)},
+                        Vectors.dense(0.0, 0.0));
+
+        KMeansModelData modelData2 =
+                new KMeansModelData(
+                        new DenseVector[] {
+                            Vectors.dense(10.1, 100.1), Vectors.dense(-10.2, -100.2)
+                        },
+                        Vectors.dense(0.0, 0.0));
+
+        InMemorySourceFunction<KMeansModelData> modelDataSource = new InMemorySourceFunction<>();
+        Table modelDataTable =
+                tEnv.fromDataStream(
+                        env.addSource(modelDataSource, TypeInformation.of(KMeansModelData.class)));
+
+        OnlineKMeansModel onlineModel =
+                new OnlineKMeansModel()
+                        .setModelData(modelDataTable)
+                        .setFeaturesCol("features")
+                        .setPredictionCol("prediction");
+        transformAndOutputData(onlineModel);
+
+        miniCluster.submitJob(env.getStreamGraph().getJobGraph());
+
+        modelDataSource.addAll(modelData1);
+        waitInitModelDataSetup();
+        predictAndAssert(
+                expectedGroups1, onlineModel.getFeaturesCol(), onlineModel.getPredictionCol());
+
+        modelDataSource.addAll(modelData2);
+        waitModelDataUpdate();
+        predictAndAssert(
+                expectedGroups2, onlineModel.getFeaturesCol(), onlineModel.getPredictionCol());
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/util/InMemorySinkFunction.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/util/InMemorySinkFunction.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.util;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/** A {@link SinkFunction} implementation that makes all collected records available for tests. */
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class InMemorySinkFunction<T> extends RichSinkFunction<T> {
+    private static final Map<UUID, BlockingQueue> queueMap = new ConcurrentHashMap<>();
+    private final UUID id;
+    private BlockingQueue<T> queue;
+
+    public InMemorySinkFunction() {
+        id = UUID.randomUUID();
+        queue = new LinkedBlockingQueue();
+        queueMap.put(id, queue);
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        queue = queueMap.get(id);
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        queueMap.remove(id);
+    }
+
+    @Override
+    public void invoke(T value, Context context) {
+        if (!queue.offer(value)) {
+            throw new RuntimeException(
+                    "Failed to offer " + value + " to blocking queue " + id + ".");
+        }
+    }
+
+    public List<T> poll(int num) throws InterruptedException {
+        List<T> result = new ArrayList<>();
+        for (int i = 0; i < num; i++) {
+            result.add(poll());
+        }
+        return result;
+    }
+
+    public T poll() throws InterruptedException {
+        T value = queue.poll(1, TimeUnit.MINUTES);
+        if (value == null) {
+            throw new RuntimeException("Failed to poll next value from blocking queue.");
+        }
+        return value;
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/util/InMemorySourceFunction.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/util/InMemorySourceFunction.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.util;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/** A {@link SourceFunction} implementation that can directly receive records from tests. */
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class InMemorySourceFunction<T> extends RichSourceFunction<T> {
+    private static final Map<UUID, BlockingQueue> queueMap = new ConcurrentHashMap<>();
+    private final UUID id;
+    private BlockingQueue<Optional<T>> queue;
+    private volatile boolean isRunning = true;
+
+    public InMemorySourceFunction() {
+        id = UUID.randomUUID();
+        queue = new LinkedBlockingQueue();
+        queueMap.put(id, queue);
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        queue = queueMap.get(id);
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        queueMap.remove(id);
+    }
+
+    @Override
+    public void run(SourceContext<T> context) throws InterruptedException {
+        while (isRunning) {
+            Optional<T> maybeValue = queue.take();
+            if (!maybeValue.isPresent()) {
+                break;
+            }
+            context.collect(maybeValue.get());
+        }
+    }
+
+    @Override
+    public void cancel() {
+        isRunning = false;
+        queue.add(Optional.empty());
+    }
+
+    @SafeVarargs
+    public final void addAll(T... values) {
+        Preconditions.checkState(isRunning);
+        for (T value : values) {
+            queue.add(Optional.of(value));
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
This PR adds Estimator and Transformer for the Online KMeans operator.

Compared with the existing KMeans operator, Online KMeans allows to train KMeans model continuously from an unbounded train data stream. The corresponding Model operator also supports updating model data dynamically from a DataStream.

In order for Online KMeans to train incrementally based on offline KMeans's model, this PR modifies KMeans's model data format to add a weight property.

Besides, this PR also adds simple infrastructures needed to test online algorithms, which allows to control the order to consume train data and predict data, or to read metrics.

## Brief change log
- Adds `OnlineKMeans`, `OnlineKMeansModel` and `OnlineKMeansParams` class to support Online KMeans algorithm. Also adds `OnlineKMeansTest` class to test these classes.
- Adds `HasBatchStrategy` and `HasDecayFactor` interfaces to represent corresponding parameters for online algorithms.
- Adds `MockKVStore`, `MockMessageQueues`, `TestMetricReporter`, `MockSourceFunction` and `MockSinkFunction` to control the stream's velocity in online algorithm's test cases.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (Java doc)