### PR TITLE
[FLINK-27096] Add LabeledPointWithWeightGenerator and Benchmark Configuration for KMeans and NaiveBayes

### DIFF
--- a/flink-ml-benchmark/README.md
+++ b/flink-ml-benchmark/README.md
@@ -63,7 +63,7 @@ Then in Flink ML's binary distribution's folder, execute the following command
 to run the default benchmarks.
 
 ```bash
-./bin/benchmark-run.sh conf/benchmark-conf.json --output-file results.json
+./bin/benchmark-run.sh conf/benchmark-demo.json --output-file results.json
 ```
 
 You will notice that some Flink jobs are submitted to your Flink cluster, and
@@ -97,7 +97,7 @@ added.
       "className" : "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap" : {
         "seed" : 2,
-        "colNames" : [ "features" ],
+        "colNames" : [["features"]],
         "numValues" : 10000,
         "vectorDim" : 10
       }
@@ -129,7 +129,7 @@ If a benchmark failed, it would be saved in the file as follows.
       "className" : "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap" : {
         "seed" : 2,
-        "colNames" : [ "non-features" ],
+        "colNames" : [["non-features"]],
         "numValues" : 10000,
         "vectorDim" : 10
       }
@@ -146,7 +146,7 @@ If a benchmark failed, it would be saved in the file as follows.
 ### Customize Benchmark Configuration
 
 `benchmark-run.sh` parses benchmarks to be executed according to the input
-configuration file, like `conf/benchmark-conf.json`. It can also parse your
+configuration file, like `conf/benchmark-demo.json`. It can also parse your
 custom configuration file so long as it contains a JSON object in the following
 format.
 
@@ -165,8 +165,9 @@ format.
   - `"className"`: The full classpath of a `WithParams` subclass. For `"stage"`,
     the class should be a subclass of `Stage`. For `"inputs"` or `"modelData"`,
     the class should be a subclass of `DataGenerator`.
-  - `"paramMap"`: A JSON object containing the parameters related to the
-    specific `Stage` or `DataGenerator`.
+  - `"paramMap"`: An optional JSON object containing the parameters related to
+    the specific `Stage` or `DataGenerator`, overriding default values for the
+    parameters.
 
 Combining the format requirements above, an example configuration is as follows.
 This configuration contains two benchmarks. The first benchmark name is
@@ -188,7 +189,7 @@ This configuration contains two benchmarks. The first benchmark name is
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "seed": 2,
-        "colNames": ["features"],
+        "colNames": [["features"]],
         "numValues": 10000,
         "vectorDim": 10
       }
@@ -216,7 +217,7 @@ This configuration contains two benchmarks. The first benchmark name is
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "seed": 2,
-        "colNames": ["features"],
+        "colNames": [["features"]],
         "numValues": 10000,
         "vectorDim": 10
       }

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/InputDataGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/InputDataGenerator.java
@@ -21,7 +21,7 @@ package org.apache.flink.ml.benchmark.datagenerator;
 import org.apache.flink.ml.param.LongParam;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.param.ParamValidators;
-import org.apache.flink.ml.param.StringArrayParam;
+import org.apache.flink.ml.param.StringArrayArrayParam;
 
 /** Interface for generating data as input table arrays. */
 public interface InputDataGenerator<T extends InputDataGenerator<T>> extends DataGenerator<T> {
@@ -29,10 +29,10 @@ public interface InputDataGenerator<T extends InputDataGenerator<T>> extends Dat
             new LongParam(
                     "numValues", "Number of data to be generated.", 10L, ParamValidators.gt(0));
 
-    Param<String[]> COL_NAMES =
-            new StringArrayParam(
+    Param<String[][]> COL_NAMES =
+            new StringArrayArrayParam(
                     "colNames",
-                    "An array of common-separated strings representing field names of data tables.",
+                    "A 2D array of strings. Each string array element represents the column names of a data table.",
                     null);
 
     default long getNumValues() {
@@ -43,11 +43,11 @@ public interface InputDataGenerator<T extends InputDataGenerator<T>> extends Dat
         return set(NUM_VALUES, value);
     }
 
-    default String[] getColNames() {
+    default String[][] getColNames() {
         return get(COL_NAMES);
     }
 
-    default T setColNames(String... value) {
+    default T setColNames(String[]... value) {
         return set(COL_NAMES, value);
     }
 }

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DenseVectorArrayGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DenseVectorArrayGenerator.java
@@ -68,8 +68,9 @@ public class DenseVectorArrayGenerator
         Schema schema = Schema.newBuilder().column("f0", DataTypes.of(DenseVector[].class)).build();
         Table dataTable = tEnv.fromDataStream(dataStream, schema);
         if (getColNames() != null) {
-            Preconditions.checkState(getColNames().length > 0);
-            dataTable = dataTable.as(getColNames()[0]);
+            Preconditions.checkState(getColNames().length == 1);
+            Preconditions.checkState(getColNames()[0].length == 1);
+            dataTable = dataTable.as(getColNames()[0][0]);
         }
 
         return new Table[] {dataTable};

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DenseVectorGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DenseVectorGenerator.java
@@ -61,8 +61,9 @@ public class DenseVectorGenerator
 
         Table dataTable = tEnv.fromDataStream(dataStream);
         if (getColNames() != null) {
-            Preconditions.checkState(getColNames().length > 0);
-            dataTable = dataTable.as(getColNames()[0]);
+            Preconditions.checkState(getColNames().length == 1);
+            Preconditions.checkState(getColNames()[0].length == 1);
+            dataTable = dataTable.as(getColNames()[0][0]);
         }
 
         return new Table[] {dataTable};

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/LabeledPointWithWeightGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/LabeledPointWithWeightGenerator.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark.datagenerator.common;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.benchmark.datagenerator.InputDataGenerator;
+import org.apache.flink.ml.benchmark.datagenerator.param.HasVectorDim;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.NumberSequenceIterator;
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * A DataGenerator which creates a table of features, label and weight.
+ *
+ * <p>Users need to specify three column names as {@link #COL_NAMES}'s value in the following order:
+ *
+ * <ul>
+ *   <li>features column name
+ *   <li>label column name
+ *   <li>weight column name
+ * </ul>
+ */
+public class LabeledPointWithWeightGenerator
+        implements InputDataGenerator<LabeledPointWithWeightGenerator>,
+                HasVectorDim<LabeledPointWithWeightGenerator> {
+
+    public static final Param<Integer> FEATURE_ARITY =
+            new IntParam(
+                    "featureArity",
+                    "Arity of each feature. "
+                            + "If set to positive value, each feature would be an integer in range [0, arity - 1]. "
+                            + "If set to zero, each feature would be a continuous double in range [0, 1).",
+                    2,
+                    ParamValidators.gtEq(0));
+
+    public static final Param<Integer> LABEL_ARITY =
+            new IntParam(
+                    "labelArity",
+                    "Arity of label. "
+                            + "If set to positive value, the label would be an integer in range [0, arity - 1]. "
+                            + "If set to zero, the label would be a continuous double in range [0, 1).",
+                    2,
+                    ParamValidators.gtEq(0));
+
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public LabeledPointWithWeightGenerator() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    public int getFeatureArity() {
+        return get(FEATURE_ARITY);
+    }
+
+    public LabeledPointWithWeightGenerator setFeatureArity(int value) {
+        return set(FEATURE_ARITY, value);
+    }
+
+    public int getLabelArity() {
+        return get(LABEL_ARITY);
+    }
+
+    public LabeledPointWithWeightGenerator setLabelArity(int value) {
+        return set(LABEL_ARITY, value);
+    }
+
+    @Override
+    public Table[] getData(StreamTableEnvironment tEnv) {
+        Preconditions.checkState(getColNames().length == 1);
+        Preconditions.checkState(getColNames()[0].length == 3);
+
+        StreamExecutionEnvironment env = TableUtils.getExecutionEnvironment(tEnv);
+
+        DataStream<Row> dataStream =
+                env.fromParallelCollection(
+                                new NumberSequenceIterator(1L, getNumValues()),
+                                BasicTypeInfo.LONG_TYPE_INFO)
+                        .map(
+                                new RandomLabeledPointWithWeightGenerator(
+                                        getSeed(),
+                                        getVectorDim(),
+                                        getFeatureArity(),
+                                        getLabelArity()),
+                                new RowTypeInfo(
+                                        new TypeInformation[] {
+                                            DenseVectorTypeInfo.INSTANCE, Types.DOUBLE, Types.DOUBLE
+                                        },
+                                        getColNames()[0]));
+
+        Table dataTable = tEnv.fromDataStream(dataStream);
+
+        return new Table[] {dataTable};
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    private static class RandomLabeledPointWithWeightGenerator extends RichMapFunction<Long, Row> {
+        private final long initSeed;
+        private final int vectorDim;
+        private final int featureArity;
+        private final int labelArity;
+        private Random random;
+
+        private RandomLabeledPointWithWeightGenerator(
+                long initSeed, int vectorDim, int featureArity, int labelArity) {
+            this.initSeed = initSeed;
+            this.vectorDim = vectorDim;
+            this.featureArity = featureArity;
+            this.labelArity = labelArity;
+        }
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            super.open(parameters);
+            int index = getRuntimeContext().getIndexOfThisSubtask();
+            random = new Random(Tuple2.of(initSeed, index).hashCode());
+        }
+
+        @Override
+        public Row map(Long ignored) {
+            double[] features = new double[vectorDim];
+            for (int i = 0; i < vectorDim; i++) {
+                features[i] = getValue(featureArity);
+            }
+
+            double label = getValue(labelArity);
+
+            double weight = random.nextDouble();
+
+            return Row.of(Vectors.dense(features), label, weight);
+        }
+
+        private double getValue(int arity) {
+            if (arity > 0) {
+                return random.nextInt(arity);
+            }
+            return random.nextDouble();
+        }
+    }
+}

--- a/flink-ml-benchmark/src/main/resources/benchmark-demo.json
+++ b/flink-ml-benchmark/src/main/resources/benchmark-demo.json
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 {
   "version": 1,
   "KMeans-1": {
@@ -12,7 +27,7 @@
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "seed": 2,
-        "colNames": ["features"],
+        "colNames": [["features"]],
         "numValues": 10000,
         "vectorDim": 10
       }
@@ -40,7 +55,7 @@
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "seed": 2,
-        "colNames": ["features"],
+        "colNames": [["features"]],
         "numValues": 10000,
         "vectorDim": 10
       }
@@ -68,7 +83,7 @@
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "seed": 2,
-        "colNames": ["features"],
+        "colNames": [["features"]],
         "numValues": 20000,
         "vectorDim": 10
       }
@@ -96,7 +111,7 @@
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "seed": 2,
-        "colNames": ["features"],
+        "colNames": [["features"]],
         "numValues": 30000,
         "vectorDim": 10
       }
@@ -124,7 +139,7 @@
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "seed": 2,
-        "colNames": ["features"],
+        "colNames": [["features"]],
         "numValues": 40000,
         "vectorDim": 10
       }
@@ -152,7 +167,7 @@
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "seed": 2,
-        "colNames": ["features"],
+        "colNames": [["features"]],
         "numValues": 50000,
         "vectorDim": 10
       }
@@ -171,7 +186,7 @@
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "seed": 2,
-        "colNames": ["features"],
+        "colNames": [["features"]],
         "numValues": 10000,
         "vectorDim": 10
       }

--- a/flink-ml-benchmark/src/main/resources/kmeans-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/kmeans-benchmark.json
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "version": 1,
+  "KMeans": {
+    "stage": {
+      "className": "org.apache.flink.ml.clustering.kmeans.KMeans",
+      "paramMap": {
+        "maxIter": 10,
+        "k": 10
+      }
+    },
+    "inputData": {
+      "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
+      "paramMap": {
+        "seed": 2,
+        "colNames": [["features"]],
+        "numValues": 1000000,
+        "vectorDim": 100
+      }
+    }
+  }
+}

--- a/flink-ml-benchmark/src/main/resources/naivebayes-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/naivebayes-benchmark.json
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "version": 1,
+  "NaiveBayes": {
+    "stage": {
+      "className": "org.apache.flink.ml.classification.naivebayes.NaiveBayes"
+    },
+    "inputData": {
+      "className": "org.apache.flink.ml.benchmark.datagenerator.common.LabeledPointWithWeightGenerator",
+      "paramMap": {
+        "colNames": [["features", "label", "weight"]],
+        "featureArity": 20,
+        "labelArity": 10,
+        "numValues": 2000000,
+        "vectorDim": 100
+      }
+    }
+  }
+}

--- a/flink-ml-benchmark/src/test/java/org/apache/flink/ml/benchmark/BenchmarkTest.java
+++ b/flink-ml-benchmark/src/test/java/org/apache/flink/ml/benchmark/BenchmarkTest.java
@@ -45,7 +45,7 @@ public class BenchmarkTest extends AbstractTestBase {
     public void testParseJsonFile() throws Exception {
         File configFile = new File(tempFolder.newFolder().getAbsolutePath() + "/test-conf.json");
         InputStream inputStream =
-                this.getClass().getClassLoader().getResourceAsStream("benchmark-conf.json");
+                this.getClass().getClassLoader().getResourceAsStream("benchmark-demo.json");
         FileUtils.copyInputStreamToFile(inputStream, configFile);
 
         Map<String, ?> benchmarks = BenchmarkUtils.parseJsonFile(configFile.getAbsolutePath());
@@ -79,7 +79,7 @@ public class BenchmarkTest extends AbstractTestBase {
                 "paramMap",
                 new HashMap<String, Object>() {
                     {
-                        put("colNames", new String[] {"test_feature"});
+                        put("colNames", new String[][] {new String[] {"test_feature"}});
                         put("numValues", 1000L);
                         put("vectorDim", 10);
                     }

--- a/flink-ml-benchmark/src/test/java/org/apache/flink/ml/benchmark/DataGeneratorTest.java
+++ b/flink-ml-benchmark/src/test/java/org/apache/flink/ml/benchmark/DataGeneratorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark;
+
+import org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorArrayGenerator;
+import org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator;
+import org.apache.flink.ml.benchmark.datagenerator.common.LabeledPointWithWeightGenerator;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests data generators. */
+public class DataGeneratorTest {
+    @Test
+    public void testDenseVectorGenerator() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        DenseVectorGenerator generator =
+                new DenseVectorGenerator()
+                        .setColNames(new String[] {"denseVector"})
+                        .setNumValues(100)
+                        .setVectorDim(10);
+
+        int count = 0;
+        for (CloseableIterator<Row> it = generator.getData(tEnv)[0].execute().collect();
+                it.hasNext(); ) {
+            Row row = it.next();
+            assertEquals(row.getArity(), 1);
+            DenseVector vector = (DenseVector) row.getField(generator.getColNames()[0][0]);
+            assertEquals(vector.size(), generator.getVectorDim());
+            count++;
+        }
+        assertEquals(generator.getNumValues(), count);
+    }
+
+    @Test
+    public void testDenseVectorArrayGenerator() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        DenseVectorArrayGenerator generator =
+                new DenseVectorArrayGenerator()
+                        .setColNames(new String[] {"denseVectors"})
+                        .setNumValues(100)
+                        .setVectorDim(10)
+                        .setArraySize(20);
+
+        DataStream<DenseVector[]> stream =
+                tEnv.toDataStream(generator.getData(tEnv)[0], DenseVector[].class);
+
+        int count = 0;
+        for (CloseableIterator<DenseVector[]> it = stream.executeAndCollect(); it.hasNext(); ) {
+            DenseVector[] vectors = it.next();
+            assertEquals(generator.getArraySize(), vectors.length);
+            for (DenseVector vector : vectors) {
+                assertEquals(vector.size(), generator.getVectorDim());
+            }
+            count++;
+        }
+        assertEquals(generator.getNumValues(), count);
+    }
+
+    @Test
+    public void testLabeledPointWithWeightGenerator() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        String featuresCol = "features";
+        String labelCol = "label";
+        String weightCol = "weight";
+
+        LabeledPointWithWeightGenerator generator =
+                new LabeledPointWithWeightGenerator()
+                        .setFeatureArity(10)
+                        .setLabelArity(10)
+                        .setColNames(new String[] {featuresCol, labelCol, weightCol})
+                        .setNumValues(100);
+
+        int count = 0;
+        for (CloseableIterator<Row> it = generator.getData(tEnv)[0].execute().collect();
+                it.hasNext(); ) {
+            Row row = it.next();
+            count++;
+            DenseVector features = (DenseVector) row.getField(featuresCol);
+            for (double value : features.values) {
+                assertTrue(value >= 0);
+                assertTrue(value <= generator.getFeatureArity() - 1);
+            }
+
+            double label = (double) row.getField(labelCol);
+            assertTrue(label >= 0);
+            assertTrue(label <= generator.getLabelArity() - 1);
+
+            double weight = (double) row.getField(weightCol);
+            assertTrue(weight >= 0);
+            assertTrue(weight < 1);
+        }
+        assertEquals(generator.getNumValues(), count);
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/param/StringArrayArrayParam.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/param/StringArrayArrayParam.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.param;
+
+/** Class for the array of string array parameter. */
+public class StringArrayArrayParam extends ArrayArrayParam<String> {
+    public StringArrayArrayParam(
+            String name,
+            String description,
+            String[][] defaultValue,
+            ParamValidator<String[][]> validator) {
+        super(name, String[][].class, description, defaultValue, validator);
+    }
+
+    public StringArrayArrayParam(String name, String description, String[][] defaultValue) {
+        this(name, description, defaultValue, ParamValidators.alwaysTrue());
+    }
+}

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/api/StageTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/api/StageTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.ml.param.LongParam;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.param.ParamValidator;
 import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringArrayArrayParam;
 import org.apache.flink.ml.param.StringArrayParam;
 import org.apache.flink.ml.param.StringParam;
 import org.apache.flink.ml.param.WithParams;
@@ -100,6 +101,12 @@ public class StageTest {
 
         Param<String[]> STRING_ARRAY_PARAM =
                 new StringArrayParam("stringArrayParam", "Description", new String[] {"14", "15"});
+
+        Param<String[][]> STRING_ARRAY_ARRAY_PARAM =
+                new StringArrayArrayParam(
+                        "stringArrayArrayParam",
+                        "Description",
+                        new String[][] {new String[] {"14", "15"}});
 
         Param<Double[][]> DOUBLE_ARRAY_ARRAY_PARAM =
                 new DoubleArrayArrayParam(
@@ -333,6 +340,18 @@ public class StageTest {
                 new Double[] {50.0, 51.0}, stage.get(MyParams.DOUBLE_ARRAY_ARRAY_PARAM)[0]);
         Assert.assertArrayEquals(
                 new Double[] {52.0, 53.0}, stage.get(MyParams.DOUBLE_ARRAY_ARRAY_PARAM)[1]);
+
+        stage.set(
+                MyParams.STRING_ARRAY_ARRAY_PARAM,
+                new String[][] {
+                    new String[] {"50", "51"},
+                    new String[] {"52", "53"}
+                });
+        Assert.assertEquals(2, stage.get(MyParams.STRING_ARRAY_ARRAY_PARAM).length);
+        Assert.assertArrayEquals(
+                new String[] {"50", "51"}, stage.get(MyParams.STRING_ARRAY_ARRAY_PARAM)[0]);
+        Assert.assertArrayEquals(
+                new String[] {"52", "53"}, stage.get(MyParams.STRING_ARRAY_ARRAY_PARAM)[1]);
     }
 
     @Test
@@ -357,6 +376,12 @@ public class StageTest {
         stage.set(
                 MyParams.DOUBLE_ARRAY_ARRAY_PARAM,
                 new Double[][] {new Double[] {50.0, 51.0}, new Double[] {52.0, 53.0}});
+        stage.set(
+                MyParams.STRING_ARRAY_ARRAY_PARAM,
+                new String[][] {
+                    new String[] {"50", "51"},
+                    new String[] {"52", "53"}
+                });
 
         Stage<?> loadedStage = validateStageSaveLoad(tEnv, stage, Collections.emptyMap());
 
@@ -381,6 +406,11 @@ public class StageTest {
                 new Double[] {50.0, 51.0}, stage.get(MyParams.DOUBLE_ARRAY_ARRAY_PARAM)[0]);
         Assert.assertArrayEquals(
                 new Double[] {52.0, 53.0}, stage.get(MyParams.DOUBLE_ARRAY_ARRAY_PARAM)[1]);
+        Assert.assertEquals(2, stage.get(MyParams.STRING_ARRAY_ARRAY_PARAM).length);
+        Assert.assertArrayEquals(
+                new String[] {"50", "51"}, stage.get(MyParams.STRING_ARRAY_ARRAY_PARAM)[0]);
+        Assert.assertArrayEquals(
+                new String[] {"52", "53"}, stage.get(MyParams.STRING_ARRAY_ARRAY_PARAM)[1]);
     }
 
     @Test

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/minmaxscaler/MinMaxScalerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/minmaxscaler/MinMaxScalerParams.java
@@ -37,6 +37,13 @@ public interface MinMaxScalerParams<T> extends HasInputCol<T>, HasOutputCol<T> {
                     0.0,
                     ParamValidators.notNull());
 
+    Param<Double> MAX =
+            new DoubleParam(
+                    "max",
+                    "Upper bound of the output feature range.",
+                    1.0,
+                    ParamValidators.notNull());
+
     default Double getMin() {
         return get(MIN);
     }
@@ -44,13 +51,6 @@ public interface MinMaxScalerParams<T> extends HasInputCol<T>, HasOutputCol<T> {
     default T setMin(Double value) {
         return set(MIN, value);
     }
-
-    Param<Double> MAX =
-            new DoubleParam(
-                    "max",
-                    "Upper bound of the output feature range.",
-                    1.0,
-                    ParamValidators.notNull());
 
     default Double getMax() {
         return get(MAX);

--- a/pom.xml
+++ b/pom.xml
@@ -346,8 +346,6 @@ under the License.
             <exclude>**/LICENSE*</exclude>
             <!-- artifacts created during release process -->
             <exclude>release/**</exclude>
-            <!-- Test Data. -->
-            <exclude>flink-ml-benchmark/src/main/resources/*.json</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
This PR adds a `LabeledPointWithWeightGenerator` to `flink-ml-benchmark` module.

`LabeledPointWithWeightGenerator` is used to generate vector-typed features with double-typed label and weight. The generated tables can be used as the train or predict input data of some supervised algorithms. For example,
- Naive Bayes
- Logistic Regression
- Linear Regression
- Linear SVC
- Knn