### PR TITLE
[FLINK-27096] Optimize KMeans performance

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/distance/DistanceMeasure.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/distance/DistanceMeasure.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.ml.common.distance;
 
-import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.VectorWithNorm;
 
 import java.io.Serializable;
 
@@ -40,5 +40,8 @@ public interface DistanceMeasure extends Serializable {
      *
      * <p>Required: The two vectors should have the same dimension.
      */
-    double distance(Vector v1, Vector v2);
+    double distance(VectorWithNorm v1, VectorWithNorm v2);
+
+    /** Finds the index of the closest center to the given point. */
+    int findClosest(VectorWithNorm[] centroids, VectorWithNorm point);
 }

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/BLAS.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/BLAS.java
@@ -114,8 +114,19 @@ public class BLAS {
     }
 
     /** \sqrt(\sum_i x_i * x_i) . */
-    public static double norm2(DenseVector x) {
+    public static double norm2(Vector x) {
+        if (x instanceof DenseVector) {
+            return norm2((DenseVector) x);
+        }
+        return norm2((SparseVector) x);
+    }
+
+    private static double norm2(DenseVector x) {
         return JAVA_BLAS.dnrm2(x.size(), x.values, 1);
+    }
+
+    private static double norm2(SparseVector x) {
+        return JAVA_BLAS.dnrm2(x.values.length, x.values, 1);
     }
 
     /** x = x * a . */

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/VectorWithNorm.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/VectorWithNorm.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.ml.linalg;
+
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.ml.linalg.typeinfo.VectorWithNormTypeInfoFactory;
+
+/** A vector with its norm. */
+@TypeInfo(VectorWithNormTypeInfoFactory.class)
+public class VectorWithNorm {
+    public final Vector vector;
+
+    public final double l2Norm;
+
+    public VectorWithNorm(Vector vector) {
+        this(vector, BLAS.norm2(vector));
+    }
+
+    public VectorWithNorm(Vector vector, double l2Norm) {
+        this.vector = vector;
+        this.l2Norm = l2Norm;
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorSerializer.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/DenseVectorSerializer.java
@@ -84,7 +84,7 @@ public final class DenseVectorSerializer extends TypeSerializer<DenseVector> {
         target.writeInt(len);
 
         for (int i = 0; i < len; i++) {
-            Bits.putDouble(buf, i << 3, vector.values[i]);
+            Bits.putDouble(buf, (i & 127) << 3, vector.values[i]);
             if ((i & 127) == 127) {
                 target.write(buf);
             }
@@ -104,12 +104,12 @@ public final class DenseVectorSerializer extends TypeSerializer<DenseVector> {
     private void readDoubleArray(double[] dst, DataInputView source, int len) throws IOException {
         int index = 0;
         for (int i = 0; i < (len >> 7); i++) {
-            source.read(buf, 0, 1024);
+            source.readFully(buf, 0, 1024);
             for (int j = 0; j < 128; j++) {
                 dst[index++] = Bits.getDouble(buf, j << 3);
             }
         }
-        source.read(buf, 0, (len << 3) & 1023);
+        source.readFully(buf, 0, (len << 3) & 1023);
         for (int j = 0; j < (len & 127); j++) {
             dst[index++] = Bits.getDouble(buf, j << 3);
         }

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/VectorWithNormSerializer.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/VectorWithNormSerializer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.ml.linalg.typeinfo;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.VectorWithNorm;
+
+import java.io.IOException;
+
+/** Specialized serializer for {@link VectorWithNorm}. */
+public class VectorWithNormSerializer extends TypeSerializer<VectorWithNorm> {
+    private final VectorSerializer vectorSerializer = new VectorSerializer();
+
+    private static final long serialVersionUID = 1L;
+
+    private static final double[] EMPTY = new double[0];
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<VectorWithNorm> duplicate() {
+        return new VectorWithNormSerializer();
+    }
+
+    @Override
+    public VectorWithNorm createInstance() {
+        return new VectorWithNorm(new DenseVector(EMPTY));
+    }
+
+    @Override
+    public VectorWithNorm copy(VectorWithNorm from) {
+        Vector vector = vectorSerializer.copy(from.vector);
+        return new VectorWithNorm(vector, from.l2Norm);
+    }
+
+    @Override
+    public VectorWithNorm copy(VectorWithNorm from, VectorWithNorm reuse) {
+        Vector vector = vectorSerializer.copy(from.vector, reuse.vector);
+        return new VectorWithNorm(vector, from.l2Norm);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(VectorWithNorm from, DataOutputView dataOutputView) throws IOException {
+        vectorSerializer.serialize(from.vector, dataOutputView);
+        dataOutputView.writeDouble(from.l2Norm);
+    }
+
+    @Override
+    public VectorWithNorm deserialize(DataInputView dataInputView) throws IOException {
+        Vector vector = vectorSerializer.deserialize(dataInputView);
+        double l2NormSquare = dataInputView.readDouble();
+        return new VectorWithNorm(vector, l2NormSquare);
+    }
+
+    @Override
+    public VectorWithNorm deserialize(VectorWithNorm reuse, DataInputView dataInputView)
+            throws IOException {
+        Vector vector = vectorSerializer.deserialize(reuse.vector, dataInputView);
+        double l2NormSquare = dataInputView.readDouble();
+        return new VectorWithNorm(vector, l2NormSquare);
+    }
+
+    @Override
+    public void copy(DataInputView dataInputView, DataOutputView dataOutputView)
+            throws IOException {
+        vectorSerializer.copy(dataInputView, dataOutputView);
+        dataOutputView.write(dataInputView, 8);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof VectorWithNormSerializer;
+    }
+
+    @Override
+    public int hashCode() {
+        return VectorWithNormSerializer.class.hashCode();
+    }
+
+    @Override
+    public TypeSerializerSnapshot<VectorWithNorm> snapshotConfiguration() {
+        return new VectorWithNormSerializerSnapshot();
+    }
+
+    private static class VectorWithNormSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<VectorWithNorm> {
+        public VectorWithNormSerializerSnapshot() {
+            super(VectorWithNormSerializer::new);
+        }
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/VectorWithNormTypeInfo.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/VectorWithNormTypeInfo.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.ml.linalg.typeinfo;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.ml.linalg.VectorWithNorm;
+
+/** A {@link TypeInformation} for the {@link VectorWithNorm} type. */
+public class VectorWithNormTypeInfo extends TypeInformation<VectorWithNorm> {
+    @Override
+    public boolean isBasicType() {
+        return false;
+    }
+
+    @Override
+    public boolean isTupleType() {
+        return false;
+    }
+
+    @Override
+    public int getArity() {
+        return 2;
+    }
+
+    @Override
+    public int getTotalFields() {
+        return 2;
+    }
+
+    @Override
+    public Class<VectorWithNorm> getTypeClass() {
+        return VectorWithNorm.class;
+    }
+
+    @Override
+    public boolean isKeyType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<VectorWithNorm> createSerializer(ExecutionConfig executionConfig) {
+        return new VectorWithNormSerializer();
+    }
+
+    @Override
+    public String toString() {
+        return "VectorWithNormType";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof VectorWithNormTypeInfo;
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public boolean canEqual(Object o) {
+        return o instanceof VectorWithNormTypeInfo;
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/VectorWithNormTypeInfoFactory.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/typeinfo/VectorWithNormTypeInfoFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.ml.linalg.typeinfo;
+
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.ml.linalg.VectorWithNorm;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/** Used by {@link TypeExtractor} to create a {@link TypeInformation} for {@link VectorWithNorm}. */
+public class VectorWithNormTypeInfoFactory extends TypeInfoFactory<VectorWithNorm> {
+    @Override
+    public TypeInformation<VectorWithNorm> createTypeInfo(
+            Type type, Map<String, TypeInformation<?>> map) {
+        return new VectorWithNormTypeInfo();
+    }
+}

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/BLASTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/BLASTest.java
@@ -86,8 +86,10 @@ public class BLASTest {
 
     @Test
     public void testNorm2() {
-        double expectedResult = Math.sqrt(55);
-        assertEquals(expectedResult, BLAS.norm2(inputDenseVec), TOLERANCE);
+        assertEquals(Math.sqrt(55), BLAS.norm2(inputDenseVec), TOLERANCE);
+
+        SparseVector sparseVector = Vectors.sparse(5, new int[] {0, 2, 4}, new double[] {1, 3, 5});
+        assertEquals(Math.sqrt(35), BLAS.norm2(sparseVector), TOLERANCE);
     }
 
     @Test

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/VectorWithNormTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/VectorWithNormTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.linalg;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests the behavior of {@link VectorWithNorm}. */
+public class VectorWithNormTest {
+    @Test
+    public void testL2Norm() {
+        DenseVector denseVector = Vectors.dense(1, 2, 3);
+        VectorWithNorm denseVectorWithNorm = new VectorWithNorm(denseVector);
+        assertEquals(denseVector, denseVectorWithNorm.vector);
+        assertEquals(Math.sqrt(14), denseVectorWithNorm.l2Norm, 1e-7);
+
+        SparseVector sparseVector = Vectors.sparse(5, new int[] {0, 2, 4}, new double[] {1, 2, 3});
+        VectorWithNorm sparseVectorWithNorm = new VectorWithNorm(sparseVector);
+        assertEquals(sparseVector, sparseVectorWithNorm.vector);
+        assertEquals(Math.sqrt(14), sparseVectorWithNorm.l2Norm, 1e-7);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModel.java
@@ -28,6 +28,7 @@ import org.apache.flink.ml.common.datastream.TableUtils;
 import org.apache.flink.ml.common.distance.DistanceMeasure;
 import org.apache.flink.ml.linalg.DenseVector;
 import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.VectorWithNorm;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
@@ -111,7 +112,7 @@ public class KMeansModel implements Model<KMeansModel>, KMeansModelParams<KMeans
 
         private final int k;
 
-        private DenseVector[] centroids;
+        private VectorWithNorm[] centroids;
 
         public PredictLabelFunction(
                 String broadcastModelKey,
@@ -131,10 +132,14 @@ public class KMeansModel implements Model<KMeansModel>, KMeansModelParams<KMeans
                         (KMeansModelData)
                                 getRuntimeContext().getBroadcastVariable(broadcastModelKey).get(0);
                 Preconditions.checkArgument(modelData.centroids.length <= k);
-                centroids = modelData.centroids;
+                centroids = new VectorWithNorm[modelData.centroids.length];
+                for (int i = 0; i < modelData.centroids.length; i++) {
+                    centroids[i] = new VectorWithNorm(modelData.centroids[i]);
+                }
             }
             DenseVector point = ((Vector) dataPoint.getField(featuresCol)).toDense();
-            int closestCentroidId = KMeans.findClosestCentroidId(centroids, point, distanceMeasure);
+            int closestCentroidId =
+                    distanceMeasure.findClosest(centroids, new VectorWithNorm(point));
             return Row.join(dataPoint, Row.of(closestCentroidId));
         }
     }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeans.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeans.java
@@ -35,6 +35,7 @@ import org.apache.flink.ml.common.distance.DistanceMeasure;
 import org.apache.flink.ml.linalg.BLAS;
 import org.apache.flink.ml.linalg.DenseVector;
 import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.VectorWithNorm;
 import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
@@ -276,6 +277,10 @@ public class OnlineKMeans
             KMeansModelData modelData =
                     OperatorStateUtils.getUniqueElement(modelDataState, "modelData").get();
             DenseVector[] centroids = modelData.centroids;
+            VectorWithNorm[] centroidsWithNorm = new VectorWithNorm[modelData.centroids.length];
+            for (int i = 0; i < centroidsWithNorm.length; i++) {
+                centroidsWithNorm[i] = new VectorWithNorm(modelData.centroids[i]);
+            }
             DenseVector weights = modelData.weights;
             modelDataState.clear();
 
@@ -296,7 +301,7 @@ public class OnlineKMeans
             }
             for (DenseVector point : points) {
                 int closestCentroidId =
-                        KMeans.findClosestCentroidId(centroids, point, distanceMeasure);
+                        distanceMeasure.findClosest(centroidsWithNorm, new VectorWithNorm(point));
                 counts[closestCentroidId]++;
                 BLAS.axpy(1.0, point, sums[closestCentroidId]);
             }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeansModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeansModel.java
@@ -28,6 +28,7 @@ import org.apache.flink.ml.common.datastream.TableUtils;
 import org.apache.flink.ml.common.distance.DistanceMeasure;
 import org.apache.flink.ml.linalg.DenseVector;
 import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.VectorWithNorm;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
@@ -114,7 +115,7 @@ public class OnlineKMeansModel
 
         private final int k;
 
-        private DenseVector[] centroids;
+        private VectorWithNorm[] centroids;
 
         // TODO: replace this with a complete solution of reading first model data from unbounded
         // model data stream before processing the first predict data.
@@ -173,7 +174,8 @@ public class OnlineKMeansModel
                 return;
             }
             DenseVector point = ((Vector) dataPoint.getField(featuresCol)).toDense();
-            int closestCentroidId = KMeans.findClosestCentroidId(centroids, point, distanceMeasure);
+            int closestCentroidId =
+                    distanceMeasure.findClosest(centroids, new VectorWithNorm(point));
             output.collect(new StreamRecord<>(Row.join(dataPoint, Row.of(closestCentroidId))));
         }
 
@@ -181,7 +183,10 @@ public class OnlineKMeansModel
         public void processElement2(StreamRecord<KMeansModelData> streamRecord) throws Exception {
             KMeansModelData modelData = streamRecord.getValue();
             Preconditions.checkArgument(modelData.centroids.length <= k);
-            centroids = modelData.centroids;
+            centroids = new VectorWithNorm[modelData.centroids.length];
+            for (int i = 0; i < centroids.length; i++) {
+                centroids[i] = new VectorWithNorm(modelData.centroids[i]);
+            }
             modelDataVersion++;
             for (Row dataPoint : bufferedPointsState.get()) {
                 processElement1(new StreamRecord<>(dataPoint));


### PR DESCRIPTION
This PR optimizes KMeans Algorithm's performance with the following modifications.

1. reduce data transmission and per-round operator creation overhead
2. pre-compute the L2 norm of each dense vector and use this information to accelerate the process of finding the closest centroid id of each data point.

After adding the 1st optimization, the throughput of KMeans algorithm increased by around 10%. After introducing the 2nd optimization, the throughput increased by another 60%.