### PR TITLE
[hotfix] Bump dependency versions

### DIFF
--- a/flink-ml-core/pom.xml
+++ b/flink-ml-core/pom.xml
@@ -31,10 +31,6 @@ under the License.
   <artifactId>flink-ml-core_${scala.binary.version}</artifactId>
   <name>Flink ML : Core</name>
 
-  <properties>
-    <hadoop.version>2.4.1</hadoop.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.flink</groupId>

--- a/flink-ml-iteration/pom.xml
+++ b/flink-ml-iteration/pom.xml
@@ -31,10 +31,6 @@ under the License.
     <artifactId>flink-ml-iteration_${scala.binary.version}</artifactId>
     <name>Flink ML : Iteration</name>
 
-    <properties>
-        <hadoop.version>2.4.1</hadoop.version>
-    </properties>
-
     <dependencies>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,13 @@ under the License.
     <target.java.version>1.8</target.java.version>
     <spotless.version>2.4.2</spotless.version>
     <slf4j.version>1.7.15</slf4j.version>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <junit.version>4.13.1</junit.version>
     <flink.forkCount>1C</flink.forkCount>
     <flink.reuseForks>true</flink.reuseForks>
     <flink.version>1.14.4</flink.version>
     <zookeeper.version>3.4.14</zookeeper.version>
+    <hadoop.version>2.8.5</hadoop.version>
 
     <!-- Can be set to any value to reproduce a specific build. -->
     <test.randomization.seed/>


### PR DESCRIPTION
## What is the purpose of the change
This PR bumps up the dependency versions for log4j and hadoop libraries to be consistent with apache/flink. And this PR might address the issues in https://github.com/apache/flink-ml/pull/81, https://github.com/apache/flink-ml/pull/84, and https://github.com/apache/flink-ml/pull/85,  which are opened automatically by dependabot.

## Brief change log
- Bump hadoop.version from 2.4.1 to 2.8.5
- Bump log4j.version from 2.17.0 to 2.17.1

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)