### PR TITLE
[FLINK-26626] Add Transformer and Estimator for StandardScaler

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/DenseVector.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/DenseVector.java
@@ -68,4 +68,9 @@ public class DenseVector implements Vector {
     public int hashCode() {
         return Arrays.hashCode(values);
     }
+
+    @Override
+    public DenseVector clone() {
+        return new DenseVector(values.clone());
+    }
 }

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/SparseVector.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/SparseVector.java
@@ -165,4 +165,9 @@ public class SparseVector implements Vector {
                 "(" + n + ", " + Arrays.toString(indices) + ", " + Arrays.toString(values) + ")";
         return sbr;
     }
+
+    @Override
+    public SparseVector clone() {
+        return new SparseVector(n, indices.clone(), values.clone());
+    }
 }

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/BLASTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/BLASTest.java
@@ -38,9 +38,16 @@ public class BLASTest {
 
     @Test
     public void testAxpy() {
+        // Tests axpy(dense, dense).
         DenseVector anotherDenseVec = Vectors.dense(1, 2, 3, 4, 5);
         BLAS.axpy(1, inputDenseVec, anotherDenseVec);
         double[] expectedResult = new double[] {2, 0, 6, 8, 0};
+        assertArrayEquals(expectedResult, anotherDenseVec.values, TOLERANCE);
+
+        // Tests axpy(sparse, dense).
+        SparseVector sparseVec = Vectors.sparse(5, new int[] {0, 2, 4}, new double[] {1, 3, 5});
+        BLAS.axpy(2, sparseVec, anotherDenseVec);
+        expectedResult = new double[] {4, 0, 12, 8, 10};
         assertArrayEquals(expectedResult, anotherDenseVec.values, TOLERANCE);
     }
 
@@ -69,5 +76,35 @@ public class BLASTest {
         BLAS.gemv(-2.0, inputDenseMat, false, inputDenseVec, 0.0, anotherDenseVec);
         double[] expectedResult = new double[] {96.0, -60.0};
         assertArrayEquals(expectedResult, anotherDenseVec.values, TOLERANCE);
+    }
+
+    @Test
+    public void testHDot() {
+        // Tests hDot(sparse, sparse).
+        SparseVector sparseVec1 = Vectors.sparse(5, new int[] {0, 2, 3}, new double[] {1, 3, 5});
+        SparseVector sparseVec2 = Vectors.sparse(5, new int[] {0, 1, 4}, new double[] {1, 3, 5});
+        BLAS.hDot(sparseVec1, sparseVec2);
+        assertEquals(5, sparseVec2.size());
+        assertArrayEquals(new int[] {0, 1, 4}, sparseVec2.indices);
+        assertArrayEquals(new double[] {1, 0, 0}, sparseVec2.values, TOLERANCE);
+
+        // Tests hDot(dense, dense).
+        DenseVector denseVec1 = Vectors.dense(1, 2, 3, 4, 5);
+        DenseVector denseVec2 = Vectors.dense(1, 2, 3, 4, 5);
+        BLAS.hDot(denseVec1, denseVec2);
+        double[] expectedResult = new double[] {1, 4, 9, 16, 25};
+        assertArrayEquals(expectedResult, denseVec2.values, TOLERANCE);
+
+        // Tests hDot(sparse, dense).
+        BLAS.hDot(sparseVec1, denseVec1);
+        expectedResult = new double[] {1, 0, 9, 20, 0};
+        assertArrayEquals(expectedResult, denseVec1.values, TOLERANCE);
+
+        // Tests hDot(dense, sparse).
+        DenseVector denseVec3 = Vectors.dense(1, 2, 3, 4, 5);
+        BLAS.hDot(denseVec3, sparseVec1);
+        assertEquals(5, sparseVec1.size());
+        assertArrayEquals(new int[] {0, 2, 3}, sparseVec1.indices);
+        assertArrayEquals(new double[] {1, 9, 20}, sparseVec1.values, TOLERANCE);
     }
 }

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/DenseVectorTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/DenseVectorTest.java
@@ -18,25 +18,23 @@
 
 package org.apache.flink.ml.linalg;
 
-import java.io.Serializable;
+import org.junit.Test;
 
-/** A vector of double values. */
-public interface Vector extends Serializable {
+import static org.junit.Assert.assertArrayEquals;
 
-    /** Gets the size of the vector. */
-    int size();
+/** Tests the behavior of {@link DenseVector}. */
+public class DenseVectorTest {
 
-    /** Gets the value of the ith element. */
-    double get(int i);
+    private static final double TOLERANCE = 1e-7;
 
-    /** Converts the instance to a double array. */
-    double[] toArray();
+    @Test
+    public void testClone() {
+        DenseVector denseVec = Vectors.dense(1, 2, 3);
+        DenseVector clonedDenseVec = denseVec.clone();
+        assertArrayEquals(clonedDenseVec.values, new double[] {1, 2, 3}, TOLERANCE);
 
-    /** Converts the instance to a dense vector. */
-    default DenseVector toDense() {
-        return new DenseVector(toArray());
+        clonedDenseVec.values[0] = -1;
+        assertArrayEquals(denseVec.values, new double[] {1, 2, 3}, TOLERANCE);
+        assertArrayEquals(clonedDenseVec.values, new double[] {-1, 2, 3}, TOLERANCE);
     }
-
-    /** Makes a deep copy of the vector. */
-    Vector clone();
 }

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/SparseVectorTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/SparseVectorTest.java
@@ -32,8 +32,10 @@ import java.io.IOException;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-/** Tests the behavior of Vectors. */
+/** Tests the behavior of {@link SparseVector}. */
 public class SparseVectorTest {
+    private static final double TOLERANCE = 1e-7;
+
     @Test
     public void testConstructor() {
         int n = 4;
@@ -128,5 +130,21 @@ public class SparseVectorTest {
         assertEquals(vector.n, vector2.n);
         assertArrayEquals(vector.indices, vector2.indices);
         assertArrayEquals(vector.values, vector2.values, 1e-5);
+    }
+
+    @Test
+    public void testClone() {
+        SparseVector sparseVec = Vectors.sparse(3, new int[] {0, 2}, new double[] {1, 3});
+        SparseVector clonedSparseVec = sparseVec.clone();
+        assertEquals(3, clonedSparseVec.size());
+        assertArrayEquals(clonedSparseVec.indices, new int[] {0, 2});
+        assertArrayEquals(clonedSparseVec.values, new double[] {1, 3}, TOLERANCE);
+
+        clonedSparseVec.values[0] = -1;
+        assertEquals(sparseVec.size(), clonedSparseVec.size());
+        assertArrayEquals(sparseVec.indices, new int[] {0, 2});
+        assertArrayEquals(sparseVec.values, new double[] {1, 3}, TOLERANCE);
+        assertArrayEquals(clonedSparseVec.indices, new int[] {0, 2});
+        assertArrayEquals(clonedSparseVec.values, new double[] {-1, 3}, TOLERANCE);
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasInputCol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasInputCol.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared inputCol param. */
+public interface HasInputCol<T> extends WithParams<T> {
+    Param<String> INPUT_COL =
+            new StringParam("inputCol", "Input column name.", "input", ParamValidators.notNull());
+
+    default String getInputCol() {
+        return get(INPUT_COL);
+    }
+
+    default T setInputCol(String value) {
+        return set(INPUT_COL, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/minmaxscaler/MinMaxScalerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/minmaxscaler/MinMaxScalerParams.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.ml.feature.minmaxscaler;
 
-import org.apache.flink.ml.common.param.HasFeaturesCol;
-import org.apache.flink.ml.common.param.HasPredictionCol;
+import org.apache.flink.ml.common.param.HasInputCol;
+import org.apache.flink.ml.common.param.HasOutputCol;
 import org.apache.flink.ml.param.DoubleParam;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.param.ParamValidators;
@@ -29,7 +29,7 @@ import org.apache.flink.ml.param.ParamValidators;
  *
  * @param <T> The class type of this instance.
  */
-public interface MinMaxScalerParams<T> extends HasFeaturesCol<T>, HasPredictionCol<T> {
+public interface MinMaxScalerParams<T> extends HasInputCol<T>, HasOutputCol<T> {
     Param<Double> MIN =
             new DoubleParam(
                     "min",

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScaler.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScaler.java
@@ -84,7 +84,7 @@ public class StandardScaler
                                         TypeInformation.of(DenseVector.class),
                                         TypeInformation.of(DenseVector.class),
                                         BasicTypeInfo.LONG_TYPE_INFO),
-                                new ComputeMetaOperator(getFeaturesCol()));
+                                new ComputeMetaOperator(getInputCol()));
 
         DataStream<StandardScalerModelData> modelData =
                 sumAndSquaredSumAndWeight
@@ -206,10 +206,10 @@ public class StandardScaler
         private DenseVector squaredSum;
         private long numElements;
 
-        private final String featuresCol;
+        private final String inputCol;
 
-        public ComputeMetaOperator(String featuresCol) {
-            this.featuresCol = featuresCol;
+        public ComputeMetaOperator(String inputCol) {
+            this.inputCol = inputCol;
         }
 
         @Override
@@ -220,15 +220,15 @@ public class StandardScaler
         }
 
         @Override
-        public void processElement(StreamRecord<Row> element) throws Exception {
-            Vector feature = (Vector) element.getValue().getField(featuresCol);
+        public void processElement(StreamRecord<Row> element) {
+            Vector inputVec = (Vector) element.getValue().getField(inputCol);
             if (numElements == 0) {
-                sum = new DenseVector(feature.size());
-                squaredSum = new DenseVector(feature.size());
+                sum = new DenseVector(inputVec.size());
+                squaredSum = new DenseVector(inputVec.size());
             }
-            BLAS.axpy(1, feature, sum);
-            BLAS.hDot(feature, feature);
-            BLAS.axpy(1, feature, squaredSum);
+            BLAS.axpy(1, inputVec, sum);
+            BLAS.hDot(inputVec, inputVec);
+            BLAS.axpy(1, inputVec, squaredSum);
             numElements++;
         }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScaler.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScaler.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.standardscaler;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.iteration.operator.OperatorStateUtils;
+import org.apache.flink.ml.api.Estimator;
+import org.apache.flink.ml.linalg.BLAS;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An Estimator which implements the standard scaling algorithm.
+ *
+ * <p>Standardization is a common requirement for machine learning training because they may behave
+ * badly if the individual features of a input do not look like standard normally distributed data
+ * (e.g. Gaussian with 0 mean and unit variance).
+ *
+ * <p>This estimator standardizes the input features by removing the mean and scaling each dimension
+ * to unit variance.
+ */
+public class StandardScaler
+        implements Estimator<StandardScaler, StandardScalerModel>,
+                StandardScalerParams<StandardScaler> {
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public StandardScaler() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public StandardScalerModel fit(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<Tuple3<DenseVector, DenseVector, Long>> sumAndSquaredSumAndWeight =
+                tEnv.toDataStream(inputs[0])
+                        .transform(
+                                "computeMeta",
+                                new TupleTypeInfo<>(
+                                        TypeInformation.of(DenseVector.class),
+                                        TypeInformation.of(DenseVector.class),
+                                        BasicTypeInfo.LONG_TYPE_INFO),
+                                new ComputeMetaOperator(getFeaturesCol()));
+
+        DataStream<StandardScalerModelData> modelData =
+                sumAndSquaredSumAndWeight
+                        .transform(
+                                "buildModel",
+                                TypeInformation.of(StandardScalerModelData.class),
+                                new BuildModelOperator())
+                        .setParallelism(1);
+
+        StandardScalerModel model =
+                new StandardScalerModel().setModelData(tEnv.fromDataStream(modelData));
+        ReadWriteUtils.updateExistingParams(model, paramMap);
+        return model;
+    }
+
+    /**
+     * Builds the {@link StandardScalerModelData} using the meta data computed on each partition.
+     */
+    private static class BuildModelOperator extends AbstractStreamOperator<StandardScalerModelData>
+            implements OneInputStreamOperator<
+                            Tuple3<DenseVector, DenseVector, Long>, StandardScalerModelData>,
+                    BoundedOneInput {
+        private ListState<DenseVector> sumState;
+        private ListState<DenseVector> squaredSumState;
+        private ListState<Long> numElementsState;
+        private DenseVector sum;
+        private DenseVector squaredSum;
+        private long numElements;
+
+        @Override
+        public void endInput() {
+            if (numElements > 0) {
+                BLAS.scal(1.0 / numElements, sum);
+                double[] mean = sum.values;
+                double[] std = squaredSum.values;
+                if (numElements > 1) {
+                    for (int i = 0; i < mean.length; i++) {
+                        std[i] =
+                                Math.sqrt(
+                                        (squaredSum.values[i] - numElements * mean[i] * mean[i])
+                                                / (numElements - 1));
+                    }
+                } else {
+                    Arrays.fill(std, 0.0);
+                }
+
+                output.collect(
+                        new StreamRecord<>(
+                                new StandardScalerModelData(
+                                        Vectors.dense(mean), Vectors.dense(std))));
+            } else {
+                throw new RuntimeException("The training set is empty.");
+            }
+        }
+
+        @Override
+        public void processElement(StreamRecord<Tuple3<DenseVector, DenseVector, Long>> element) {
+            Tuple3<DenseVector, DenseVector, Long> value = element.getValue();
+            if (numElements == 0) {
+                sum = value.f0;
+                squaredSum = value.f1;
+                numElements = value.f2;
+            } else {
+                BLAS.axpy(1, value.f0, sum);
+                BLAS.axpy(1, value.f1, squaredSum);
+                numElements += value.f2;
+            }
+        }
+
+        @Override
+        public void initializeState(StateInitializationContext context) throws Exception {
+            super.initializeState(context);
+            sumState =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>(
+                                            "sumState", TypeInformation.of(DenseVector.class)));
+            squaredSumState =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>(
+                                            "squaredSumState",
+                                            TypeInformation.of(DenseVector.class)));
+            numElementsState =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>(
+                                            "numElementsState", BasicTypeInfo.LONG_TYPE_INFO));
+
+            sum = OperatorStateUtils.getUniqueElement(sumState, "sumState").orElse(null);
+            squaredSum =
+                    OperatorStateUtils.getUniqueElement(squaredSumState, "squaredSumState")
+                            .orElse(null);
+            numElements =
+                    OperatorStateUtils.getUniqueElement(numElementsState, "numElementsState")
+                            .orElse(0L);
+        }
+
+        @Override
+        public void snapshotState(StateSnapshotContext context) throws Exception {
+            super.snapshotState(context);
+            if (numElements > 0) {
+                sumState.update(Collections.singletonList(sum));
+                squaredSumState.update(Collections.singletonList(squaredSum));
+                numElementsState.update(Collections.singletonList(numElements));
+            }
+        }
+    }
+
+    /** Computes sum, squared sum and number of elements in each partition. */
+    private static class ComputeMetaOperator
+            extends AbstractStreamOperator<Tuple3<DenseVector, DenseVector, Long>>
+            implements OneInputStreamOperator<Row, Tuple3<DenseVector, DenseVector, Long>>,
+                    BoundedOneInput {
+        private ListState<DenseVector> sumState;
+        private ListState<DenseVector> squaredSumState;
+        private ListState<Long> numElementsState;
+        private DenseVector sum;
+        private DenseVector squaredSum;
+        private long numElements;
+
+        private final String featuresCol;
+
+        public ComputeMetaOperator(String featuresCol) {
+            this.featuresCol = featuresCol;
+        }
+
+        @Override
+        public void endInput() {
+            if (numElements > 0) {
+                output.collect(new StreamRecord<>(Tuple3.of(sum, squaredSum, numElements)));
+            }
+        }
+
+        @Override
+        public void processElement(StreamRecord<Row> element) throws Exception {
+            Vector feature = (Vector) element.getValue().getField(featuresCol);
+            if (numElements == 0) {
+                sum = new DenseVector(feature.size());
+                squaredSum = new DenseVector(feature.size());
+            }
+            BLAS.axpy(1, feature, sum);
+            BLAS.hDot(feature, feature);
+            BLAS.axpy(1, feature, squaredSum);
+            numElements++;
+        }
+
+        @Override
+        public void initializeState(StateInitializationContext context) throws Exception {
+            super.initializeState(context);
+            sumState =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>(
+                                            "sumState", TypeInformation.of(DenseVector.class)));
+            squaredSumState =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>(
+                                            "squaredSumState",
+                                            TypeInformation.of(DenseVector.class)));
+            numElementsState =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>(
+                                            "numElementsState", BasicTypeInfo.LONG_TYPE_INFO));
+
+            sum = OperatorStateUtils.getUniqueElement(sumState, "sumState").orElse(null);
+            squaredSum =
+                    OperatorStateUtils.getUniqueElement(squaredSumState, "squaredSumState")
+                            .orElse(null);
+            numElements =
+                    OperatorStateUtils.getUniqueElement(numElementsState, "numElementsState")
+                            .orElse(0L);
+        }
+
+        @Override
+        public void snapshotState(StateSnapshotContext context) throws Exception {
+            super.snapshotState(context);
+            if (numElements > 0) {
+                sumState.update(Collections.singletonList(sum));
+                squaredSumState.update(Collections.singletonList(squaredSum));
+                numElementsState.update(Collections.singletonList(numElements));
+            }
+        }
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+
+    public static StandardScaler load(StreamTableEnvironment tEnv, String path) throws IOException {
+        return ReadWriteUtils.loadStageParam(path);
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerModel.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.standardscaler;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.api.Model;
+import org.apache.flink.ml.common.broadcast.BroadcastUtils;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.linalg.BLAS;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/** A Model which transforms data using the model data computed by {@link StandardScaler}. */
+public class StandardScalerModel
+        implements Model<StandardScalerModel>, StandardScalerParams<StandardScalerModel> {
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+    private Table modelDataTable;
+
+    public StandardScalerModel() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked, rawtypes")
+    public Table[] transform(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<Row> inputStream = tEnv.toDataStream(inputs[0]);
+
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(
+                                inputTypeInfo.getFieldTypes(), TypeInformation.of(Vector.class)),
+                        ArrayUtils.addAll(inputTypeInfo.getFieldNames(), getPredictionCol()));
+
+        final String broadcastModelKey = "broadcastModelKey";
+        DataStream<StandardScalerModelData> modelDataStream =
+                StandardScalerModelData.getModelDataStream(modelDataTable);
+
+        DataStream<Row> predictionResult =
+                BroadcastUtils.withBroadcastStream(
+                        Collections.singletonList(inputStream),
+                        Collections.singletonMap(broadcastModelKey, modelDataStream),
+                        inputList -> {
+                            DataStream inputData = inputList.get(0);
+                            return inputData.map(
+                                    new PredictOutputFunction(
+                                            broadcastModelKey,
+                                            getFeaturesCol(),
+                                            getWithMean(),
+                                            getWithStd()),
+                                    outputTypeInfo);
+                        });
+
+        return new Table[] {tEnv.fromDataStream(predictionResult)};
+    }
+
+    /** A utility function used for prediction. */
+    private static class PredictOutputFunction extends RichMapFunction<Row, Row> {
+        private final String broadcastModelKey;
+        private final String featuresCol;
+        private final boolean withMean;
+        private final boolean withStd;
+        private DenseVector mean;
+        private DenseVector scale;
+
+        public PredictOutputFunction(
+                String broadcastModelKey, String featuresCol, boolean withMean, boolean withStd) {
+            this.broadcastModelKey = broadcastModelKey;
+            this.featuresCol = featuresCol;
+            this.withMean = withMean;
+            this.withStd = withStd;
+        }
+
+        @Override
+        public Row map(Row dataPoint) {
+            if (mean == null) {
+                StandardScalerModelData modelData =
+                        (StandardScalerModelData)
+                                getRuntimeContext().getBroadcastVariable(broadcastModelKey).get(0);
+                mean = modelData.mean;
+                DenseVector std = modelData.std;
+
+                if (withStd) {
+                    scale = std;
+                    double[] scaleValues = scale.values;
+                    for (int i = 0; i < scaleValues.length; i++) {
+                        scaleValues[i] = scaleValues[i] == 0 ? 0 : 1 / scaleValues[i];
+                    }
+                }
+            }
+
+            Vector output = ((Vector) (dataPoint.getField(featuresCol))).clone();
+            if (withMean) {
+                output = output.toDense();
+                BLAS.axpy(-1, mean, (DenseVector) output);
+            }
+            if (withStd) {
+                BLAS.hDot(scale, output);
+            }
+
+            return Row.join(dataPoint, Row.of(output));
+        }
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+        ReadWriteUtils.saveModelData(
+                StandardScalerModelData.getModelDataStream(modelDataTable),
+                path,
+                new StandardScalerModelData.ModelDataEncoder());
+    }
+
+    public static StandardScalerModel load(StreamTableEnvironment tEnv, String path)
+            throws IOException {
+        StandardScalerModel model = ReadWriteUtils.loadStageParam(path);
+        Table modelDataTable =
+                ReadWriteUtils.loadModelData(
+                        tEnv, path, new StandardScalerModelData.ModelDataDecoder());
+        return model.setModelData(modelDataTable);
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    @Override
+    public StandardScalerModel setModelData(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        modelDataTable = inputs[0];
+        return this;
+    }
+
+    @Override
+    public Table[] getModelData() {
+        return new Table[] {modelDataTable};
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerModelData.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.standardscaler;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.reader.SimpleStreamFormat;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorSerializer;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Model data of {@link StandardScalerModel}.
+ *
+ * <p>This class also provides methods to convert model data from Table to Datastream, and classes
+ * to save/load model data.
+ */
+public class StandardScalerModelData {
+    /** Mean of each dimension. */
+    public DenseVector mean;
+    /** Standard deviation of each dimension. */
+    public DenseVector std;
+
+    public StandardScalerModelData() {}
+
+    public StandardScalerModelData(DenseVector mean, DenseVector std) {
+        this.mean = mean;
+        this.std = std;
+    }
+
+    /**
+     * Converts the table model to a data stream.
+     *
+     * @param modelData The table model data.
+     * @return The data stream model data.
+     */
+    public static DataStream<StandardScalerModelData> getModelDataStream(Table modelData) {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) modelData).getTableEnvironment();
+
+        return tEnv.toDataStream(modelData)
+                .map(
+                        (MapFunction<Row, StandardScalerModelData>)
+                                row ->
+                                        new StandardScalerModelData(
+                                                (DenseVector) row.getField("mean"),
+                                                (DenseVector) row.getField("std")));
+    }
+
+    /** Data encoder for the {@link StandardScalerModel} model data. */
+    public static class ModelDataEncoder implements Encoder<StandardScalerModelData> {
+        @Override
+        public void encode(StandardScalerModelData modelData, OutputStream outputStream)
+                throws IOException {
+            DataOutputViewStreamWrapper outputViewStreamWrapper =
+                    new DataOutputViewStreamWrapper(outputStream);
+
+            DenseVectorSerializer.INSTANCE.serialize(modelData.mean, outputViewStreamWrapper);
+            DenseVectorSerializer.INSTANCE.serialize(modelData.std, outputViewStreamWrapper);
+        }
+    }
+
+    /** Data decoder for the {@link StandardScalerModel} model data. */
+    public static class ModelDataDecoder extends SimpleStreamFormat<StandardScalerModelData> {
+        @Override
+        public Reader<StandardScalerModelData> createReader(
+                Configuration configuration, FSDataInputStream inputStream) {
+            return new Reader<StandardScalerModelData>() {
+
+                @Override
+                public StandardScalerModelData read() throws IOException {
+                    DataInputViewStreamWrapper inputViewStreamWrapper =
+                            new DataInputViewStreamWrapper(inputStream);
+
+                    try {
+                        DenseVector mean =
+                                DenseVectorSerializer.INSTANCE.deserialize(inputViewStreamWrapper);
+                        DenseVector std =
+                                DenseVectorSerializer.INSTANCE.deserialize(inputViewStreamWrapper);
+                        return new StandardScalerModelData(mean, std);
+                    } catch (EOFException e) {
+                        return null;
+                    }
+                }
+
+                @Override
+                public void close() throws IOException {
+                    inputStream.close();
+                }
+            };
+        }
+
+        @Override
+        public TypeInformation<StandardScalerModelData> getProducedType() {
+            return TypeInformation.of(StandardScalerModelData.class);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerParams.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.standardscaler;
+
+import org.apache.flink.ml.common.param.HasFeaturesCol;
+import org.apache.flink.ml.common.param.HasPredictionCol;
+import org.apache.flink.ml.param.BooleanParam;
+import org.apache.flink.ml.param.Param;
+
+/**
+ * Params for {@link StandardScaler}.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface StandardScalerParams<T> extends HasFeaturesCol<T>, HasPredictionCol<T> {
+    Param<Boolean> WITH_MEAN =
+            new BooleanParam(
+                    "withMean", "Whether centers the data with mean before scaling.", false);
+
+    Param<Boolean> WITH_STD =
+            new BooleanParam("withStd", "Whether scales the data with standard deviation.", true);
+
+    default Boolean getWithMean() {
+        return get(WITH_MEAN);
+    }
+
+    default T setWithMean(boolean withMean) {
+        return set(WITH_MEAN, withMean);
+    }
+
+    default Boolean getWithStd() {
+        return get(WITH_STD);
+    }
+
+    default T setWithStd(boolean withMean) {
+        return set(WITH_STD, withMean);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerParams.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.ml.feature.standardscaler;
 
-import org.apache.flink.ml.common.param.HasFeaturesCol;
-import org.apache.flink.ml.common.param.HasPredictionCol;
+import org.apache.flink.ml.common.param.HasInputCol;
+import org.apache.flink.ml.common.param.HasOutputCol;
 import org.apache.flink.ml.param.BooleanParam;
 import org.apache.flink.ml.param.Param;
 
@@ -28,7 +28,7 @@ import org.apache.flink.ml.param.Param;
  *
  * @param <T> The class type of this instance.
  */
-public interface StandardScalerParams<T> extends HasFeaturesCol<T>, HasPredictionCol<T> {
+public interface StandardScalerParams<T> extends HasInputCol<T>, HasOutputCol<T> {
     Param<Boolean> WITH_MEAN =
             new BooleanParam(
                     "withMean", "Whether centers the data with mean before scaling.", false);

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/KnnTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/KnnTest.java
@@ -149,7 +149,7 @@ public class KnnTest {
     }
 
     @Test
-    public void testFeaturePredictionParam() throws Exception {
+    public void testOutputSchema() throws Exception {
         Knn knn =
                 new Knn()
                         .setLabelCol("test_label")

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/LogisticRegressionTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/LogisticRegressionTest.java
@@ -191,7 +191,7 @@ public class LogisticRegressionTest {
     }
 
     @Test
-    public void testFeaturePredictionParam() {
+    public void testOutputSchema() {
         Table tempTable = binomialDataTable.as("test_features", "test_label", "test_weight");
         LogisticRegression logisticRegression =
                 new LogisticRegression()

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/NaiveBayesTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/NaiveBayesTest.java
@@ -170,7 +170,7 @@ public class NaiveBayesTest {
     }
 
     @Test
-    public void testFeaturePredictionParam() {
+    public void testOutputSchema() {
         trainTable = trainTable.as("test_features", "test_label");
         predictTable = predictTable.as("test_features");
 

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/KMeansTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/KMeansTest.java
@@ -148,7 +148,7 @@ public class KMeansTest extends AbstractTestBase {
     }
 
     @Test
-    public void testFeaturePredictionParam() {
+    public void testOutputSchema() {
         Table input = dataTable.as("test_feature");
         KMeans kmeans =
                 new KMeans().setFeaturesCol("test_feature").setPredictionCol("test_prediction");

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/MinMaxScalerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/MinMaxScalerTest.java
@@ -134,7 +134,7 @@ public class MinMaxScalerTest {
     }
 
     @Test
-    public void testFeaturePredictionParam() {
+    public void testOutputSchema() {
         MinMaxScaler minMaxScaler =
                 new MinMaxScaler()
                         .setFeaturesCol("test_features")

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/StandardScalerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/StandardScalerTest.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.feature.standardscaler.StandardScaler;
+import org.apache.flink.ml.feature.standardscaler.StandardScalerModel;
+import org.apache.flink.ml.feature.standardscaler.StandardScalerModelData;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.StageTestUtils;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/** Tests {@link StandardScaler} and {@link StandardScalerModel}. */
+public class StandardScalerTest extends AbstractTestBase {
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+    private StreamExecutionEnvironment env;
+    private StreamTableEnvironment tEnv;
+    private Table denseTable;
+
+    private final List<Row> denseInput =
+            Arrays.asList(
+                    Row.of(Vectors.dense(-2.5, 9, 1)),
+                    Row.of(Vectors.dense(1.4, -5, 1)),
+                    Row.of(Vectors.dense(2, -1, -2)));
+
+    private final List<DenseVector> expectedResWithMean =
+            Arrays.asList(
+                    Vectors.dense(-2.8, 8, 1),
+                    Vectors.dense(1.1, -6, 1),
+                    Vectors.dense(1.7, -2, -2));
+
+    private final List<DenseVector> expectedResWithStd =
+            Arrays.asList(
+                    Vectors.dense(-1.0231819, 1.2480754, 0.5773502),
+                    Vectors.dense(0.5729819, -0.6933752, 0.5773503),
+                    Vectors.dense(0.8185455, -0.1386750, -1.1547005));
+
+    private final List<DenseVector> expectedResWithMeanAndStd =
+            Arrays.asList(
+                    Vectors.dense(-1.1459637, 1.1094004, 0.5773503),
+                    Vectors.dense(0.45020003, -0.8320503, 0.5773503),
+                    Vectors.dense(0.69576368, -0.2773501, -1.1547005));
+
+    private final double[] expectedMean = new double[] {0.3, 1, 0};
+    private final double[] expectedStd = new double[] {2.4433583, 7.2111026, 1.7320508};
+    private static final double TOLERANCE = 1e-7;
+
+    @Before
+    public void before() {
+        Configuration config = new Configuration();
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.setParallelism(4);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        tEnv = StreamTableEnvironment.create(env);
+        denseTable = tEnv.fromDataStream(env.fromCollection(denseInput)).as("features");
+    }
+
+    @SuppressWarnings("unchecked")
+    private void verifyPredictionResult(
+            List<DenseVector> expectedOutput, Table output, String predictionCol) throws Exception {
+        List<Row> collectedResult =
+                IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
+        List<DenseVector> predictions = new ArrayList<>(collectedResult.size());
+
+        for (Row r : collectedResult) {
+            Vector vec = (Vector) r.getField(predictionCol);
+            predictions.add(vec.toDense());
+        }
+
+        assertEquals(expectedOutput.size(), predictions.size());
+
+        predictions.sort(
+                (vec1, vec2) -> {
+                    int size = Math.min(vec1.size(), vec2.size());
+                    for (int i = 0; i < size; i++) {
+                        int cmp = Double.compare(vec1.get(i), vec2.get(i));
+                        if (cmp != 0) {
+                            return cmp;
+                        }
+                    }
+                    return 0;
+                });
+
+        for (int i = 0; i < predictions.size(); i++) {
+            assertArrayEquals(expectedOutput.get(i).values, predictions.get(i).values, TOLERANCE);
+        }
+    }
+
+    @Test
+    public void testParam() {
+        StandardScaler standardScaler = new StandardScaler();
+
+        assertEquals("features", standardScaler.getFeaturesCol());
+        assertEquals(false, standardScaler.getWithMean());
+        assertEquals(true, standardScaler.getWithStd());
+        assertEquals("prediction", standardScaler.getPredictionCol());
+
+        standardScaler
+                .setFeaturesCol("test_features")
+                .setWithMean(true)
+                .setWithStd(false)
+                .setPredictionCol("test_prediction");
+
+        assertEquals("test_features", standardScaler.getFeaturesCol());
+        assertEquals(true, standardScaler.getWithMean());
+        assertEquals(false, standardScaler.getWithStd());
+        assertEquals("test_prediction", standardScaler.getPredictionCol());
+    }
+
+    @Test
+    public void testFeaturePredictionParam() {
+        Table tempTable = denseTable.as("test_features");
+        StandardScaler standardScaler =
+                new StandardScaler()
+                        .setFeaturesCol("test_features")
+                        .setPredictionCol("test_prediction");
+        Table output = standardScaler.fit(tempTable).transform(tempTable)[0];
+
+        assertEquals(
+                Arrays.asList("test_features", "test_prediction"),
+                output.getResolvedSchema().getColumnNames());
+    }
+
+    @Test
+    public void testFitAndPredictWithStd() throws Exception {
+        StandardScaler standardScaler = new StandardScaler();
+        Table output = standardScaler.fit(denseTable).transform(denseTable)[0];
+        verifyPredictionResult(expectedResWithStd, output, standardScaler.getPredictionCol());
+    }
+
+    @Test
+    public void testFitAndPredictWithMean() throws Exception {
+        StandardScaler standardScaler = new StandardScaler().setWithStd(false).setWithMean(true);
+        Table output = standardScaler.fit(denseTable).transform(denseTable)[0];
+        verifyPredictionResult(expectedResWithMean, output, standardScaler.getPredictionCol());
+    }
+
+    @Test
+    public void testFitAndPredictWithMeanAndStd() throws Exception {
+        StandardScaler standardScaler = new StandardScaler().setWithMean(true);
+        Table output = standardScaler.fit(denseTable).transform(denseTable)[0];
+        verifyPredictionResult(
+                expectedResWithMeanAndStd, output, standardScaler.getPredictionCol());
+    }
+
+    @Test
+    public void testSaveLoadAndPredict() throws Exception {
+        StandardScaler standardScaler = new StandardScaler();
+        standardScaler =
+                StageTestUtils.saveAndReload(
+                        tEnv, standardScaler, tempFolder.newFolder().getAbsolutePath());
+
+        StandardScalerModel model = standardScaler.fit(denseTable);
+        model = StageTestUtils.saveAndReload(tEnv, model, tempFolder.newFolder().getAbsolutePath());
+
+        assertEquals(
+                Arrays.asList("mean", "std"),
+                model.getModelData()[0].getResolvedSchema().getColumnNames());
+
+        Table output = model.transform(denseTable)[0];
+        verifyPredictionResult(expectedResWithStd, output, standardScaler.getPredictionCol());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetModelData() throws Exception {
+        StandardScaler standardScaler = new StandardScaler();
+        StandardScalerModel model = standardScaler.fit(denseTable);
+        Table modelDataTable = model.getModelData()[0];
+
+        assertEquals(
+                Arrays.asList("mean", "std"), modelDataTable.getResolvedSchema().getColumnNames());
+
+        List<StandardScalerModelData> collectedModelData =
+                (List<StandardScalerModelData>)
+                        IteratorUtils.toList(
+                                StandardScalerModelData.getModelDataStream(modelDataTable)
+                                        .executeAndCollect());
+        assertEquals(1, collectedModelData.size());
+
+        StandardScalerModelData modelData = collectedModelData.get(0);
+        assertArrayEquals(expectedMean, modelData.mean.values, TOLERANCE);
+        assertArrayEquals(expectedStd, modelData.std.values, TOLERANCE);
+    }
+
+    @Test
+    public void testSetModelData() throws Exception {
+        StandardScaler standardScaler = new StandardScaler();
+        StandardScalerModel model = standardScaler.fit(denseTable);
+
+        StandardScalerModel newModel = new StandardScalerModel();
+        ReadWriteUtils.updateExistingParams(newModel, model.getParamMap());
+        newModel.setModelData(model.getModelData());
+        Table output = newModel.transform(denseTable)[0];
+
+        verifyPredictionResult(expectedResWithStd, output, standardScaler.getPredictionCol());
+    }
+
+    @Test
+    public void testSparseInput() throws Exception {
+        final List<Row> sparseInput =
+                Arrays.asList(
+                        Row.of(Vectors.sparse(3, new int[] {0, 1}, new double[] {-2.5, 1})),
+                        Row.of(Vectors.sparse(3, new int[] {1, 2}, new double[] {2, -2})),
+                        Row.of(Vectors.sparse(3, new int[] {0, 2}, new double[] {1.4, 1})));
+        Table sparseTable = tEnv.fromDataStream(env.fromCollection(sparseInput)).as("features");
+
+        final List<DenseVector> expectedResWithStd =
+                Arrays.asList(
+                        Vectors.dense(-1.2653836, 1, 0),
+                        Vectors.dense(0, 2, -1.30930734),
+                        Vectors.dense(0.7086148, 0, 0.6546537));
+        StandardScaler standardScaler = new StandardScaler();
+        Table output = standardScaler.fit(sparseTable).transform(sparseTable)[0];
+
+        verifyPredictionResult(expectedResWithStd, output, standardScaler.getPredictionCol());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testFitOnEmptyData() throws Exception {
+        Table emptyTable =
+                tEnv.fromDataStream(env.fromCollection(denseInput).filter(x -> x.getArity() == 0))
+                        .as("features");
+        StandardScalerModel model = new StandardScaler().fit(emptyTable);
+        Table modelDataTable = model.getModelData()[0];
+        try {
+            IteratorUtils.toList(
+                    StandardScalerModelData.getModelDataStream(modelDataTable).executeAndCollect());
+            fail();
+        } catch (Throwable e) {
+            while (e.getCause() != null) {
+                e = e.getCause();
+            }
+            assertEquals("The training set is empty.", e.getMessage());
+        }
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/StandardScalerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/StandardScalerTest.java
@@ -149,7 +149,7 @@ public class StandardScalerTest extends AbstractTestBase {
     }
 
     @Test
-    public void testFeaturePredictionParam() {
+    public void testOutputSchema() {
         Table tempTable = denseTable.as("test_features");
         StandardScaler standardScaler =
                 new StandardScaler()

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/IndexToStringModelTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/IndexToStringModelTest.java
@@ -81,7 +81,7 @@ public class IndexToStringModelTest extends AbstractTestBase {
     }
 
     @Test
-    public void testPredictParam() {
+    public void testOutputSchema() {
         IndexToStringModel indexToStringModel =
                 new IndexToStringModel()
                         .setInputCols("inputCol1", "inputCol2")

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/StringIndexerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/StringIndexerTest.java
@@ -96,7 +96,7 @@ public class StringIndexerTest extends AbstractTestBase {
     }
 
     @Test
-    public void testFitParam() {
+    public void testParam() {
         StringIndexer stringIndexer = new StringIndexer();
         assertEquals(stringIndexer.getStringOrderType(), StringIndexerParams.ARBITRARY_ORDER);
         assertEquals(stringIndexer.getHandleInvalid(), StringIndexerParams.ERROR_INVALID);
@@ -114,7 +114,7 @@ public class StringIndexerTest extends AbstractTestBase {
     }
 
     @Test
-    public void testPredictParam() {
+    public void testOutputSchema() {
         StringIndexer stringIndexer =
                 new StringIndexer()
                         .setInputCols("inputCol1", "inputCol2")


### PR DESCRIPTION
## What is the purpose of the change
- Add Transformer and Estimator of StandardScaler in FlinkML. Standardization is a common requirement for machine learning training because they may behave badly if the individual features of a input do not look like standard normally distributed data (e.g. Gaussian with 0 mean and unit variance).

## Brief change log
- Add StandardScaler.
- Add StandardScalerModel.
- Add unit test for the proposed functionalities.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (Java doc)