### PR TITLE
[hotfix] Update .asf.yaml file to disable the merge button and update collaborators etc.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,17 @@
+github:
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: true
+  collaborators:
+    - flinkbot
+  labels:
+    - flink
+    - machine-learning
+    - ml
+    - big-data
+    - java
+    - python
 notifications:
   commits:      commits@flink.apache.org
   issues:       issues@flink.apache.org


### PR DESCRIPTION
This PR updates the `.asf.yaml` file to disable the merge button, update collaborators, and add project labels.

See https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features for an explanation of asf.yaml file and its entries' semantics.