### PR TITLE
[hotfix] Suppress the output of downloading messages in the github action log

### DIFF
--- a/.github/workflows/java8-build.yml
+++ b/.github/workflows/java8-build.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           java-version: 1.8
       - name: Build
-        run: mvn clean install
+        run: mvn clean install --no-transfer-progress
 


### PR DESCRIPTION
Currently the Java 8 Build log from github action could contain 20000+ lines of logs with redundant information such as `Progress (1): 17/36 MB` [1]. This information is typically not useful for developers and make it hard to find the useful information from the github webpage.

This PR uses the `--no-transfer-progress` option to suppress the output of downloading messages [2].

The effective of this PR has been verified via the Java 8 Build log in this PR [3].

[1] https://github.com/apache/flink-ml/runs/6106425232?check_suite_focus=true
[2] https://stackoverflow.com/questions/21638697/disable-maven-download-progress-indication
[3] https://github.com/apache/flink-ml/runs/6144354382?check_suite_focus=true