### PR TITLE
[FLINK-27096] Improve DataCache and KMeans performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ target
 *.ipr
 *.iws
 *.pyc
+.vscode
 flink-ml-python/dist/
 flink-ml-python/apache_flink_ml.egg-info/

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/broadcast/operator/AbstractBroadcastWrapperOperator.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/broadcast/operator/AbstractBroadcastWrapperOperator.java
@@ -389,14 +389,12 @@ public abstract class AbstractBroadcastWrapperOperator<T, S extends StreamOperat
             ThrowingConsumer<StreamRecord, Exception> elementConsumer,
             ThrowingConsumer<Watermark, Exception> watermarkConsumer)
             throws Exception {
-        dataCacheWriters[inputIndex].finishCurrentSegment();
-        List<Segment> pendingSegments = dataCacheWriters[inputIndex].getFinishSegments();
+        List<Segment> pendingSegments = dataCacheWriters[inputIndex].getSegments();
         if (pendingSegments.size() != 0) {
             DataCacheReader dataCacheReader =
                     new DataCacheReader<>(
                             new CacheElementTypeInfo<>(inTypes[inputIndex])
                                     .createSerializer(containingTask.getExecutionConfig()),
-                            basePath.getFileSystem(),
                             pendingSegments);
             while (dataCacheReader.hasNext()) {
                 CacheElement cacheElement = (CacheElement) dataCacheReader.next();
@@ -565,12 +563,10 @@ public abstract class AbstractBroadcastWrapperOperator<T, S extends StreamOperat
             dos.writeInt(numInputs);
         }
         for (int i = 0; i < numInputs; i++) {
-            dataCacheWriters[i].finishCurrentSegment();
+            dataCacheWriters[i].writeSegmentsToFiles();
             DataCacheSnapshot dataCacheSnapshot =
                     new DataCacheSnapshot(
-                            basePath.getFileSystem(),
-                            null,
-                            dataCacheWriters[i].getFinishSegments());
+                            basePath.getFileSystem(), null, dataCacheWriters[i].getSegments());
             dataCacheSnapshot.writeTo(checkpointOutputStream);
         }
     }

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorTypeInfo.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorTypeInfo.java
@@ -62,9 +62,8 @@ public class DenseVectorTypeInfo extends TypeInformation<DenseVector> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public TypeSerializer<DenseVector> createSerializer(ExecutionConfig executionConfig) {
-        return DenseVectorSerializer.INSTANCE;
+        return new DenseVectorSerializer();
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/SparseVectorSerializer.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/SparseVectorSerializer.java
@@ -82,6 +82,7 @@ public final class SparseVectorSerializer extends TypeSerializerSingleton<Sparse
         target.writeInt(vector.n);
         final int len = vector.values.length;
         target.writeInt(len);
+        // TODO: optimize the serialization/deserialization process of SparseVectorSerializer.
         for (int i = 0; i < len; i++) {
             target.writeInt(vector.indices[i]);
             target.writeDouble(vector.values[i]);

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/VectorSerializer.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/VectorSerializer.java
@@ -37,10 +37,7 @@ public final class VectorSerializer extends TypeSerializerSingleton<Vector> {
 
     private static final double[] EMPTY = new double[0];
 
-    public static final VectorSerializer INSTANCE = new VectorSerializer();
-
-    private static final DenseVectorSerializer DENSE_VECTOR_SERIALIZER =
-            DenseVectorSerializer.INSTANCE;
+    private final DenseVectorSerializer denseVectorSerializer = new DenseVectorSerializer();
 
     private static final SparseVectorSerializer SPARSE_VECTOR_SERIALIZER =
             SparseVectorSerializer.INSTANCE;
@@ -58,7 +55,7 @@ public final class VectorSerializer extends TypeSerializerSingleton<Vector> {
     @Override
     public Vector copy(Vector from) {
         if (from instanceof DenseVector) {
-            return DENSE_VECTOR_SERIALIZER.copy((DenseVector) from);
+            return denseVectorSerializer.copy((DenseVector) from);
         } else {
             return SPARSE_VECTOR_SERIALIZER.copy((SparseVector) from);
         }
@@ -68,7 +65,7 @@ public final class VectorSerializer extends TypeSerializerSingleton<Vector> {
     public Vector copy(Vector from, Vector reuse) {
         assert from.getClass() == reuse.getClass();
         if (from instanceof DenseVector) {
-            return DENSE_VECTOR_SERIALIZER.copy((DenseVector) from, (DenseVector) reuse);
+            return denseVectorSerializer.copy((DenseVector) from, (DenseVector) reuse);
         } else {
             return SPARSE_VECTOR_SERIALIZER.copy((SparseVector) from, (SparseVector) reuse);
         }
@@ -83,7 +80,7 @@ public final class VectorSerializer extends TypeSerializerSingleton<Vector> {
     public void serialize(Vector vector, DataOutputView target) throws IOException {
         if (vector instanceof DenseVector) {
             target.writeByte(0);
-            DENSE_VECTOR_SERIALIZER.serialize((DenseVector) vector, target);
+            denseVectorSerializer.serialize((DenseVector) vector, target);
         } else {
             target.writeByte(1);
             SPARSE_VECTOR_SERIALIZER.serialize((SparseVector) vector, target);
@@ -94,7 +91,7 @@ public final class VectorSerializer extends TypeSerializerSingleton<Vector> {
     public Vector deserialize(DataInputView source) throws IOException {
         byte type = source.readByte();
         if (type == 0) {
-            return DENSE_VECTOR_SERIALIZER.deserialize(source);
+            return denseVectorSerializer.deserialize(source);
         } else {
             return SPARSE_VECTOR_SERIALIZER.deserialize(source);
         }
@@ -106,7 +103,7 @@ public final class VectorSerializer extends TypeSerializerSingleton<Vector> {
         assert type == 0 && reuse instanceof DenseVector
                 || type == 1 && reuse instanceof SparseVector;
         if (type == 0) {
-            return DENSE_VECTOR_SERIALIZER.deserialize(source);
+            return denseVectorSerializer.deserialize(source);
         } else {
             return SPARSE_VECTOR_SERIALIZER.deserialize(source);
         }
@@ -130,7 +127,7 @@ public final class VectorSerializer extends TypeSerializerSingleton<Vector> {
             extends SimpleTypeSerializerSnapshot<Vector> {
 
         public VectorSerializerSnapshot() {
-            super(() -> INSTANCE);
+            super(VectorSerializer::new);
         }
     }
 }

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/VectorTypeInfo.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/VectorTypeInfo.java
@@ -63,7 +63,7 @@ public class VectorTypeInfo extends TypeInformation<Vector> {
 
     @Override
     public TypeSerializer<Vector> createSerializer(ExecutionConfig executionConfig) {
-        return VectorSerializer.INSTANCE;
+        return new VectorSerializer();
     }
 
     @Override

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/util/Bits.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/util/Bits.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.util;
+
+/**
+ * Utility methods for packing/unpacking primitive values in/out of byte arrays using big-endian
+ * byte ordering. Referenced from java.io.Bits.
+ */
+public class Bits {
+
+    /*
+     * Methods for unpacking primitive values from byte arrays starting at
+     * given offsets.
+     */
+
+    public static long getLong(byte[] b, int off) {
+        return ((b[off + 7] & 0xFFL))
+                + ((b[off + 6] & 0xFFL) << 8)
+                + ((b[off + 5] & 0xFFL) << 16)
+                + ((b[off + 4] & 0xFFL) << 24)
+                + ((b[off + 3] & 0xFFL) << 32)
+                + ((b[off + 2] & 0xFFL) << 40)
+                + ((b[off + 1] & 0xFFL) << 48)
+                + (((long) b[off]) << 56);
+    }
+
+    public static double getDouble(byte[] b, int off) {
+        return Double.longBitsToDouble(getLong(b, off));
+    }
+
+    /*
+     * Methods for packing primitive values into byte arrays starting at given
+     * offsets.
+     */
+
+    public static void putLong(byte[] b, int off, long val) {
+        b[off + 7] = (byte) (val);
+        b[off + 6] = (byte) (val >>> 8);
+        b[off + 5] = (byte) (val >>> 16);
+        b[off + 4] = (byte) (val >>> 24);
+        b[off + 3] = (byte) (val >>> 32);
+        b[off + 2] = (byte) (val >>> 40);
+        b[off + 1] = (byte) (val >>> 48);
+        b[off] = (byte) (val >>> 56);
+    }
+
+    public static void putDouble(byte[] b, int off, double val) {
+        putLong(b, off, Double.doubleToLongBits(val));
+    }
+}

--- a/flink-ml-iteration/pom.xml
+++ b/flink-ml-iteration/pom.xml
@@ -166,5 +166,10 @@ under the License.
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-runtime</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/checkpoint/Checkpoints.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/checkpoint/Checkpoints.java
@@ -153,18 +153,18 @@ public class Checkpoints<T> implements AutoCloseable {
                         pendingCheckpoint -> {
                             try {
                                 pendingCheckpoint.dataCacheWriter.finish();
+                                pendingCheckpoint.dataCacheWriter.writeSegmentsToFiles();
                                 DataCacheSnapshot snapshot =
                                         new DataCacheSnapshot(
                                                 fileSystem,
                                                 null,
-                                                pendingCheckpoint.dataCacheWriter
-                                                        .getFinishSegments());
+                                                pendingCheckpoint.dataCacheWriter.getSegments());
                                 pendingCheckpoint.checkpointOutputStream.startNewPartition();
                                 snapshot.writeTo(pendingCheckpoint.checkpointOutputStream);
 
                                 // Directly cleanup all the files since we are using the local fs.
                                 // TODO: support of the remote fs.
-                                pendingCheckpoint.dataCacheWriter.cleanup();
+                                pendingCheckpoint.dataCacheWriter.clear();
                             } catch (Exception e) {
                                 LOG.error("Failed to commit checkpoint until " + checkpointId, e);
                                 throw new FlinkRuntimeException(e);
@@ -182,7 +182,7 @@ public class Checkpoints<T> implements AutoCloseable {
                 (checkpointId, pendingCheckpoint) -> {
                     pendingCheckpoint.snapshotLease.close();
                     try {
-                        pendingCheckpoint.dataCacheWriter.cleanup();
+                        pendingCheckpoint.dataCacheWriter.clear();
                     } catch (IOException e) {
                         LOG.error("Failed to cleanup " + checkpointId, e);
                     }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/FileSegmentReader.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/FileSegmentReader.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+
+/** A class that reads the cached data in a segment from file system. */
+@Internal
+class FileSegmentReader<T> implements SegmentReader<T> {
+
+    /** The tool to deserialize bytes into records. */
+    private final TypeSerializer<T> serializer;
+
+    /** The input stream to read serialized records from. */
+    private final FSDataInputStream inputStream;
+
+    /** The wrapper view of input stream to be used with TypeSerializer API. */
+    private final DataInputView inputView;
+
+    /** The total number of records contained in the segments. */
+    private final int totalCount;
+
+    /** The number of records that have been read so far. */
+    private int count;
+
+    FileSegmentReader(TypeSerializer<T> serializer, Segment segment, int startOffset)
+            throws IOException {
+        this.serializer = serializer;
+        Path path = segment.getPath();
+        this.inputStream = path.getFileSystem().open(path);
+        BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream);
+        this.inputView = new DataInputViewStreamWrapper(bufferedInputStream);
+        this.totalCount = segment.getCount();
+        this.count = 0;
+
+        for (int i = 0; i < startOffset; i++) {
+            next();
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        return count < totalCount;
+    }
+
+    @Override
+    public T next() throws IOException {
+        T value = serializer.deserialize(inputView);
+        count++;
+        return value;
+    }
+
+    @Override
+    public void close() throws IOException {
+        inputStream.close();
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/FileSegmentWriter.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/FileSegmentWriter.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+/** A class that writes cache data to a target file in given file system. */
+@Internal
+class FileSegmentWriter<T> implements SegmentWriter<T> {
+
+    /** The tool to serialize received records into bytes. */
+    private final TypeSerializer<T> serializer;
+
+    /** The path to the target file. */
+    private final Path path;
+
+    /** The output stream that writes to the target file. */
+    private final FSDataOutputStream outputStream;
+
+    /** A buffer that wraps the output stream to optimize performance. */
+    private final BufferedOutputStream bufferedOutputStream;
+
+    /** The wrapper view of the output stream to be used with TypeSerializer API. */
+    private final DataOutputView outputView;
+
+    /** The number of records added so far. */
+    private int count;
+
+    FileSegmentWriter(TypeSerializer<T> serializer, Path path) throws IOException {
+        this.serializer = serializer;
+        this.path = path;
+        this.outputStream = path.getFileSystem().create(path, FileSystem.WriteMode.NO_OVERWRITE);
+        this.bufferedOutputStream = new BufferedOutputStream(outputStream);
+        this.outputView = new DataOutputViewStreamWrapper(bufferedOutputStream);
+    }
+
+    @Override
+    public boolean addRecord(T record) throws IOException {
+        if (outputStream.getPos() >= DataCacheWriter.MAX_SEGMENT_SIZE) {
+            return false;
+        }
+        serializer.serialize(record, outputView);
+        count++;
+        return true;
+    }
+
+    @Override
+    public Optional<Segment> finish() throws IOException {
+        bufferedOutputStream.flush();
+        long size = outputStream.getPos();
+        outputStream.close();
+
+        if (count > 0) {
+            Segment segment = new Segment(path, count, size);
+            return Optional.of(segment);
+        } else {
+            // If there are no records, we tend to directly delete this file
+            path.getFileSystem().delete(path, false);
+            return Optional.empty();
+        }
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCache.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCache.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.iteration.operator.OperatorUtils;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StatePartitionStreamProvider;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.table.runtime.util.LazyMemorySegmentPool;
+import org.apache.flink.table.runtime.util.MemorySegmentPool;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.collections.IteratorUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link ListState} child class that records data and replays them when required.
+ *
+ * <p>This class basically stores data in file system, and provides the option to cache them in
+ * memory. In order to use the memory caching option, users need to allocate certain managed memory
+ * for the wrapper operator through {@link
+ * org.apache.flink.api.dag.Transformation#declareManagedMemoryUseCaseAtOperatorScope}.
+ *
+ * <p>NOTE: Users need to explicitly invoke this class's {@link
+ * #snapshotState(StateSnapshotContext)} method in order to store the recorded data in snapshot.
+ */
+public class ListStateWithCache<T> implements ListState<T> {
+
+    /** The tool to serialize/deserialize records. */
+    private final TypeSerializer<T> serializer;
+
+    /** The path of the directory that holds the files containing recorded data. */
+    private final Path basePath;
+
+    /** The data cache writer for the received records. */
+    private final DataCacheWriter<T> dataCacheWriter;
+
+    @SuppressWarnings("unchecked")
+    public ListStateWithCache(
+            TypeSerializer<T> serializer,
+            StreamTask<?, ?> containingTask,
+            StreamingRuntimeContext runtimeContext,
+            StateInitializationContext stateInitializationContext,
+            OperatorID operatorID)
+            throws IOException {
+        this.serializer = serializer;
+
+        MemorySegmentPool segmentPool = null;
+        double fraction =
+                containingTask
+                        .getConfiguration()
+                        .getManagedMemoryFractionOperatorUseCaseOfSlot(
+                                ManagedMemoryUseCase.OPERATOR,
+                                runtimeContext.getTaskManagerRuntimeInfo().getConfiguration(),
+                                runtimeContext.getUserCodeClassLoader());
+        if (fraction > 0) {
+            MemoryManager memoryManager = containingTask.getEnvironment().getMemoryManager();
+            segmentPool =
+                    new LazyMemorySegmentPool(
+                            containingTask,
+                            memoryManager,
+                            memoryManager.computeNumberOfPages(fraction));
+        }
+
+        basePath =
+                OperatorUtils.getDataCachePath(
+                        containingTask.getEnvironment().getTaskManagerInfo().getConfiguration(),
+                        containingTask
+                                .getEnvironment()
+                                .getIOManager()
+                                .getSpillingDirectoriesPaths());
+
+        List<StatePartitionStreamProvider> inputs =
+                IteratorUtils.toList(
+                        stateInitializationContext.getRawOperatorStateInputs().iterator());
+        Preconditions.checkState(
+                inputs.size() < 2, "The input from raw operator state should be one or zero.");
+
+        List<Segment> priorFinishedSegments = new ArrayList<>();
+        if (inputs.size() > 0) {
+            DataCacheSnapshot dataCacheSnapshot =
+                    DataCacheSnapshot.recover(
+                            inputs.get(0).getStream(),
+                            basePath.getFileSystem(),
+                            OperatorUtils.createDataCacheFileGenerator(
+                                    basePath, "cache", operatorID));
+
+            if (segmentPool != null) {
+                dataCacheSnapshot.tryReadSegmentsToMemory(serializer, segmentPool);
+            }
+
+            priorFinishedSegments = dataCacheSnapshot.getSegments();
+        }
+
+        this.dataCacheWriter =
+                new DataCacheWriter<>(
+                        serializer,
+                        basePath.getFileSystem(),
+                        OperatorUtils.createDataCacheFileGenerator(basePath, "cache", operatorID),
+                        segmentPool,
+                        priorFinishedSegments);
+    }
+
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        dataCacheWriter.writeSegmentsToFiles();
+        DataCacheSnapshot dataCacheSnapshot =
+                new DataCacheSnapshot(
+                        basePath.getFileSystem(), null, dataCacheWriter.getSegments());
+        context.getRawOperatorStateOutput().startNewPartition();
+        dataCacheSnapshot.writeTo(context.getRawOperatorStateOutput());
+    }
+
+    @Override
+    public Iterable<T> get() throws Exception {
+        List<Segment> segments = dataCacheWriter.getSegments();
+        return () -> new DataCacheReader<>(serializer, segments);
+    }
+
+    @Override
+    public void add(T t) throws Exception {
+        dataCacheWriter.addRecord(t);
+    }
+
+    @Override
+    public void update(List<T> list) throws Exception {
+        dataCacheWriter.clear();
+        addAll(list);
+    }
+
+    @Override
+    public void addAll(List<T> list) throws Exception {
+        for (T t : list) {
+            add(t);
+        }
+    }
+
+    @Override
+    public void clear() {
+        try {
+            dataCacheWriter.clear();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/MemorySegmentReader.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/MemorySegmentReader.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.MemorySegment;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/** A class that reads data cached in memory. */
+@Internal
+class MemorySegmentReader<T> implements SegmentReader<T> {
+
+    /** The tool to deserialize bytes into records. */
+    private final TypeSerializer<T> serializer;
+
+    /** The wrapper view of the input stream of memory segments to be used in TypeSerializer API. */
+    private final DataInputView inputView;
+
+    /** The total number of records contained in the segments. */
+    private final int totalCount;
+
+    /** The number of records that have been read so far. */
+    private int count;
+
+    MemorySegmentReader(TypeSerializer<T> serializer, Segment segment, int startOffset)
+            throws IOException {
+        ManagedMemoryInputStream inputStream = new ManagedMemoryInputStream(segment.getCache());
+        this.inputView = new DataInputViewStreamWrapper(inputStream);
+        this.serializer = serializer;
+        this.totalCount = segment.getCount();
+        this.count = 0;
+
+        for (int i = 0; i < startOffset; i++) {
+            next();
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        return count < totalCount;
+    }
+
+    @Override
+    public T next() throws IOException {
+        T value = serializer.deserialize(inputView);
+        count++;
+        return value;
+    }
+
+    @Override
+    public void close() {}
+
+    /** An input stream subclass that reads bytes from memory segments. */
+    private static class ManagedMemoryInputStream extends InputStream {
+
+        /** The memory segments to read bytes from. */
+        private final List<MemorySegment> segments;
+
+        /** The index of the segment that is currently being read. */
+        private int segmentIndex;
+
+        /** The number of bytes that have been read from the current segment so far. */
+        private int segmentOffset;
+
+        public ManagedMemoryInputStream(List<MemorySegment> segments) {
+            this.segments = segments;
+            this.segmentIndex = 0;
+            this.segmentOffset = 0;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int ret = segments.get(segmentIndex).get(segmentOffset) & 0xff;
+            segmentOffset += 1;
+            if (segmentOffset >= segments.get(segmentIndex).size()) {
+                segmentIndex++;
+                segmentOffset = 0;
+            }
+            return ret;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int readLen = 0;
+
+            while (len > 0 && segmentIndex < segments.size()) {
+                int currentLen = Math.min(segments.get(segmentIndex).size() - segmentOffset, len);
+                segments.get(segmentIndex).get(segmentOffset, b, off, currentLen);
+                segmentOffset += currentLen;
+                if (segmentOffset >= segments.get(segmentIndex).size()) {
+                    segmentIndex++;
+                    segmentOffset = 0;
+                }
+
+                readLen += currentLen;
+                off += currentLen;
+                len -= currentLen;
+            }
+
+            return readLen;
+        }
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/MemorySegmentWriter.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/MemorySegmentWriter.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
+import org.apache.flink.table.runtime.util.MemorySegmentPool;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/** A class that writes cache data to memory segments. */
+@Internal
+class MemorySegmentWriter<T> implements SegmentWriter<T> {
+
+    /** The tool to serialize received records into bytes. */
+    private final TypeSerializer<T> serializer;
+
+    /** The pre-allocated path to hold cached records into the file system. */
+    private final Path path;
+
+    /** The pool to allocate memory segments from. */
+    private final MemorySegmentPool segmentPool;
+
+    /** The output stream to write serialized content to memory segments. */
+    private final ManagedMemoryOutputStream outputStream;
+
+    /** The wrapper view of the output stream to be used with TypeSerializer API. */
+    private final DataOutputView outputView;
+
+    /** The number of records added so far. */
+    private int count;
+
+    MemorySegmentWriter(
+            TypeSerializer<T> serializer,
+            Path path,
+            MemorySegmentPool segmentPool,
+            long expectedSize)
+            throws MemoryAllocationException {
+        this.serializer = serializer;
+        this.path = path;
+        this.segmentPool = segmentPool;
+        this.outputStream = new ManagedMemoryOutputStream(segmentPool, expectedSize);
+        this.outputView = new DataOutputViewStreamWrapper(outputStream);
+        this.count = 0;
+    }
+
+    @Override
+    public boolean addRecord(T record) throws IOException {
+        if (outputStream.getPos() >= DataCacheWriter.MAX_SEGMENT_SIZE) {
+            return false;
+        }
+        try {
+            serializer.serialize(record, outputView);
+            count++;
+            return true;
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof MemoryAllocationException) {
+                return false;
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public Optional<Segment> finish() throws IOException {
+        if (count > 0) {
+            return Optional.of(new Segment(path, count, outputStream.getSegments()));
+        } else {
+            segmentPool.returnAll(outputStream.getSegments());
+            return Optional.empty();
+        }
+    }
+
+    /** An output stream subclass that accepts bytes and writes them to memory segments. */
+    private static class ManagedMemoryOutputStream extends OutputStream {
+
+        /** The pool to allocate memory segments from. */
+        private final MemorySegmentPool segmentPool;
+
+        /** The number of bytes in a memory segment. */
+        private final int pageSize;
+
+        /** The memory segments containing written bytes. */
+        private final List<MemorySegment> segments = new ArrayList<>();
+
+        /** The index of the segment that currently accepts written bytes. */
+        private int segmentIndex;
+
+        /** The number of bytes in the current segment that have been written. */
+        private int segmentOffset;
+
+        /** The number of bytes that have been written so far. */
+        private long globalOffset;
+
+        /** The number of bytes that have been allocated so far. */
+        private long allocatedBytes;
+
+        public ManagedMemoryOutputStream(MemorySegmentPool segmentPool, long expectedSize)
+                throws MemoryAllocationException {
+            this.segmentPool = segmentPool;
+            this.pageSize = segmentPool.pageSize();
+            ensureCapacity(Math.max(expectedSize, 1L));
+        }
+
+        public long getPos() {
+            return globalOffset;
+        }
+
+        public List<MemorySegment> getSegments() {
+            return segments;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            write(new byte[] {(byte) b}, 0, 1);
+        }
+
+        @Override
+        public void write(@Nullable byte[] b, int off, int len) throws IOException {
+            try {
+                ensureCapacity(globalOffset + len);
+            } catch (MemoryAllocationException e) {
+                throw new RuntimeException(e);
+            }
+
+            while (len > 0) {
+                int currentLen = Math.min(len, pageSize - segmentOffset);
+                segments.get(segmentIndex).put(segmentOffset, b, off, currentLen);
+                segmentOffset += currentLen;
+                globalOffset += currentLen;
+                if (segmentOffset >= pageSize) {
+                    segmentIndex++;
+                    segmentOffset = 0;
+                }
+                off += currentLen;
+                len -= currentLen;
+            }
+        }
+
+        private void ensureCapacity(long capacity) throws MemoryAllocationException {
+            if (allocatedBytes >= capacity) {
+                return;
+            }
+
+            int required =
+                    (int) (capacity % pageSize == 0 ? capacity / pageSize : capacity / pageSize + 1)
+                            - segments.size();
+
+            List<MemorySegment> allocatedSegments = new ArrayList<>();
+            for (int i = 0; i < required; i++) {
+                MemorySegment memorySegment = segmentPool.nextSegment();
+                if (memorySegment == null) {
+                    segmentPool.returnAll(allocatedSegments);
+                    throw new MemoryAllocationException();
+                }
+                allocatedSegments.add(memorySegment);
+            }
+
+            segments.addAll(allocatedSegments);
+            allocatedBytes += (long) allocatedSegments.size() * pageSize;
+        }
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/Segment.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/Segment.java
@@ -18,38 +18,84 @@
 
 package org.apache.flink.iteration.datacache.nonkeyed;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.MemorySegment;
 
-import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
-/** A segment represents a single file for the cache. */
-public class Segment implements Serializable {
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
+/** A segment contains the information about a cache unit. */
+@Internal
+public class Segment {
+
+    /** The path to the file containing persisted records. */
     private final Path path;
 
-    /** The count of the records in the file. */
+    /**
+     * The count of records in the file at the path if the file size is not zero, otherwise the
+     * count of records in the cache.
+     */
     private final int count;
 
-    /** The total length of file. */
-    private final long size;
+    /**
+     * The total length of the file containing persisted records. Its value is 0 iff the segment has
+     * not been written to the given path.
+     */
+    private long fsSize = 0L;
 
-    public Segment(Path path, int count, long size) {
+    /**
+     * The memory segments containing cached records. This list is empty iff the segment has not
+     * been cached in memory.
+     */
+    private List<MemorySegment> cache = new ArrayList<>();
+
+    Segment(Path path, int count, long fsSize) {
         this.path = path;
         this.count = count;
-        this.size = size;
+        this.fsSize = fsSize;
+
+        checkNotNull(path);
+        checkArgument(count > 0);
+        checkArgument(fsSize > 0);
     }
 
-    public Path getPath() {
+    Segment(Path path, int count, List<MemorySegment> cache) {
+        this.path = path;
+        this.count = count;
+        this.cache = cache;
+
+        checkNotNull(path);
+        checkArgument(count > 0);
+    }
+
+    void setCache(List<MemorySegment> cache) {
+        this.cache = cache;
+    }
+
+    void setFsSize(long fsSize) {
+        checkArgument(fsSize > 0);
+        this.fsSize = fsSize;
+    }
+
+    Path getPath() {
         return path;
     }
 
-    public int getCount() {
+    int getCount() {
         return count;
     }
 
-    public long getSize() {
-        return size;
+    long getFsSize() {
+        return fsSize;
+    }
+
+    List<MemorySegment> getCache() {
+        return cache;
     }
 
     @Override
@@ -63,16 +109,16 @@ public class Segment implements Serializable {
         }
 
         Segment segment = (Segment) o;
-        return count == segment.count && size == segment.size && Objects.equals(path, segment.path);
+        return count == segment.count && Objects.equals(path, segment.path);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(path, count, size);
+        return Objects.hash(path, count);
     }
 
     @Override
     public String toString() {
-        return "Segment{" + "path=" + path + ", count=" + count + ", size=" + size + '}';
+        return "Segment{" + "path=" + path + ", count=" + count + '}';
     }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/SegmentReader.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/SegmentReader.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+
+/** Reader for the cached data in a segment. */
+@Internal
+interface SegmentReader<T> {
+    /** Checks whether the reader has next record. */
+    boolean hasNext();
+
+    /** Gets the next record from the reader. */
+    T next() throws IOException;
+
+    /** Closes resources used by the reader. */
+    void close() throws IOException;
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/SegmentWriter.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/SegmentWriter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/** Writer for the data to be cached to a segment. */
+@Internal
+interface SegmentWriter<T> {
+    /**
+     * Adds a record to the writer.
+     *
+     * @return true if the record is successfully added, false if the size of the segment has
+     *     reached {@link DataCacheWriter#MAX_SEGMENT_SIZE} and cannot add current record.
+     */
+    boolean addRecord(T record) throws IOException;
+
+    /**
+     * Finishes the writer and returns a segment if any record has ever been added through {@link
+     * #addRecord(Object)}.
+     */
+    Optional<Segment> finish() throws IOException;
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperator.java
@@ -256,7 +256,6 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
                 DataCacheSnapshot.replay(
                         rawStateInput.getStream(),
                         checkpoints.getTypeSerializer(),
-                        checkpoints.getFileSystem(),
                         (record) ->
                                 recordProcessor.processFeedbackElement(new StreamRecord<>(record)));
             }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/ReplayOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/ReplayOperator.java
@@ -180,7 +180,6 @@ public class ReplayOperator<T> extends AbstractStreamOperator<IterationRecord<T>
                 currentDataCacheReader =
                         new DataCacheReader<>(
                                 typeSerializer,
-                                fileSystem,
                                 dataCacheSnapshot.getSegments(),
                                 dataCacheSnapshot.getReaderPosition());
             }
@@ -203,14 +202,14 @@ public class ReplayOperator<T> extends AbstractStreamOperator<IterationRecord<T>
 
         currentEpochState.update(Collections.singletonList(currentEpoch));
 
-        dataCacheWriter.finishCurrentSegment();
+        dataCacheWriter.writeSegmentsToFiles();
         DataCacheSnapshot dataCacheSnapshot =
                 new DataCacheSnapshot(
                         fileSystem,
                         currentDataCacheReader == null
                                 ? null
                                 : currentDataCacheReader.getPosition(),
-                        dataCacheWriter.getFinishSegments());
+                        dataCacheWriter.getSegments());
         context.getRawOperatorStateOutput().startNewPartition();
         dataCacheSnapshot.writeTo(context.getRawOperatorStateOutput());
     }
@@ -262,6 +261,8 @@ public class ReplayOperator<T> extends AbstractStreamOperator<IterationRecord<T>
     public void onEpochWatermarkIncrement(int epochWatermark) throws IOException {
         if (epochWatermark == 0) {
             // No need to replay for the round 0, it is output directly.
+            // TODO: free cached records when they will no longer be replayed, and enable caching
+            // data in memory.
             dataCacheWriter.finish();
             emitEpochWatermark(epochWatermark);
             return;
@@ -271,12 +272,11 @@ public class ReplayOperator<T> extends AbstractStreamOperator<IterationRecord<T>
         }
 
         // At this point, there would be no more inputs before we finish replaying all the data.
-        // Thus it is safe we implement ourself mailbox loop.
+        // Thus it is safe for us to implement our own mailbox loop.
         checkState(currentDataCacheReader == null, "Concurrent replay is not supported");
         currentEpoch = epochWatermark;
         currentDataCacheReader =
-                new DataCacheReader<>(
-                        typeSerializer, fileSystem, dataCacheWriter.getFinishSegments());
+                new DataCacheReader<>(typeSerializer, dataCacheWriter.getSegments());
         replayRecords(currentDataCacheReader, epochWatermark);
     }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/knn/KnnModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/knn/KnnModelData.java
@@ -83,12 +83,14 @@ public class KnnModelData {
 
     /** Encoder for {@link KnnModelData}. */
     public static class ModelDataEncoder implements Encoder<KnnModelData> {
+        private final DenseVectorSerializer serializer = new DenseVectorSerializer();
+
         @Override
         public void encode(KnnModelData modelData, OutputStream outputStream) throws IOException {
             DataOutputView dataOutputView = new DataOutputViewStreamWrapper(outputStream);
             DenseMatrixSerializer.INSTANCE.serialize(modelData.packedFeatures, dataOutputView);
-            DenseVectorSerializer.INSTANCE.serialize(modelData.featureNormSquares, dataOutputView);
-            DenseVectorSerializer.INSTANCE.serialize(modelData.labels, dataOutputView);
+            serializer.serialize(modelData.featureNormSquares, dataOutputView);
+            serializer.serialize(modelData.labels, dataOutputView);
         }
     }
 
@@ -100,13 +102,14 @@ public class KnnModelData {
 
                 private final DataInputView source = new DataInputViewStreamWrapper(stream);
 
+                private final DenseVectorSerializer serializer = new DenseVectorSerializer();
+
                 @Override
                 public KnnModelData read() throws IOException {
                     try {
                         DenseMatrix matrix = DenseMatrixSerializer.INSTANCE.deserialize(source);
-                        DenseVector normSquares =
-                                DenseVectorSerializer.INSTANCE.deserialize(source);
-                        DenseVector labels = DenseVectorSerializer.INSTANCE.deserialize(source);
+                        DenseVector normSquares = serializer.deserialize(source);
+                        DenseVector labels = serializer.deserialize(source);
                         return new KnnModelData(matrix, normSquares, labels);
                     } catch (EOFException e) {
                         return null;

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/linearsvc/LinearSVCModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/linearsvc/LinearSVCModelData.java
@@ -68,11 +68,12 @@ public class LinearSVCModelData {
 
     /** Data encoder for {@link LinearSVCModel}. */
     public static class ModelDataEncoder implements Encoder<LinearSVCModelData> {
+        private final DenseVectorSerializer serializer = new DenseVectorSerializer();
 
         @Override
         public void encode(LinearSVCModelData modelData, OutputStream outputStream)
                 throws IOException {
-            DenseVectorSerializer.INSTANCE.serialize(
+            serializer.serialize(
                     modelData.coefficient, new DataOutputViewStreamWrapper(outputStream));
         }
     }
@@ -84,13 +85,13 @@ public class LinearSVCModelData {
         public Reader<LinearSVCModelData> createReader(
                 Configuration configuration, FSDataInputStream inputStream) {
             return new Reader<LinearSVCModelData>() {
+                private final DenseVectorSerializer serializer = new DenseVectorSerializer();
 
                 @Override
                 public LinearSVCModelData read() throws IOException {
                     try {
                         DenseVector coefficient =
-                                DenseVectorSerializer.INSTANCE.deserialize(
-                                        new DataInputViewStreamWrapper(inputStream));
+                                serializer.deserialize(new DataInputViewStreamWrapper(inputStream));
                         return new LinearSVCModelData(coefficient);
                     } catch (EOFException e) {
                         return null;

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/LogisticRegressionModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/LogisticRegressionModelData.java
@@ -108,14 +108,14 @@ public class LogisticRegressionModelData {
 
     /** Data encoder for {@link LogisticRegression} and {@link OnlineLogisticRegression}. */
     public static class ModelDataEncoder implements Encoder<LogisticRegressionModelData> {
+        private final DenseVectorSerializer serializer = new DenseVectorSerializer();
 
         @Override
         public void encode(LogisticRegressionModelData modelData, OutputStream outputStream)
                 throws IOException {
             DataOutputViewStreamWrapper dataOutputViewStreamWrapper =
                     new DataOutputViewStreamWrapper(outputStream);
-            DenseVectorSerializer.INSTANCE.serialize(
-                    modelData.coefficient, dataOutputViewStreamWrapper);
+            serializer.serialize(modelData.coefficient, dataOutputViewStreamWrapper);
             dataOutputViewStreamWrapper.writeLong(modelData.modelVersion);
         }
     }
@@ -127,6 +127,7 @@ public class LogisticRegressionModelData {
         public Reader<LogisticRegressionModelData> createReader(
                 Configuration configuration, FSDataInputStream inputStream) {
             return new Reader<LogisticRegressionModelData>() {
+                private final DenseVectorSerializer serializer = new DenseVectorSerializer();
 
                 @Override
                 public LogisticRegressionModelData read() throws IOException {
@@ -134,8 +135,7 @@ public class LogisticRegressionModelData {
                         DataInputViewStreamWrapper dataInputViewStreamWrapper =
                                 new DataInputViewStreamWrapper(inputStream);
                         DenseVector coefficient =
-                                DenseVectorSerializer.INSTANCE.deserialize(
-                                        dataInputViewStreamWrapper);
+                                serializer.deserialize(dataInputViewStreamWrapper);
                         long modelVersion = dataInputViewStreamWrapper.readLong();
                         return new LogisticRegressionModelData(coefficient, modelVersion);
                     } catch (EOFException e) {

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/naivebayes/NaiveBayesModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/naivebayes/NaiveBayesModelData.java
@@ -92,6 +92,8 @@ public class NaiveBayesModelData {
 
     /** Data encoder for the {@link NaiveBayesModelData}. */
     public static class ModelDataEncoder implements Encoder<NaiveBayesModelData> {
+        private final DenseVectorSerializer serializer = new DenseVectorSerializer();
+
         @Override
         public void encode(NaiveBayesModelData modelData, OutputStream outputStream)
                 throws IOException {
@@ -101,9 +103,9 @@ public class NaiveBayesModelData {
             MapSerializer<Double, Double> mapSerializer =
                     new MapSerializer<>(DoubleSerializer.INSTANCE, DoubleSerializer.INSTANCE);
 
-            DenseVectorSerializer.INSTANCE.serialize(modelData.labels, outputViewStreamWrapper);
+            serializer.serialize(modelData.labels, outputViewStreamWrapper);
 
-            DenseVectorSerializer.INSTANCE.serialize(modelData.piArray, outputViewStreamWrapper);
+            serializer.serialize(modelData.piArray, outputViewStreamWrapper);
 
             outputViewStreamWrapper.writeInt(modelData.theta.length);
             outputViewStreamWrapper.writeInt(modelData.theta[0].length);
@@ -121,6 +123,7 @@ public class NaiveBayesModelData {
         public Reader<NaiveBayesModelData> createReader(
                 Configuration config, FSDataInputStream inputStream) {
             return new Reader<NaiveBayesModelData>() {
+                private final DenseVectorSerializer serializer = new DenseVectorSerializer();
 
                 @Override
                 public NaiveBayesModelData read() throws IOException {
@@ -131,11 +134,9 @@ public class NaiveBayesModelData {
                                 new MapSerializer<>(
                                         DoubleSerializer.INSTANCE, DoubleSerializer.INSTANCE);
 
-                        DenseVector labels =
-                                DenseVectorSerializer.INSTANCE.deserialize(inputViewStreamWrapper);
+                        DenseVector labels = serializer.deserialize(inputViewStreamWrapper);
 
-                        DenseVector piArray =
-                                DenseVectorSerializer.INSTANCE.deserialize(inputViewStreamWrapper);
+                        DenseVector piArray = serializer.deserialize(inputViewStreamWrapper);
 
                         int featureSize = inputViewStreamWrapper.readInt();
                         int numLabels = inputViewStreamWrapper.readInt();

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/minmaxscaler/MinMaxScalerModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/minmaxscaler/MinMaxScalerModelData.java
@@ -74,12 +74,14 @@ public class MinMaxScalerModelData {
 
     /** Encoder for {@link MinMaxScalerModelData}. */
     public static class ModelDataEncoder implements Encoder<MinMaxScalerModelData> {
+        private final DenseVectorSerializer serializer = new DenseVectorSerializer();
+
         @Override
         public void encode(MinMaxScalerModelData modelData, OutputStream outputStream)
                 throws IOException {
             DataOutputView dataOutputView = new DataOutputViewStreamWrapper(outputStream);
-            DenseVectorSerializer.INSTANCE.serialize(modelData.minVector, dataOutputView);
-            DenseVectorSerializer.INSTANCE.serialize(modelData.maxVector, dataOutputView);
+            serializer.serialize(modelData.minVector, dataOutputView);
+            serializer.serialize(modelData.maxVector, dataOutputView);
         }
     }
 
@@ -89,13 +91,14 @@ public class MinMaxScalerModelData {
         public Reader<MinMaxScalerModelData> createReader(
                 Configuration config, FSDataInputStream stream) {
             return new Reader<MinMaxScalerModelData>() {
+                private final DenseVectorSerializer serializer = new DenseVectorSerializer();
 
                 @Override
                 public MinMaxScalerModelData read() throws IOException {
                     DataInputView source = new DataInputViewStreamWrapper(stream);
                     try {
-                        DenseVector minVector = DenseVectorSerializer.INSTANCE.deserialize(source);
-                        DenseVector maxVector = DenseVectorSerializer.INSTANCE.deserialize(source);
+                        DenseVector minVector = serializer.deserialize(source);
+                        DenseVector maxVector = serializer.deserialize(source);
                         return new MinMaxScalerModelData(minVector, maxVector);
                     } catch (EOFException e) {
                         return null;

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerModelData.java
@@ -78,14 +78,16 @@ public class StandardScalerModelData {
 
     /** Data encoder for the {@link StandardScalerModel} model data. */
     public static class ModelDataEncoder implements Encoder<StandardScalerModelData> {
+        private final DenseVectorSerializer serializer = new DenseVectorSerializer();
+
         @Override
         public void encode(StandardScalerModelData modelData, OutputStream outputStream)
                 throws IOException {
             DataOutputViewStreamWrapper outputViewStreamWrapper =
                     new DataOutputViewStreamWrapper(outputStream);
 
-            DenseVectorSerializer.INSTANCE.serialize(modelData.mean, outputViewStreamWrapper);
-            DenseVectorSerializer.INSTANCE.serialize(modelData.std, outputViewStreamWrapper);
+            serializer.serialize(modelData.mean, outputViewStreamWrapper);
+            serializer.serialize(modelData.std, outputViewStreamWrapper);
         }
     }
 
@@ -95,6 +97,7 @@ public class StandardScalerModelData {
         public Reader<StandardScalerModelData> createReader(
                 Configuration configuration, FSDataInputStream inputStream) {
             return new Reader<StandardScalerModelData>() {
+                private final DenseVectorSerializer serializer = new DenseVectorSerializer();
 
                 @Override
                 public StandardScalerModelData read() throws IOException {
@@ -102,10 +105,8 @@ public class StandardScalerModelData {
                             new DataInputViewStreamWrapper(inputStream);
 
                     try {
-                        DenseVector mean =
-                                DenseVectorSerializer.INSTANCE.deserialize(inputViewStreamWrapper);
-                        DenseVector std =
-                                DenseVectorSerializer.INSTANCE.deserialize(inputViewStreamWrapper);
+                        DenseVector mean = serializer.deserialize(inputViewStreamWrapper);
+                        DenseVector std = serializer.deserialize(inputViewStreamWrapper);
                         return new StandardScalerModelData(mean, std);
                     } catch (EOFException e) {
                         return null;

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/regression/linearregression/LinearRegressionModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/regression/linearregression/LinearRegressionModelData.java
@@ -67,11 +67,12 @@ public class LinearRegressionModelData {
 
     /** Data encoder for {@link LinearRegressionModel}. */
     public static class ModelDataEncoder implements Encoder<LinearRegressionModelData> {
+        private final DenseVectorSerializer serializer = new DenseVectorSerializer();
 
         @Override
         public void encode(LinearRegressionModelData modelData, OutputStream outputStream)
                 throws IOException {
-            DenseVectorSerializer.INSTANCE.serialize(
+            serializer.serialize(
                     modelData.coefficient, new DataOutputViewStreamWrapper(outputStream));
         }
     }
@@ -83,13 +84,13 @@ public class LinearRegressionModelData {
         public Reader<LinearRegressionModelData> createReader(
                 Configuration configuration, FSDataInputStream inputStream) {
             return new Reader<LinearRegressionModelData>() {
+                private final DenseVectorSerializer serializer = new DenseVectorSerializer();
 
                 @Override
                 public LinearRegressionModelData read() throws IOException {
                     try {
                         DenseVector coefficient =
-                                DenseVectorSerializer.INSTANCE.deserialize(
-                                        new DataInputViewStreamWrapper(inputStream));
+                                serializer.deserialize(new DataInputViewStreamWrapper(inputStream));
                         return new LinearRegressionModelData(coefficient);
                     } catch (EOFException e) {
                         return null;


### PR DESCRIPTION
## What is the purpose of the change

This PR mainly improves `DataCacheReader` and `DataCacheWriter`'s performance with memory caches, and further optimizes KMeans algorithm with DataCache mechanism.

## Brief change log
- In DataCache mechanism, provides the option to cache records in memory in serialized format, instead of directly saving  them to file system, unless checkpoint is invoked or there is not enough memory.
- Changes `DataStreamUtils.mapParition()`'s implementation from using `ListState` to using `DataCacheWriter`.
- Utilizes the memory-caching functionality in `KMeans.SelectNearestCentroidOperator` to avoid OOM.
    - All other existing usages of `DataCacheWriter` is untouched, continuing to directly saving records to file system.
- Adds `DataStreamUtils.sample()` and uses it in `KMeans.selectRandomCentroids()` to reduce memory usage.


## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)