### PR TITLE
[FLINK-27096] Add on-heap DataCache and optimize KMeans performance

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorSerializer.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorSerializer.java
@@ -84,7 +84,7 @@ public final class DenseVectorSerializer extends TypeSerializer<DenseVector> {
         target.writeInt(len);
 
         for (int i = 0; i < len; i++) {
-            Bits.putDouble(buf, i << 3, vector.values[i]);
+            Bits.putDouble(buf, (i & 127) << 3, vector.values[i]);
             if ((i & 127) == 127) {
                 target.write(buf);
             }

--- a/flink-ml-dist/pom.xml
+++ b/flink-ml-dist/pom.xml
@@ -55,6 +55,15 @@ under the License.
             <scope>compile</scope>
         </dependency>
 
+        <!-- Java Object Layout Dependencies -->
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <version>0.16</version>
+            <scope>compile</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/flink-ml-dist/src/main/assemblies/bin.xml
+++ b/flink-ml-dist/src/main/assemblies/bin.xml
@@ -35,6 +35,7 @@ under the License.
 
             <includes>
                 <include>org.apache.flink:statefun-flink-core</include>
+                <include>org.openjdk.jol:jol-core</include>
                 <include>org.apache.flink:flink-ml-uber</include>
             </includes>
         </dependencySet>

--- a/flink-ml-iteration/pom.xml
+++ b/flink-ml-iteration/pom.xml
@@ -171,5 +171,11 @@ under the License.
             <artifactId>flink-table-runtime</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <version>0.16</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/config/DataCacheStrategy.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/config/DataCacheStrategy.java
@@ -16,21 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.iteration.datacache.nonkeyed;
+package org.apache.flink.iteration.config;
 
-import org.apache.flink.annotation.Internal;
+/** The strategy to store cache data. */
+public enum DataCacheStrategy {
+    ON_HEAP_AND_DISK(true, false),
+    OFF_HEAP_AND_DISK(false, true),
+    DISK_ONLY(false, false);
 
-import java.io.IOException;
+    /** Whether to use on-heap memory for cache. */
+    public final boolean useOnHeap;
 
-/** Reader for the cached data in a segment. */
-@Internal
-interface SegmentReader<T> {
-    /** Checks whether the reader has next record. */
-    boolean hasNext();
+    /** Whether to use off-heap memory for cache. */
+    public final boolean useOffHeap;
 
-    /** Gets the next record from the reader. */
-    T next() throws IOException;
-
-    /** Closes resources used by the reader. */
-    default void close() throws IOException {}
+    DataCacheStrategy(boolean useOnHeap, boolean useOffHeap) {
+        this.useOnHeap = useOnHeap;
+        this.useOffHeap = useOffHeap;
+    }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/config/IterationOptions.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/config/IterationOptions.java
@@ -20,18 +20,36 @@ package org.apache.flink.iteration.config;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.description.Description;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
 /** The options for the iteration. */
 public class IterationOptions {
-
+    // TODO: create configuration section in Flink ML's document and add these.
     public static final ConfigOption<String> DATA_CACHE_PATH =
             key("iteration.data-cache.path")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "The base path of the data cached used inside the iteration. "
-                                    + "If not specified, it will use local path randomly chosen from "
-                                    + CoreOptions.TMP_DIRS.key());
+                            Description.builder()
+                                    .text(
+                                            "The base path of the data cached used inside the iteration. ")
+                                    .text(
+                                            "If not specified, it will use local path randomly chosen from ")
+                                    .text(CoreOptions.TMP_DIRS.key())
+                                    .build());
+
+    public static final ConfigOption<DataCacheStrategy> DATA_CACHE_STRATEGY =
+            key("iteration.data-cache.strategy")
+                    .enumType(DataCacheStrategy.class)
+                    .defaultValue(DataCacheStrategy.OFF_HEAP_AND_DISK)
+                    .withDescription("The strategy to store cache data.");
+
+    public static final ConfigOption<Double> DATA_CACHE_HEAP_MEMORY_FRACTION =
+            key("iteration.data-cache.heap.memory.fraction")
+                    .doubleType()
+                    .defaultValue(0.3)
+                    .withDescription(
+                            "Fraction of total task heap memory reserved for storing cache data.");
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheReader.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheReader.java
@@ -97,8 +97,11 @@ public class DataCacheReader<T> implements Iterator<T> {
             }
 
             Segment segment = segments.get(currentSegmentIndex);
-            if (!segment.getCache().isEmpty()) {
-                currentSegmentReader = new MemorySegmentReader<>(serializer, segment, startOffset);
+            if (!segment.getOnHeapCache().isEmpty()) {
+                currentSegmentReader = new OnHeapMemorySegmentReader<>(segment, startOffset);
+            } else if (!segment.getOffHeapCache().isEmpty()) {
+                currentSegmentReader =
+                        new OffHeapMemorySegmentReader<>(serializer, segment, startOffset);
             } else {
                 currentSegmentReader = new FileSegmentReader<>(serializer, segment, startOffset);
             }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OffHeapMemorySegmentReader.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OffHeapMemorySegmentReader.java
@@ -28,9 +28,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-/** A class that reads data cached in memory. */
+/** A class that reads data cached in off-heap memory. */
 @Internal
-class MemorySegmentReader<T> implements SegmentReader<T> {
+class OffHeapMemorySegmentReader<T> implements SegmentReader<T> {
 
     /** The tool to deserialize bytes into records. */
     private final TypeSerializer<T> serializer;
@@ -44,9 +44,10 @@ class MemorySegmentReader<T> implements SegmentReader<T> {
     /** The number of records that have been read so far. */
     private int count;
 
-    MemorySegmentReader(TypeSerializer<T> serializer, Segment segment, int startOffset)
+    OffHeapMemorySegmentReader(TypeSerializer<T> serializer, Segment segment, int startOffset)
             throws IOException {
-        ManagedMemoryInputStream inputStream = new ManagedMemoryInputStream(segment.getCache());
+        ManagedMemoryInputStream inputStream =
+                new ManagedMemoryInputStream(segment.getOffHeapCache());
         this.inputView = new DataInputViewStreamWrapper(inputStream);
         this.serializer = serializer;
         this.totalCount = segment.getCount();
@@ -68,9 +69,6 @@ class MemorySegmentReader<T> implements SegmentReader<T> {
         count++;
         return value;
     }
-
-    @Override
-    public void close() {}
 
     /** An input stream subclass that reads bytes from memory segments. */
     private static class ManagedMemoryInputStream extends InputStream {

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OffHeapMemorySegmentWriter.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OffHeapMemorySegmentWriter.java
@@ -35,9 +35,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-/** A class that writes cache data to memory segments. */
+/** A class that writes cache data to off-heap memory segments. */
 @Internal
-class MemorySegmentWriter<T> implements SegmentWriter<T> {
+class OffHeapMemorySegmentWriter<T> implements SegmentWriter<T> {
 
     /** The tool to serialize received records into bytes. */
     private final TypeSerializer<T> serializer;
@@ -57,7 +57,7 @@ class MemorySegmentWriter<T> implements SegmentWriter<T> {
     /** The number of records added so far. */
     private int count;
 
-    MemorySegmentWriter(
+    OffHeapMemorySegmentWriter(
             TypeSerializer<T> serializer,
             Path path,
             MemorySegmentPool segmentPool,

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OnHeapMemoryPool.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OnHeapMemoryPool.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.iteration.config.IterationOptions;
+import org.apache.flink.util.Preconditions;
+
+/** A class that manages bookkeeping for a fixed-size heap memory space. */
+@Internal
+public class OnHeapMemoryPool {
+
+    private static Configuration configuration;
+
+    private static OnHeapMemoryPool onHeapMemoryPool;
+
+    /** The number of bytes this pool can allocate at most. */
+    private final long poolSize;
+
+    /** The number of allocated bytes. */
+    private long memoryUsed;
+
+    OnHeapMemoryPool(long poolSize) {
+        this.poolSize = poolSize;
+        this.memoryUsed = 0L;
+    }
+
+    /**
+     * Gets or creates the {@link OnHeapMemoryPool} instance from the provided {@param
+     * configuration} and registers it as a singleton object. There would be only one {@link
+     * OnHeapMemoryPool} instance for each JVM (TaskManager).
+     */
+    public static OnHeapMemoryPool getOrCreate(Configuration configuration) {
+        if (onHeapMemoryPool != null) {
+            Preconditions.checkArgument(OnHeapMemoryPool.configuration.equals(configuration));
+            return onHeapMemoryPool;
+        }
+
+        OnHeapMemoryPool.configuration = configuration;
+        double dataCacheHeapMemoryFraction =
+                configuration.get(IterationOptions.DATA_CACHE_HEAP_MEMORY_FRACTION);
+        MemorySize memorySize =
+                configuration
+                        .get(TaskManagerOptions.TASK_HEAP_MEMORY)
+                        .multiply(dataCacheHeapMemoryFraction);
+
+        onHeapMemoryPool = new OnHeapMemoryPool(memorySize.getBytes());
+        return onHeapMemoryPool;
+    }
+
+    long getMemoryUsed() {
+        return memoryUsed;
+    }
+
+    /**
+     * Acquires a certain number of bytes from the memory space.
+     *
+     * @return true if the bytes are successfully acquired, false if there is not enough space for
+     *     the bytes.
+     */
+    public boolean acquireMemory(long numBytesToAcquire) {
+        if (numBytesToAcquire + memoryUsed > poolSize) {
+            return false;
+        }
+        memoryUsed += numBytesToAcquire;
+        return true;
+    }
+
+    /** Returns a certain number of bytes to the memory space. */
+    public void releaseMemory(long numBytesToRelease) {
+        memoryUsed -= numBytesToRelease;
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OnHeapMemorySegmentReader.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OnHeapMemorySegmentReader.java
@@ -18,19 +18,30 @@
 
 package org.apache.flink.iteration.datacache.nonkeyed;
 
-import org.apache.flink.annotation.Internal;
-
 import java.io.IOException;
+import java.util.List;
 
-/** Reader for the cached data in a segment. */
-@Internal
-interface SegmentReader<T> {
-    /** Checks whether the reader has next record. */
-    boolean hasNext();
+/** A class that reads data cached in heap memory. */
+public class OnHeapMemorySegmentReader<T> implements SegmentReader<T> {
 
-    /** Gets the next record from the reader. */
-    T next() throws IOException;
+    /** The cached data. */
+    private final List<T> list;
 
-    /** Closes resources used by the reader. */
-    default void close() throws IOException {}
+    /** The number of records that have been read so far. */
+    private int count;
+
+    public OnHeapMemorySegmentReader(Segment segment, int startOffset) {
+        this.list = segment.getOnHeapCache();
+        this.count = startOffset;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return count < list.size();
+    }
+
+    @Override
+    public T next() throws IOException {
+        return list.get(count++);
+    }
 }

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OnHeapMemorySegmentWriter.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OnHeapMemorySegmentWriter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.core.fs.Path;
+
+import org.openjdk.jol.info.GraphLayout;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/** A class that writes cache data to heap memory. */
+public class OnHeapMemorySegmentWriter<T> implements SegmentWriter<T> {
+
+    /** The pre-allocated path to hold cached records into the file system. */
+    private final Path path;
+
+    /** The pool to allocate heap memory space from. */
+    private final OnHeapMemoryPool memoryPool;
+
+    /** The cached data. */
+    private final List<T> list = new ArrayList<>();
+
+    public OnHeapMemorySegmentWriter(Path path, OnHeapMemoryPool memoryPool) {
+        this.path = path;
+        this.memoryPool = memoryPool;
+    }
+
+    @Override
+    public boolean addRecord(T record) throws IOException {
+        long recordSize = GraphLayout.parseInstance(record).totalSize();
+        if (!memoryPool.acquireMemory(recordSize)) {
+            return false;
+        }
+        list.add(record);
+        return true;
+    }
+
+    @Override
+    public Optional<Segment> finish() throws IOException {
+        if (list.size() > 0) {
+            return Optional.of(new Segment(path, list));
+        }
+        return Optional.empty();
+    }
+}

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/Segment.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/Segment.java
@@ -49,10 +49,16 @@ public class Segment {
     private long fsSize = 0L;
 
     /**
-     * The memory segments containing cached records. This list is empty iff the segment has not
-     * been cached in memory.
+     * The off-heap memory segments containing cached records. This list is empty iff the segment
+     * has not been cached in off-heap memory.
      */
-    private List<MemorySegment> cache = new ArrayList<>();
+    private List<MemorySegment> offHeapCache = new ArrayList<>();
+
+    /**
+     * The on-heap cached records. This list is empty iff the segment has not been cached in heap
+     * memory.
+     */
+    private List<Object> onHeapCache = new ArrayList<>();
 
     Segment(Path path, int count, long fsSize) {
         this.path = path;
@@ -64,17 +70,32 @@ public class Segment {
         checkArgument(fsSize > 0);
     }
 
-    Segment(Path path, int count, List<MemorySegment> cache) {
+    Segment(Path path, int count, List<MemorySegment> offHeapCache) {
         this.path = path;
         this.count = count;
-        this.cache = cache;
+        this.offHeapCache = offHeapCache;
 
         checkNotNull(path);
         checkArgument(count > 0);
     }
 
-    void setCache(List<MemorySegment> cache) {
-        this.cache = cache;
+    @SuppressWarnings("unchecked")
+    <T> Segment(Path path, List<T> onHeapCache) {
+        this.path = path;
+        this.count = onHeapCache.size();
+        this.onHeapCache = (List<Object>) onHeapCache;
+
+        checkNotNull(path);
+        checkArgument(count > 0);
+    }
+
+    void setOffHeapCache(List<MemorySegment> offHeapCache) {
+        this.offHeapCache = offHeapCache;
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> void setOnHeapCache(List<T> onHeapCache) {
+        this.onHeapCache = (List<Object>) onHeapCache;
     }
 
     void setFsSize(long fsSize) {
@@ -94,8 +115,13 @@ public class Segment {
         return fsSize;
     }
 
-    List<MemorySegment> getCache() {
-        return cache;
+    List<MemorySegment> getOffHeapCache() {
+        return offHeapCache;
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> List<T> getOnHeapCache() {
+        return (List<T>) onHeapCache;
     }
 
     @Override

--- a/flink-ml-iteration/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheWriteReadTest.java
+++ b/flink-ml-iteration/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/DataCacheWriteReadTest.java
@@ -143,7 +143,72 @@ public class DataCacheWriteReadTest extends TestLogger {
     }
 
     @Test
-    public void testCacheInMemory() throws IOException {
+    public void testCacheInOnHeapMemory() throws IOException {
+        int numRecords = 1024;
+        long poolSize = numRecords * 20;
+
+        OnHeapMemoryPool onHeapMemoryPool = new OnHeapMemoryPool(poolSize);
+
+        DataCacheWriter<Integer> writer =
+                new DataCacheWriter<>(
+                        IntSerializer.INSTANCE,
+                        fileSystem,
+                        () -> new Path(basePath, "test_cache." + UUID.randomUUID()),
+                        onHeapMemoryPool);
+        for (int i = 0; i < numRecords; ++i) {
+            writer.addRecord(i);
+        }
+
+        List<Segment> segments = writer.finish();
+        assertTrue(onHeapMemoryPool.getMemoryUsed() < poolSize);
+        long memoryUsed = onHeapMemoryPool.getMemoryUsed();
+
+        for (int i = 0; i < 2; i++) {
+            DataCacheReader<Integer> reader =
+                    new DataCacheReader<>(IntSerializer.INSTANCE, segments);
+            List<Integer> read = new ArrayList<>();
+            while (reader.hasNext()) {
+                read.add(reader.next());
+            }
+
+            assertEquals(IntStream.range(0, numRecords).boxed().collect(Collectors.toList()), read);
+            assertEquals(memoryUsed, onHeapMemoryPool.getMemoryUsed());
+        }
+    }
+
+    @Test
+    public void testInsufficientOnHeapMemory() throws IOException {
+        int numRecords = 1024;
+        long poolSize = numRecords * 2;
+
+        OnHeapMemoryPool onHeapMemoryPool = new OnHeapMemoryPool(poolSize);
+
+        DataCacheWriter<Integer> writer =
+                new DataCacheWriter<>(
+                        IntSerializer.INSTANCE,
+                        fileSystem,
+                        () -> new Path(basePath, "test_cache." + UUID.randomUUID()),
+                        onHeapMemoryPool);
+        for (int i = 0; i < numRecords; ++i) {
+            writer.addRecord(i);
+        }
+
+        List<Segment> segments = writer.finish();
+        assertTrue(segments.size() > 1);
+        assertTrue(segments.get(1).getFsSize() > 0);
+
+        for (int i = 0; i < 2; i++) {
+            DataCacheReader<Integer> reader =
+                    new DataCacheReader<>(IntSerializer.INSTANCE, segments);
+            List<Integer> read = new ArrayList<>();
+            while (reader.hasNext()) {
+                read.add(reader.next());
+            }
+        }
+    }
+
+    @Test
+    public void testCacheInOffHeapMemory() throws IOException {
         int numRecords = 10240;
         int pageSize = 4096;
         int pageNum = 64;
@@ -181,7 +246,7 @@ public class DataCacheWriteReadTest extends TestLogger {
     }
 
     @Test
-    public void testInsufficientMemoryForWriter() throws IOException {
+    public void testInsufficientOffHeapMemoryForWriter() throws IOException {
         int numRecords = 10240;
         int pageSize = 4096;
         int pageNum = 4;
@@ -219,7 +284,7 @@ public class DataCacheWriteReadTest extends TestLogger {
     }
 
     @Test
-    public void testInsufficientMemoryForReader() throws IOException {
+    public void testInsufficientOffHeapMemoryForReader() throws IOException {
         int numRecords = 10240;
         int pageSize = 4096;
         int pageNum = 4;

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
@@ -23,10 +23,9 @@ import org.apache.flink.api.common.functions.MapPartitionFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.iteration.DataStreamList;
@@ -40,10 +39,10 @@ import org.apache.flink.iteration.datacache.nonkeyed.ListStateWithCache;
 import org.apache.flink.iteration.operator.OperatorStateUtils;
 import org.apache.flink.ml.api.Estimator;
 import org.apache.flink.ml.common.datastream.DataStreamUtils;
-import org.apache.flink.ml.common.datastream.EndOfStreamWindows;
 import org.apache.flink.ml.common.distance.DistanceMeasure;
 import org.apache.flink.ml.common.iteration.ForwardInputsOfLastRound;
 import org.apache.flink.ml.common.iteration.TerminateOnMaxIter;
+import org.apache.flink.ml.linalg.BLAS;
 import org.apache.flink.ml.linalg.DenseVector;
 import org.apache.flink.ml.linalg.Vector;
 import org.apache.flink.ml.linalg.typeinfo.DenseVectorSerializer;
@@ -54,10 +53,8 @@ import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.functions.windowing.AllWindowFunction;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
-import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -65,10 +62,9 @@ import org.apache.flink.table.api.internal.TableImpl;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.commons.collections.IteratorUtils;
-
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -153,39 +149,24 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
             DataStream<Integer> terminationCriteria =
                     centroids.flatMap(new TerminateOnMaxIter(maxIterationNum));
 
-            DataStream<Tuple2<Integer, DenseVector>> centroidIdAndPoints =
+            DataStream<Tuple2<Integer[], DenseVector[]>> centroidIdAndPoints =
                     points.connect(centroids.broadcast())
                             .transform(
-                                    "SelectNearestCentroid",
+                                    "CentroidsUpdateAccumulator",
                                     new TupleTypeInfo<>(
-                                            BasicTypeInfo.INT_TYPE_INFO,
-                                            DenseVectorTypeInfo.INSTANCE),
-                                    new SelectNearestCentroidOperator(distanceMeasure));
+                                            BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO,
+                                            ObjectArrayTypeInfo.getInfoFor(
+                                                    DenseVectorTypeInfo.INSTANCE)),
+                                    new CentroidsUpdateAccumulator(distanceMeasure));
 
             DataStreamUtils.setManagedMemoryWeight(centroidIdAndPoints.getTransformation(), 100);
 
-            PerRoundSubBody perRoundSubBody =
-                    new PerRoundSubBody() {
-                        @Override
-                        public DataStreamList process(DataStreamList inputs) {
-                            DataStream<Tuple2<Integer, DenseVector>> centroidIdAndPoints =
-                                    inputs.get(0);
-                            DataStream<KMeansModelData> modelDataStream =
-                                    centroidIdAndPoints
-                                            .map(new CountAppender())
-                                            .keyBy(t -> t.f0)
-                                            .window(EndOfStreamWindows.get())
-                                            .reduce(new CentroidAccumulator())
-                                            .map(new CentroidAverager())
-                                            .windowAll(EndOfStreamWindows.get())
-                                            .apply(new ModelDataGenerator());
-                            return DataStreamList.of(modelDataStream);
-                        }
-                    };
+            int parallelism = centroidIdAndPoints.getParallelism();
             DataStream<KMeansModelData> newModelData =
-                    IterationBody.forEachRound(
-                                    DataStreamList.of(centroidIdAndPoints), perRoundSubBody)
-                            .get(0);
+                    centroidIdAndPoints
+                            .countWindowAll(parallelism)
+                            .reduce(new CentroidsUpdateReducer())
+                            .map(new ModelDataGenerator());
 
             DataStream<DenseVector[]> newCentroids =
                     newModelData.map(x -> x.centroids).setParallelism(1);
@@ -200,62 +181,40 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
         }
     }
 
+    private static class CentroidsUpdateReducer
+            implements ReduceFunction<Tuple2<Integer[], DenseVector[]>> {
+        @Override
+        public Tuple2<Integer[], DenseVector[]> reduce(
+                Tuple2<Integer[], DenseVector[]> tuple2, Tuple2<Integer[], DenseVector[]> t1)
+                throws Exception {
+            for (int i = 0; i < tuple2.f0.length; i++) {
+                tuple2.f0[i] += t1.f0[i];
+                BLAS.axpy(1.0, t1.f1[i], tuple2.f1[i]);
+            }
+
+            return tuple2;
+        }
+    }
+
     private static class ModelDataGenerator
-            implements AllWindowFunction<Tuple2<DenseVector, Double>, KMeansModelData, TimeWindow> {
+            implements MapFunction<Tuple2<Integer[], DenseVector[]>, KMeansModelData> {
         @Override
-        public void apply(
-                TimeWindow timeWindow,
-                Iterable<Tuple2<DenseVector, Double>> iterable,
-                Collector<KMeansModelData> collector) {
-            List<Tuple2<DenseVector, Double>> list = IteratorUtils.toList(iterable.iterator());
-            DenseVector[] centroids = new DenseVector[list.size()];
-            DenseVector weights = new DenseVector(list.size());
-            for (int i = 0; i < list.size(); i++) {
-                centroids[i] = list.get(i).f0;
-                weights.values[i] = list.get(i).f1;
+        public KMeansModelData map(Tuple2<Integer[], DenseVector[]> tuple2) throws Exception {
+            double[] weights = new double[tuple2.f0.length];
+            for (int i = 0; i < tuple2.f0.length; i++) {
+                BLAS.scal(1.0 / tuple2.f0[i], tuple2.f1[i]);
+                weights[i] = tuple2.f0[i];
             }
-            collector.collect(new KMeansModelData(centroids, weights));
+
+            return new KMeansModelData(tuple2.f1, new DenseVector(weights));
         }
     }
 
-    private static class CentroidAverager
-            implements MapFunction<
-                    Tuple3<Integer, DenseVector, Long>, Tuple2<DenseVector, Double>> {
-        @Override
-        public Tuple2<DenseVector, Double> map(Tuple3<Integer, DenseVector, Long> value) {
-            for (int i = 0; i < value.f1.size(); i++) {
-                value.f1.values[i] /= value.f2;
-            }
-            return Tuple2.of(value.f1, value.f2.doubleValue());
-        }
-    }
-
-    private static class CentroidAccumulator
-            implements ReduceFunction<Tuple3<Integer, DenseVector, Long>> {
-        @Override
-        public Tuple3<Integer, DenseVector, Long> reduce(
-                Tuple3<Integer, DenseVector, Long> v1, Tuple3<Integer, DenseVector, Long> v2) {
-            for (int i = 0; i < v1.f1.size(); i++) {
-                v1.f1.values[i] += v2.f1.values[i];
-            }
-            return new Tuple3<>(v1.f0, v1.f1, v1.f2 + v2.f2);
-        }
-    }
-
-    private static class CountAppender
-            implements MapFunction<
-                    Tuple2<Integer, DenseVector>, Tuple3<Integer, DenseVector, Long>> {
-        @Override
-        public Tuple3<Integer, DenseVector, Long> map(Tuple2<Integer, DenseVector> value) {
-            return Tuple3.of(value.f0, value.f1, 1L);
-        }
-    }
-
-    private static class SelectNearestCentroidOperator
-            extends AbstractStreamOperator<Tuple2<Integer, DenseVector>>
+    private static class CentroidsUpdateAccumulator
+            extends AbstractStreamOperator<Tuple2<Integer[], DenseVector[]>>
             implements TwoInputStreamOperator<
-                            DenseVector, DenseVector[], Tuple2<Integer, DenseVector>>,
-                    IterationListener<Tuple2<Integer, DenseVector>> {
+                            DenseVector, DenseVector[], Tuple2<Integer[], DenseVector[]>>,
+                    IterationListener<Tuple2<Integer[], DenseVector[]>> {
 
         private final DistanceMeasure distanceMeasure;
 
@@ -263,7 +222,7 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
 
         private ListStateWithCache<DenseVector> points;
 
-        public SelectNearestCentroidOperator(DistanceMeasure distanceMeasure) {
+        public CentroidsUpdateAccumulator(DistanceMeasure distanceMeasure) {
             super();
             this.distanceMeasure = distanceMeasure;
         }
@@ -307,24 +266,41 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
 
         @Override
         public void onEpochWatermarkIncremented(
-                int epochWatermark, Context context, Collector<Tuple2<Integer, DenseVector>> out)
+                int epochWatermark,
+                Context context,
+                Collector<Tuple2<Integer[], DenseVector[]>> out)
                 throws Exception {
             DenseVector[] centroidValues =
                     Objects.requireNonNull(
                             OperatorStateUtils.getUniqueElement(centroids, "centroids")
                                     .orElse(null));
+
+            DenseVector[] newCentroids = new DenseVector[centroidValues.length];
+            int[] counts = new int[centroidValues.length];
+            for (int i = 0; i < centroidValues.length; i++) {
+                newCentroids[i] = new DenseVector(centroidValues[i].size());
+            }
+
             for (DenseVector point : points.get()) {
                 int closestCentroidId =
                         findClosestCentroidId(centroidValues, point, distanceMeasure);
-                output.collect(new StreamRecord<>(Tuple2.of(closestCentroidId, point)));
+
+                BLAS.axpy(1.0, point, newCentroids[closestCentroidId]);
+                counts[closestCentroidId]++;
             }
+
+            output.collect(
+                    new StreamRecord<>(
+                            Tuple2.of(
+                                    Arrays.stream(counts).boxed().toArray(Integer[]::new),
+                                    newCentroids)));
 
             centroids.clear();
         }
 
         @Override
         public void onIterationTerminated(
-                Context context, Collector<Tuple2<Integer, DenseVector>> collector) {
+                Context context, Collector<Tuple2<Integer[], DenseVector[]>> collector) {
             centroids.clear();
             points.clear();
         }


### PR DESCRIPTION
## What is the purpose of the change
This PR mainly adds a data cache option that allows to store cached records in heap memory in deserialized format, and further optimizes the performance of KMeans algorithm.

## Brief change log
- Add `DATA_CACHE_STRATEGY` and `DATA_CACHE_HEAP_MEMORY_FRACTION` in `IterationOptions` to control how to cache records and how much memory space can be used for caching.
- Add `OnHeapMemoryPool` to control the usage of heap memory.
- Add `OnHeapMemorySegmentReader/Writer` for the implementation  of on-heap cache.
- Modify `DataCacheWriter`, `DataCacheSnapshot` and `ListStateWithCache` to support on-heap cache with the introduced classes above.
- Add tests to verify the correctness of introduced classes.
- Refractor KMeans implementation to reduce the overhead of data transmission.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)