### PR TITLE
[FLINK-27072] Add Transformer for Bucketizer

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/param/ArrayArrayParam.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/param/ArrayArrayParam.java
@@ -16,16 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.feature.stringindexer;
+package org.apache.flink.ml.param;
 
-import org.apache.flink.ml.common.param.HasHandleInvalid;
-import org.apache.flink.ml.common.param.HasInputCols;
-import org.apache.flink.ml.common.param.HasOutputCols;
+import org.apache.flink.ml.util.ReadWriteUtils;
 
-/**
- * Params of {@link StringIndexerModel}.
- *
- * @param <T> The class type of this instance.
- */
-public interface StringIndexerModelParams<T>
-        extends HasInputCols<T>, HasOutputCols<T>, HasHandleInvalid<T> {}
+import java.io.IOException;
+
+/** Class for the array parameter. */
+public class ArrayArrayParam<T> extends Param<T[][]> {
+
+    public ArrayArrayParam(
+            String name,
+            Class<T[][]> clazz,
+            String description,
+            T[][] defaultValue,
+            ParamValidator<T[][]> validator) {
+        super(name, clazz, description, defaultValue, validator);
+    }
+
+    @Override
+    public T[][] jsonDecode(Object json) throws IOException {
+        String jsonStr = ReadWriteUtils.OBJECT_MAPPER.writeValueAsString(json);
+        return ReadWriteUtils.OBJECT_MAPPER.readValue(jsonStr, clazz);
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/param/ArrayParam.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/param/ArrayParam.java
@@ -22,7 +22,7 @@ import org.apache.flink.ml.util.ReadWriteUtils;
 
 import java.io.IOException;
 
-/** Class for array-type parameters. */
+/** Class for the array parameter. */
 public class ArrayParam<T> extends Param<T[]> {
 
     public ArrayParam(

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/param/DoubleArrayArrayParam.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/param/DoubleArrayArrayParam.java
@@ -16,16 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.feature.stringindexer;
+package org.apache.flink.ml.param;
 
-import org.apache.flink.ml.common.param.HasHandleInvalid;
-import org.apache.flink.ml.common.param.HasInputCols;
-import org.apache.flink.ml.common.param.HasOutputCols;
+/** Class for the array of double array parameter. */
+public class DoubleArrayArrayParam extends ArrayArrayParam<Double> {
 
-/**
- * Params of {@link StringIndexerModel}.
- *
- * @param <T> The class type of this instance.
- */
-public interface StringIndexerModelParams<T>
-        extends HasInputCols<T>, HasOutputCols<T>, HasHandleInvalid<T> {}
+    public DoubleArrayArrayParam(
+            String name,
+            String description,
+            Double[][] defaultValue,
+            ParamValidator<Double[][]> validator) {
+        super(name, Double[][].class, description, defaultValue, validator);
+    }
+
+    public DoubleArrayArrayParam(String name, String description, Double[][] defaultValue) {
+        this(name, description, defaultValue, ParamValidators.alwaysTrue());
+    }
+}

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/api/StageTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/api/StageTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.ml.api;
 
 import org.apache.flink.ml.param.BooleanParam;
+import org.apache.flink.ml.param.DoubleArrayArrayParam;
 import org.apache.flink.ml.param.DoubleArrayParam;
 import org.apache.flink.ml.param.DoubleParam;
 import org.apache.flink.ml.param.FloatArrayParam;
@@ -99,6 +100,12 @@ public class StageTest {
 
         Param<String[]> STRING_ARRAY_PARAM =
                 new StringArrayParam("stringArrayParam", "Description", new String[] {"14", "15"});
+
+        Param<Double[][]> DOUBLE_ARRAY_ARRAY_PARAM =
+                new DoubleArrayArrayParam(
+                        "doubleArrayArrayParam",
+                        "Description",
+                        new Double[][] {new Double[] {14.0, 15.0}, new Double[] {16.0, 17.0}});
     }
 
     /**
@@ -317,6 +324,15 @@ public class StageTest {
 
         stage.set(MyParams.STRING_ARRAY_PARAM, new String[] {"50", "51"});
         Assert.assertArrayEquals(new String[] {"50", "51"}, stage.get(MyParams.STRING_ARRAY_PARAM));
+
+        stage.set(
+                MyParams.DOUBLE_ARRAY_ARRAY_PARAM,
+                new Double[][] {new Double[] {50.0, 51.0}, new Double[] {52.0, 53.0}});
+        Assert.assertEquals(2, stage.get(MyParams.DOUBLE_ARRAY_ARRAY_PARAM).length);
+        Assert.assertArrayEquals(
+                new Double[] {50.0, 51.0}, stage.get(MyParams.DOUBLE_ARRAY_ARRAY_PARAM)[0]);
+        Assert.assertArrayEquals(
+                new Double[] {52.0, 53.0}, stage.get(MyParams.DOUBLE_ARRAY_ARRAY_PARAM)[1]);
     }
 
     @Test
@@ -338,6 +354,9 @@ public class StageTest {
         stage.set(MyParams.FLOAT_ARRAY_PARAM, new Float[] {50.0f, 51.0f});
         stage.set(MyParams.DOUBLE_ARRAY_PARAM, new Double[] {50.0, 51.0});
         stage.set(MyParams.STRING_ARRAY_PARAM, new String[] {"50", "51"});
+        stage.set(
+                MyParams.DOUBLE_ARRAY_ARRAY_PARAM,
+                new Double[][] {new Double[] {50.0, 51.0}, new Double[] {52.0, 53.0}});
 
         Stage<?> loadedStage = validateStageSaveLoad(tEnv, stage, Collections.emptyMap());
 
@@ -357,6 +376,11 @@ public class StageTest {
                 new Double[] {50.0, 51.0}, loadedStage.get(MyParams.DOUBLE_ARRAY_PARAM));
         Assert.assertArrayEquals(
                 new String[] {"50", "51"}, loadedStage.get(MyParams.STRING_ARRAY_PARAM));
+        Assert.assertEquals(2, stage.get(MyParams.DOUBLE_ARRAY_ARRAY_PARAM).length);
+        Assert.assertArrayEquals(
+                new Double[] {50.0, 51.0}, stage.get(MyParams.DOUBLE_ARRAY_ARRAY_PARAM)[0]);
+        Assert.assertArrayEquals(
+                new Double[] {52.0, 53.0}, stage.get(MyParams.DOUBLE_ARRAY_ARRAY_PARAM)[1]);
     }
 
     @Test

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasHandleInvalid.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasHandleInvalid.java
@@ -32,18 +32,21 @@ import org.apache.flink.ml.param.WithParams;
  * <ul>
  *   <li>error: raise an exception.
  *   <li>skip: filter out rows with bad values.
+ *   <li>keep: keep bad rows according to a specific rule. Check out each algorithm for detail
+ *       rules.
  * </ul>
  */
 public interface HasHandleInvalid<T> extends WithParams<T> {
     String ERROR_INVALID = "error";
     String SKIP_INVALID = "skip";
+    String KEEP_INVALID = "keep";
 
     Param<String> HANDLE_INVALID =
             new StringParam(
                     "handleInvalid",
                     "Strategy to handle invalid entries.",
                     ERROR_INVALID,
-                    ParamValidators.inArray(ERROR_INVALID, SKIP_INVALID));
+                    ParamValidators.inArray(ERROR_INVALID, SKIP_INVALID, KEEP_INVALID));
 
     default String getHandleInvalid() {
         return get(HANDLE_INVALID);

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasHandleInvalid.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasHandleInvalid.java
@@ -32,8 +32,7 @@ import org.apache.flink.ml.param.WithParams;
  * <ul>
  *   <li>error: raise an exception.
  *   <li>skip: filter out rows with bad values.
- *   <li>keep: keep bad rows according to a specific rule. Check out each algorithm for detail
- *       rules.
+ *   <li>keep: keep bad rows according to a specific rule. Check out each algorithm for details.
  * </ul>
  */
 public interface HasHandleInvalid<T> extends WithParams<T> {

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/bucketizer/Bucketizer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/bucketizer/Bucketizer.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.bucketizer;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.api.Transformer;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.common.param.HasHandleInvalid;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Bucketizer is a transformer that maps multiple columns of continuous features to multiple columns
+ * of discrete features, i.e., buckets indices. The indices are in [0, numSplitsInThisColumn - 1].
+ *
+ * <p>The `keep` option of {@link HasHandleInvalid} means that we put the invalid data in the last
+ * bucket of the splits, whose index is the number of the buckets.
+ */
+public class Bucketizer implements Transformer<Bucketizer>, BucketizerParams<Bucketizer> {
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public Bucketizer() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public Table[] transform(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        String[] inputCols = getInputCols();
+        String[] outputCols = getOutputCols();
+        Double[][] splitsArray = getSplitsArray();
+        Preconditions.checkArgument(inputCols.length == outputCols.length);
+        Preconditions.checkArgument(inputCols.length == splitsArray.length);
+
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+        TypeInformation<?>[] outputTypes = new TypeInformation[outputCols.length];
+        Arrays.fill(outputTypes, BasicTypeInfo.INT_TYPE_INFO);
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(inputTypeInfo.getFieldTypes(), outputTypes),
+                        ArrayUtils.addAll(inputTypeInfo.getFieldNames(), getOutputCols()));
+
+        DataStream<Row> result =
+                tEnv.toDataStream(inputs[0])
+                        .flatMap(
+                                new FindBucketFunction(inputCols, splitsArray, getHandleInvalid()),
+                                outputTypeInfo);
+        return new Table[] {tEnv.fromDataStream(result)};
+    }
+
+    /** Finds the bucket index for each continuous feature of an input data point. */
+    private static class FindBucketFunction implements FlatMapFunction<Row, Row> {
+        private final String[] inputCols;
+        private final String handleInvalid;
+        private final Double[][] splitsArray;
+
+        public FindBucketFunction(
+                String[] inputCols, Double[][] splitsArray, String handleInvalid) {
+            this.inputCols = inputCols;
+            this.splitsArray = splitsArray;
+            this.handleInvalid = handleInvalid;
+        }
+
+        @Override
+        public void flatMap(Row value, Collector<Row> out) {
+            Row outputRow = new Row(inputCols.length);
+
+            for (int i = 0; i < inputCols.length; i++) {
+                double feature = ((Number) value.getField(inputCols[i])).doubleValue();
+                Double[] splits = splitsArray[i];
+                boolean isInvalid = false;
+
+                if (!Double.isNaN(feature)) {
+                    int index = Arrays.binarySearch(splits, feature);
+                    if (index >= 0) {
+                        if (index == inputCols.length - 1) {
+                            index--;
+                        }
+                        outputRow.setField(i, index);
+                    } else {
+                        index = -index - 1;
+                        if (index == 0 || index == inputCols.length) {
+                            isInvalid = true;
+                        } else {
+                            outputRow.setField(i, index - 1);
+                        }
+                    }
+                } else {
+                    isInvalid = true;
+                }
+
+                if (isInvalid) {
+                    switch (handleInvalid) {
+                        case ERROR_INVALID:
+                            throw new RuntimeException(
+                                    "The input contains invalid value. See "
+                                            + HANDLE_INVALID
+                                            + " parameter for more options.");
+                        case SKIP_INVALID:
+                            return;
+                        case KEEP_INVALID:
+                            outputRow.setField(i, splits.length - 1);
+                            break;
+                        default:
+                            throw new UnsupportedOperationException(
+                                    "Unsupported " + HANDLE_INVALID + " type: " + handleInvalid);
+                    }
+                }
+            }
+            out.collect(Row.join(value, outputRow));
+        }
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+
+    public static Bucketizer load(StreamTableEnvironment tEnv, String path) throws IOException {
+        return ReadWriteUtils.loadStageParam(path);
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/bucketizer/BucketizerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/bucketizer/BucketizerParams.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.bucketizer;
+
+import org.apache.flink.ml.common.param.HasHandleInvalid;
+import org.apache.flink.ml.common.param.HasInputCols;
+import org.apache.flink.ml.common.param.HasOutputCols;
+import org.apache.flink.ml.param.DoubleArrayArrayParam;
+import org.apache.flink.ml.param.ParamValidator;
+
+/**
+ * Params for {@link Bucketizer}.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface BucketizerParams<T>
+        extends HasInputCols<T>, HasOutputCols<T>, HasHandleInvalid<T> {
+    /**
+     * The array of split points for mapping continuous features into buckets for multiple columns.
+     *
+     * <p>Each input column is supposed to be mapped into {numberOfSplitPoints - 1} buckets. A
+     * bucket is defined by two split points. For example, bucket(x,y) contains values in the range
+     * [x,y). An exception is that the last bucket also contains y. The array should contain at
+     * least three split points and be strictly increasing.
+     */
+    DoubleArrayArrayParam SPLITS_ARRAY =
+            new DoubleArrayArrayParam(
+                    "splitsArray",
+                    "Array of split points for mapping continuous features into buckets.",
+                    null,
+                    new SplitsArrayValidator());
+
+    default Double[][] getSplitsArray() {
+        return get(SPLITS_ARRAY);
+    }
+
+    default T setSplitsArray(Double[][] value) {
+        set(SPLITS_ARRAY, value);
+        return (T) this;
+    }
+
+    /** Param validator for splitsArray. */
+    class SplitsArrayValidator implements ParamValidator<Double[][]> {
+
+        @Override
+        public boolean validate(Double[][] splitsArray) {
+            if (null == splitsArray || splitsArray.length == 0) {
+                return false;
+            }
+            for (Double[] splits : splitsArray) {
+                if (splits.length < 3) {
+                    return false;
+                }
+                for (int j = 1; j < splits.length; j++) {
+                    if (splits[j] <= splits[j - 1]) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoder.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoder.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.functions.MapPartitionFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.ml.api.Estimator;
 import org.apache.flink.ml.common.datastream.DataStreamUtils;
-import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
@@ -59,7 +58,7 @@ public class OneHotEncoder
     @Override
     public OneHotEncoderModel fit(Table... inputs) {
         Preconditions.checkArgument(inputs.length == 1);
-        Preconditions.checkArgument(getHandleInvalid().equals(HasHandleInvalid.ERROR_INVALID));
+        Preconditions.checkArgument(getHandleInvalid().equals(ERROR_INVALID));
 
         final String[] inputCols = getInputCols();
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoder.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoder.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.functions.MapPartitionFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.ml.api.Estimator;
 import org.apache.flink.ml.common.datastream.DataStreamUtils;
+import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
@@ -43,6 +44,9 @@ import java.util.Map;
  *
  * <p>Data of selected input columns should be indexed numbers in order for OneHotEncoder to
  * function correctly.
+ *
+ * <p>The `keep` and `skip` option of {@link HasHandleInvalid} is not supported in {@link
+ * OneHotEncoderParams}.
  *
  * <p>See https://en.wikipedia.org/wiki/One-hot.
  */

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoderModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoderModel.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.ml.api.Model;
 import org.apache.flink.ml.common.broadcast.BroadcastUtils;
 import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.linalg.Vectors;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
@@ -50,6 +51,9 @@ import java.util.function.Function;
 /**
  * A Model which encodes data into one-hot format using the model data computed by {@link
  * OneHotEncoder}.
+ *
+ * <p>The `keep` and `skip` option of {@link HasHandleInvalid} is not supported in {@link
+ * OneHotEncoderParams}.
  */
 public class OneHotEncoderModel
         implements Model<OneHotEncoderModel>, OneHotEncoderParams<OneHotEncoderModel> {

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoderModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoderModel.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.ml.api.Model;
 import org.apache.flink.ml.common.broadcast.BroadcastUtils;
 import org.apache.flink.ml.common.datastream.TableUtils;
-import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.linalg.Vectors;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
@@ -68,7 +67,7 @@ public class OneHotEncoderModel
         final boolean dropLast = getDropLast();
         final String broadcastModelKey = "OneHotModelStream";
 
-        Preconditions.checkArgument(getHandleInvalid().equals(HasHandleInvalid.ERROR_INVALID));
+        Preconditions.checkArgument(getHandleInvalid().equals(ERROR_INVALID));
         Preconditions.checkArgument(inputs.length == 1);
         Preconditions.checkArgument(inputCols.length == outputCols.length);
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoderParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoderParams.java
@@ -27,6 +27,9 @@ import org.apache.flink.ml.param.Param;
 /**
  * Params of OneHotEncoderModel.
  *
+ * <p>The `keep` and `skip` option of {@link HasHandleInvalid} is not supported in {@link
+ * OneHotEncoderParams}.
+ *
  * @param <T> The class type of this instance.
  */
 public interface OneHotEncoderParams<T>

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoderParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoderParams.java
@@ -27,9 +27,6 @@ import org.apache.flink.ml.param.Param;
 /**
  * Params of OneHotEncoderModel.
  *
- * <p>The `keep` and `skip` option of {@link HasHandleInvalid} is not supported in {@link
- * OneHotEncoderParams}.
- *
  * @param <T> The class type of this instance.
  */
 public interface OneHotEncoderParams<T>

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexer.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.ml.api.Estimator;
 import org.apache.flink.ml.common.datastream.DataStreamUtils;
+import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
@@ -54,6 +55,9 @@ import java.util.Map;
  * <p>The input columns are cast to string if they are numeric values. By default, the output model
  * is arbitrarily ordered. Users can control this by setting {@link
  * StringIndexerParams#STRING_ORDER_TYPE}.
+ *
+ * <p>The `keep` option of {@link HasHandleInvalid} means that we put the invalid entries in a
+ * special bucket, whose index is the number of distinct values in this column.
  */
 public class StringIndexer
         implements Estimator<StringIndexer, StringIndexerModel>,

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexer.java
@@ -141,27 +141,31 @@ public class StringIndexer
             for (int i = 0; i < stringsAndCntsByColumn.length; i++) {
                 List<Tuple2<String, Long>> stringsAndCnts = stringsAndCntsByColumn[i];
                 switch (stringOrderType) {
-                    case StringIndexerParams.ALPHABET_ASC_ORDER:
+                    case ALPHABET_ASC_ORDER:
                         stringsAndCnts.sort(Comparator.comparing(valAndCnt -> valAndCnt.f0));
                         break;
-                    case StringIndexerParams.ALPHABET_DESC_ORDER:
+                    case ALPHABET_DESC_ORDER:
                         stringsAndCnts.sort(
                                 (valAndCnt1, valAndCnt2) ->
                                         -valAndCnt1.f0.compareTo(valAndCnt2.f0));
                         break;
-                    case StringIndexerParams.FREQUENCY_ASC_ORDER:
+                    case FREQUENCY_ASC_ORDER:
                         stringsAndCnts.sort(Comparator.comparing(valAndCnt -> valAndCnt.f1));
                         break;
-                    case StringIndexerParams.FREQUENCY_DESC_ORDER:
+                    case FREQUENCY_DESC_ORDER:
                         stringsAndCnts.sort(
                                 (valAndCnt1, valAndCnt2) ->
                                         -valAndCnt1.f1.compareTo(valAndCnt2.f1));
                         break;
-                    case StringIndexerParams.ARBITRARY_ORDER:
+                    case ARBITRARY_ORDER:
                         break;
                     default:
-                        throw new IllegalStateException(
-                                "Unsupported string order type: " + stringOrderType);
+                        throw new UnsupportedOperationException(
+                                "Unsupported "
+                                        + STRING_ORDER_TYPE
+                                        + " type: "
+                                        + stringOrderType
+                                        + ".");
                 }
 
                 stringArrays[i] = new String[stringsAndCnts.size()];

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerModel.java
@@ -176,19 +176,21 @@ public class StringIndexerModel
                     outputIndices.setField(i, modelDataMap[i].get(stringVal));
                 } else {
                     switch (handleInValid) {
-                        case StringIndexerModelParams.SKIP_INVALID:
+                        case SKIP_INVALID:
                             return;
-                        case StringIndexerModelParams.ERROR_INVALID:
+                        case ERROR_INVALID:
                             throw new RuntimeException(
                                     "The input contains unseen string: "
                                             + stringVal
-                                            + ". See handleInvalid parameter for more options.");
-                        case StringIndexerModelParams.KEEP_INVALID:
+                                            + ". See "
+                                            + HANDLE_INVALID
+                                            + " parameter for more options.");
+                        case KEEP_INVALID:
                             outputIndices.setField(i, modelDataMap[i].size());
                             break;
                         default:
-                            throw new IllegalStateException(
-                                    "Unsupported types of handling invalid data: " + handleInValid);
+                            throw new UnsupportedOperationException(
+                                    "Unsupported " + HANDLE_INVALID + "type: " + handleInValid);
                     }
                 }
             }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerModel.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.ml.api.Model;
 import org.apache.flink.ml.common.broadcast.BroadcastUtils;
 import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
@@ -47,6 +48,9 @@ import java.util.Map;
 /**
  * A Model which transforms input string/numeric column(s) to integer column(s) using the model data
  * computed by {@link StringIndexer}.
+ *
+ * <p>The `keep` option of {@link HasHandleInvalid} means that we put the invalid entries in a
+ * special bucket, whose index is the number of distinct values in this column.
  */
 public class StringIndexerModel
         implements Model<StringIndexerModel>, StringIndexerModelParams<StringIndexerModel> {

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerModelParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerModelParams.java
@@ -18,45 +18,17 @@
 
 package org.apache.flink.ml.feature.stringindexer;
 
+import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.common.param.HasInputCols;
 import org.apache.flink.ml.common.param.HasOutputCols;
-import org.apache.flink.ml.param.Param;
-import org.apache.flink.ml.param.ParamValidators;
-import org.apache.flink.ml.param.StringParam;
 
 /**
  * Params of {@link StringIndexerModel}.
  *
+ * <p>The `keep` option of {@link HasHandleInvalid} means that we put the invalid entries in a
+ * special bucket, whose index is the number of distinct values in this column.
+ *
  * @param <T> The class type of this instance.
  */
-public interface StringIndexerModelParams<T> extends HasInputCols<T>, HasOutputCols<T> {
-    String ERROR_INVALID = "error";
-    String SKIP_INVALID = "skip";
-    String KEEP_INVALID = "keep";
-
-    /**
-     * Supported options and the corresponding behavior to handle invalid entries in
-     * StringIndexerModel are listed as follows.
-     *
-     * <ul>
-     *   <li>error: raise an exception.
-     *   <li>skip: filter out rows with bad values.
-     *   <li>keep: put the invalid entries in a special bucket, whose index is the number of
-     *       distinct values in this column.
-     * </ul>
-     */
-    Param<String> HANDLE_INVALID =
-            new StringParam(
-                    "handleInvalid",
-                    "Strategy to handle invalid entries.",
-                    ERROR_INVALID,
-                    ParamValidators.inArray(ERROR_INVALID, SKIP_INVALID, KEEP_INVALID));
-
-    default String getHandleInvalid() {
-        return get(HANDLE_INVALID);
-    }
-
-    default T setHandleInvalid(String value) {
-        return set(HANDLE_INVALID, value);
-    }
-}
+public interface StringIndexerModelParams<T>
+        extends HasInputCols<T>, HasOutputCols<T>, HasHandleInvalid<T> {}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssembler.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssembler.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.ml.api.Transformer;
 import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.linalg.DenseVector;
 import org.apache.flink.ml.linalg.SparseVector;
 import org.apache.flink.ml.linalg.Vector;
@@ -47,6 +48,9 @@ import java.util.Map;
 /**
  * A feature transformer that combines a given list of input columns into a vector column. Types of
  * input columns must be either vector or numerical value.
+ *
+ * <p>The `keep` option of {@link HasHandleInvalid} means that we output bad rows with output column
+ * set to null.
  */
 public class VectorAssembler
         implements Transformer<VectorAssembler>, VectorAssemblerParams<VectorAssembler> {

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssembler.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssembler.java
@@ -97,16 +97,16 @@ public class VectorAssembler
                 out.collect(Row.join(value, Row.of(assembledVector)));
             } catch (Exception e) {
                 switch (handleInvalid) {
-                    case VectorAssemblerParams.ERROR_INVALID:
+                    case ERROR_INVALID:
                         throw e;
-                    case VectorAssemblerParams.SKIP_INVALID:
+                    case SKIP_INVALID:
                         return;
-                    case VectorAssemblerParams.KEEP_INVALID:
+                    case KEEP_INVALID:
                         out.collect(Row.join(value, Row.of((Object) null)));
                         return;
                     default:
                         throw new UnsupportedOperationException(
-                                "handleInvalid=" + handleInvalid + " is not supported");
+                                "Unsupported " + HANDLE_INVALID + " type: " + handleInvalid);
                 }
             }
         }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssemblerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssemblerParams.java
@@ -25,9 +25,6 @@ import org.apache.flink.ml.common.param.HasOutputCol;
 /**
  * Params of VectorAssembler.
  *
- * <p>The `keep` option of {@link HasHandleInvalid} means that we output bad rows with output column
- * set to null.
- *
  * @param <T> The class type of this instance.
  */
 public interface VectorAssemblerParams<T>

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssemblerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssemblerParams.java
@@ -18,46 +18,17 @@
 
 package org.apache.flink.ml.feature.vectorassembler;
 
+import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.common.param.HasInputCols;
 import org.apache.flink.ml.common.param.HasOutputCol;
-import org.apache.flink.ml.param.Param;
-import org.apache.flink.ml.param.ParamValidators;
-import org.apache.flink.ml.param.StringParam;
 
 /**
  * Params of VectorAssembler.
  *
+ * <p>The `keep` option of {@link HasHandleInvalid} means that we output bad rows with output column
+ * set to null.
+ *
  * @param <T> The class type of this instance.
  */
-public interface VectorAssemblerParams<T> extends HasInputCols<T>, HasOutputCol<T> {
-
-    String ERROR_INVALID = "error";
-    String SKIP_INVALID = "skip";
-    String KEEP_INVALID = "keep";
-
-    /**
-     * Supported options and the corresponding behavior to handle invalid entries is listed as
-     * follows.
-     *
-     * <ul>
-     *   <li>error: raise an exception.
-     *   <li>skip: filter out rows with bad values.
-     *   <li>keep: output bad rows with output column's value set to null.
-     * </ul>
-     */
-    Param<String> HANDLE_INVALID =
-            new StringParam(
-                    "handleInvalid",
-                    "Strategy to handle invalid entries.",
-                    ERROR_INVALID,
-                    ParamValidators.inArray(ERROR_INVALID, SKIP_INVALID, KEEP_INVALID));
-
-    default String getHandleInvalid() {
-        return get(HANDLE_INVALID);
-    }
-
-    default T setHandleInvalid(String value) {
-        set(HANDLE_INVALID, value);
-        return (T) this;
-    }
-}
+public interface VectorAssemblerParams<T>
+        extends HasInputCols<T>, HasOutputCol<T>, HasHandleInvalid<T> {}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/LogisticRegressionTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/LogisticRegressionTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
 
 import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -275,10 +276,10 @@ public class LogisticRegressionTest {
             new LogisticRegression().fit(multinomialDataTable);
             env.execute();
             fail();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             assertEquals(
                     "Multinomial classification is not supported yet. Supported options: [auto, binomial].",
-                    e.getCause().getCause().getMessage());
+                    ExceptionUtils.getRootCause(e).getMessage());
         }
     }
 

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/NaiveBayesTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/NaiveBayesTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -198,10 +199,7 @@ public class NaiveBayesTest {
             outputTable.execute().collect().next();
             Assert.fail("Expected NullPointerException");
         } catch (Exception e) {
-            Throwable exception = e;
-            while (exception.getCause() != null) {
-                exception = exception.getCause();
-            }
+            Throwable exception = ExceptionUtils.getRootCause(e);
             assertEquals(
                     NaiveBayesModel.class.getName(), exception.getStackTrace()[0].getClassName());
             assertEquals("calculateProb", exception.getStackTrace()[0].getMethodName());
@@ -226,10 +224,7 @@ public class NaiveBayesTest {
             outputTable.execute().collect().next();
             Assert.fail("Expected IllegalArgumentException");
         } catch (Exception e) {
-            Throwable exception = e;
-            while (exception.getCause() != null) {
-                exception = exception.getCause();
-            }
+            Throwable exception = ExceptionUtils.getRootCause(e);
             assertEquals(IllegalArgumentException.class, exception.getClass());
             assertEquals("Feature vectors should be of equal length.", exception.getMessage());
         }
@@ -249,10 +244,7 @@ public class NaiveBayesTest {
             outputTable.execute().collect().next();
             Assert.fail("Expected IllegalArgumentException");
         } catch (Exception e) {
-            Throwable exception = e;
-            while (exception.getCause() != null) {
-                exception = exception.getCause();
-            }
+            Throwable exception = ExceptionUtils.getRootCause(e);
             assertEquals(IllegalArgumentException.class, exception.getClass());
             assertEquals("Feature vectors should be of equal length.", exception.getMessage());
         }

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/OnlineKMeansTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/OnlineKMeansTest.java
@@ -372,11 +372,7 @@ public class OnlineKMeansTest extends TestLogger {
         try {
             onlineKMeans.fit(onlineTrainTable);
             Assert.fail("Expected IllegalStateException");
-        } catch (Exception e) {
-            Throwable exception = e;
-            while (exception.getCause() != null) {
-                exception = exception.getCause();
-            }
+        } catch (Throwable exception) {
             assertEquals(IllegalStateException.class, exception.getClass());
             assertEquals(
                     "There are more subtasks in the training process than the number "

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/BucketizerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/BucketizerTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.common.param.HasHandleInvalid;
+import org.apache.flink.ml.feature.bucketizer.Bucketizer;
+import org.apache.flink.ml.util.StageTestUtils;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/** Tests the {@link Bucketizer}. */
+public class BucketizerTest extends AbstractTestBase {
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+    private StreamTableEnvironment tEnv;
+    private Table inputTable;
+
+    private static final List<Row> inputData =
+            Arrays.asList(
+                    Row.of(1, -0.5, 0.0, 1.0),
+                    Row.of(2, Double.NEGATIVE_INFINITY, 1.0, Double.POSITIVE_INFINITY),
+                    Row.of(3, Double.NaN, -0.5, -0.5));
+
+    private static final Double[][] splitsArray =
+            new Double[][] {
+                new Double[] {-0.5, 0.0, 0.5},
+                new Double[] {-1.0, 0.0, 2.0},
+                new Double[] {Double.NEGATIVE_INFINITY, 10.0, Double.POSITIVE_INFINITY}
+            };
+
+    private final List<Row> expectedKeepResult =
+            Arrays.asList(Row.of(1, 0, 1, 0), Row.of(2, 2, 1, 1), Row.of(3, 2, 0, 0));
+
+    private final List<Row> expectedSkipResult = Collections.singletonList(Row.of(1, 0, 1, 0));
+
+    @Before
+    public void before() {
+        Configuration config = new Configuration();
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.setParallelism(4);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        tEnv = StreamTableEnvironment.create(env);
+        inputTable = tEnv.fromDataStream(env.fromCollection(inputData)).as("id", "f1", "f2", "f3");
+    }
+
+    @SuppressWarnings("all")
+    private void verifyOutputResult(Table output, String[] outputCols, List<Row> expectedResult)
+            throws Exception {
+        List<Row> collectedResult =
+                IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
+        List<Row> result = new ArrayList<>(collectedResult.size());
+
+        for (Row r : collectedResult) {
+            Row outRow = new Row(outputCols.length + 1);
+            outRow.setField(0, r.getField("id"));
+            for (int i = 0; i < outputCols.length; i++) {
+                outRow.setField(i + 1, r.getField(outputCols[i]));
+            }
+            result.add(outRow);
+        }
+
+        compareResultCollections(
+                expectedResult, result, Comparator.comparingInt(r -> ((Integer) r.getField(0))));
+    }
+
+    @Test
+    public void testParam() {
+        Bucketizer bucketizer = new Bucketizer();
+        assertEquals(HasHandleInvalid.ERROR_INVALID, bucketizer.getHandleInvalid());
+
+        bucketizer
+                .setInputCols("f1", "f2", "f3")
+                .setOutputCols("o1", "o2", "o3")
+                .setHandleInvalid(HasHandleInvalid.SKIP_INVALID)
+                .setSplitsArray(splitsArray);
+        assertArrayEquals(new String[] {"f1", "f2", "f3"}, bucketizer.getInputCols());
+        assertArrayEquals(new String[] {"o1", "o2", "o3"}, bucketizer.getOutputCols());
+        assertEquals(HasHandleInvalid.SKIP_INVALID, bucketizer.getHandleInvalid());
+
+        Double[][] setSplitsArray = bucketizer.getSplitsArray();
+        assertEquals(splitsArray.length, setSplitsArray.length);
+        for (int i = 0; i < splitsArray.length; i++) {
+            assertArrayEquals(splitsArray[i], setSplitsArray[i]);
+        }
+    }
+
+    @Test
+    public void testOutputSchema() {
+        Bucketizer bucketizer =
+                new Bucketizer()
+                        .setInputCols("f1", "f2", "f3")
+                        .setOutputCols("o1", "o2", "o3")
+                        .setHandleInvalid(HasHandleInvalid.SKIP_INVALID)
+                        .setSplitsArray(splitsArray);
+        Table output = bucketizer.transform(inputTable)[0];
+        assertEquals(
+                Arrays.asList("id", "f1", "f2", "f3", "o1", "o2", "o3"),
+                output.getResolvedSchema().getColumnNames());
+    }
+
+    @Test
+    public void testTransform() throws Exception {
+        Bucketizer bucketizer =
+                new Bucketizer()
+                        .setInputCols("f1", "f2", "f3")
+                        .setOutputCols("o1", "o2", "o3")
+                        .setSplitsArray(splitsArray);
+
+        Table output;
+
+        // Tests skip.
+        bucketizer.setHandleInvalid(HasHandleInvalid.SKIP_INVALID);
+        output = bucketizer.transform(inputTable)[0];
+        verifyOutputResult(output, bucketizer.getOutputCols(), expectedSkipResult);
+
+        // Tests keep.
+        bucketizer.setHandleInvalid(HasHandleInvalid.KEEP_INVALID);
+        output = bucketizer.transform(inputTable)[0];
+        verifyOutputResult(output, bucketizer.getOutputCols(), expectedKeepResult);
+
+        // Tests error.
+        bucketizer.setHandleInvalid(HasHandleInvalid.ERROR_INVALID);
+        output = bucketizer.transform(inputTable)[0];
+        try {
+            IteratorUtils.toList(output.execute().collect());
+            fail();
+        } catch (Throwable e) {
+            assertEquals(
+                    "The input contains invalid value. See "
+                            + HasHandleInvalid.HANDLE_INVALID
+                            + " parameter for more options.",
+                    ExceptionUtils.getRootCause(e).getMessage());
+        }
+    }
+
+    @Test
+    public void testSaveLoadAndTransform() throws Exception {
+        Bucketizer bucketizer =
+                new Bucketizer()
+                        .setInputCols("f1", "f2", "f3")
+                        .setOutputCols("o1", "o2", "o3")
+                        .setHandleInvalid(HasHandleInvalid.KEEP_INVALID)
+                        .setSplitsArray(splitsArray);
+        Bucketizer loadedBucketizer =
+                StageTestUtils.saveAndReload(
+                        tEnv, bucketizer, tempFolder.newFolder().getAbsolutePath());
+        Table output = loadedBucketizer.transform(inputTable)[0];
+        verifyOutputResult(output, loadedBucketizer.getOutputCols(), expectedKeepResult);
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/OneHotEncoderTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/OneHotEncoderTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -225,10 +226,7 @@ public class OneHotEncoderTest {
             outputTable.execute().collect().next();
             Assert.fail("Expected IllegalArgumentException");
         } catch (Exception e) {
-            Throwable exception = e;
-            while (exception.getCause() != null) {
-                exception = exception.getCause();
-            }
+            Throwable exception = ExceptionUtils.getRootCause(e);
             assertEquals(IllegalArgumentException.class, exception.getClass());
             assertEquals("Value 0.5 cannot be parsed as indexed integer.", exception.getMessage());
         }

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/StandardScalerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/StandardScalerTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
 import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -267,10 +268,7 @@ public class StandardScalerTest extends AbstractTestBase {
                     StandardScalerModelData.getModelDataStream(modelDataTable).executeAndCollect());
             fail();
         } catch (Throwable e) {
-            while (e.getCause() != null) {
-                e = e.getCause();
-            }
-            assertEquals("The training set is empty.", e.getMessage());
+            assertEquals("The training set is empty.", ExceptionUtils.getRootCause(e).getMessage());
         }
     }
 }

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/VectorAssemblerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/VectorAssemblerTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.feature.vectorassembler.VectorAssembler;
-import org.apache.flink.ml.feature.vectorassembler.VectorAssemblerParams;
 import org.apache.flink.ml.linalg.DenseVector;
 import org.apache.flink.ml.linalg.SparseVector;
 import org.apache.flink.ml.linalg.Vectors;
@@ -122,7 +121,7 @@ public class VectorAssemblerTest extends AbstractTestBase {
                 new VectorAssembler()
                         .setInputCols("vec", "num", "sparseVec")
                         .setOutputCol("assembledVec")
-                        .setHandleInvalid(VectorAssemblerParams.KEEP_INVALID);
+                        .setHandleInvalid(HasHandleInvalid.KEEP_INVALID);
         Table output = vectorAssembler.transform(inputDataTable)[0];
         assertEquals(
                 Arrays.asList("id", "vec", "num", "sparseVec", "assembledVec"),
@@ -141,10 +140,11 @@ public class VectorAssemblerTest extends AbstractTestBase {
             Table outputTable = vectorAssembler.transform(inputDataTable)[0];
             outputTable.execute().collect().next();
             Assert.fail("Expected IllegalArgumentException");
-        } catch (Exception e) {
-            assertEquals(
-                    "Input column value should not be null.",
-                    e.getCause().getCause().getCause().getCause().getCause().getMessage());
+        } catch (Throwable e) {
+            while (e.getCause() != null) {
+                e = e.getCause();
+            }
+            assertEquals("Input column value should not be null.", e.getMessage());
         }
     }
 
@@ -154,7 +154,7 @@ public class VectorAssemblerTest extends AbstractTestBase {
                 new VectorAssembler()
                         .setInputCols("vec", "num", "sparseVec")
                         .setOutputCol("assembledVec")
-                        .setHandleInvalid(VectorAssemblerParams.SKIP_INVALID);
+                        .setHandleInvalid(HasHandleInvalid.SKIP_INVALID);
         Table output = vectorAssembler.transform(inputDataTable)[0];
         assertEquals(
                 Arrays.asList("id", "vec", "num", "sparseVec", "assembledVec"),

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/VectorAssemblerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/VectorAssemblerTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
 import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -141,10 +142,9 @@ public class VectorAssemblerTest extends AbstractTestBase {
             outputTable.execute().collect().next();
             Assert.fail("Expected IllegalArgumentException");
         } catch (Throwable e) {
-            while (e.getCause() != null) {
-                e = e.getCause();
-            }
-            assertEquals("Input column value should not be null.", e.getMessage());
+            assertEquals(
+                    "Input column value should not be null.",
+                    ExceptionUtils.getRootCause(e).getMessage());
         }
     }
 

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/IndexToStringModelTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/IndexToStringModelTest.java
@@ -106,10 +106,11 @@ public class IndexToStringModelTest extends AbstractTestBase {
         try {
             IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
             fail();
-        } catch (Exception e) {
-            assertEquals(
-                    "The input contains unseen index: 4.",
-                    e.getCause().getCause().getCause().getCause().getCause().getMessage());
+        } catch (Throwable e) {
+            while (e.getCause() != null) {
+                e = e.getCause();
+            }
+            assertEquals("The input contains unseen index: 4.", e.getMessage());
         }
     }
 

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/IndexToStringModelTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/IndexToStringModelTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
 import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -107,10 +108,9 @@ public class IndexToStringModelTest extends AbstractTestBase {
             IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
             fail();
         } catch (Throwable e) {
-            while (e.getCause() != null) {
-                e = e.getCause();
-            }
-            assertEquals("The input contains unseen index: 4.", e.getMessage());
+            assertEquals(
+                    "The input contains unseen index: 4.",
+                    ExceptionUtils.getRootCause(e).getMessage());
         }
     }
 

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/StringIndexerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/StringIndexerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.ml.feature.stringindexer;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.ml.util.StageTestUtils;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
@@ -216,11 +217,16 @@ public class StringIndexerTest extends AbstractTestBase {
             output = stringIndexer.fit(trainTable).transform(predictTable)[0];
             IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
             fail();
-        } catch (Exception e) {
+        } catch (Throwable e) {
+            while (e.getCause() != null) {
+                e = e.getCause();
+            }
             assertEquals(
                     "The input contains unseen string: e. "
-                            + "See handleInvalid parameter for more options.",
-                    e.getCause().getCause().getCause().getCause().getCause().getMessage());
+                            + "See "
+                            + HasHandleInvalid.HANDLE_INVALID
+                            + " parameter for more options.",
+                    e.getMessage());
         }
     }
 

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/StringIndexerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/StringIndexerTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
 import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -218,15 +219,12 @@ public class StringIndexerTest extends AbstractTestBase {
             IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
             fail();
         } catch (Throwable e) {
-            while (e.getCause() != null) {
-                e = e.getCause();
-            }
             assertEquals(
                     "The input contains unseen string: e. "
                             + "See "
                             + HasHandleInvalid.HANDLE_INVALID
                             + " parameter for more options.",
-                    e.getMessage());
+                    ExceptionUtils.getRootCause(e).getMessage());
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change
- Add Transformer of Bucketizer in FlinkML. 

## Brief change log
- Reorganized the HasHandleInvalid param in StringIndexer, OnehotEncoder and VectorAssembler.
- Add Bucketizer.
- Add unit test for Bucketizer

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (Java doc)