### PR TITLE
[FLINK-26100] Add link to document website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,34 @@
-Flink ML is a library which provides machine learning (ML) APIs and infrastructures that simplify the building of ML pipelines. Users can implement ML algorithms with the standard ML APIs and further use these infrastructures to build ML pipelines for both training and inference jobs.
+Flink ML is a library which provides machine learning (ML) APIs and
+infrastructures that simplify the building of ML pipelines. Users can implement
+ML algorithms with the standard ML APIs and further use these infrastructures to
+build ML pipelines for both training and inference jobs.
 
-Flink ML is developed under the umbrella of [Apache Flink](https://flink.apache.org/).
+Flink ML is developed under the umbrella of [Apache
+Flink](https://flink.apache.org/).
 
 ## <a name="build"></a>Building the Project
 
 Run the `mvn clean package` command.
 
-Then you will find a JAR file that contains your application, plus any libraries that you may have added as dependencies to the application: `target/<artifact-id>-<version>.jar`.
+Then you will find a JAR file that contains your application, plus any libraries
+that you may have added as dependencies to the application:
+`target/<artifact-id>-<version>.jar`.
+
+## <a name="documentation"></a>Documentation
+
+The documentation of Flink ML is located on the website:
+https://nightlies.apache.org/flink/flink-ml-docs-master/ or in the docs/
+directory of the source code.
 
 ## <a name="contributing"></a>Contributing
 
-You can learn more about how to contribute in the [Apache Flink website](https://flink.apache.org/contributing/how-to-contribute.html). For code contributions, please read carefully the [Contributing Code](https://flink.apache.org/contributing/contribute-code.html) section for an overview of ongoing community work.
+You can learn more about how to contribute in the [Apache Flink
+website](https://flink.apache.org/contributing/how-to-contribute.html). For code
+contributions, please read carefully the [Contributing
+Code](https://flink.apache.org/contributing/contribute-code.html) section for an
+overview of ongoing community work.
 
 ## <a name="license"></a>License
 
-The code in this repository is licensed under the [Apache Software License 2](LICENSE).
+The code in this repository is licensed under the [Apache Software License
+2](LICENSE).


### PR DESCRIPTION
This PR adds a link to Flink ML's document website in README.md. The added content is referenced from Flink repo's README.