### PR TITLE
[FLINK-27877] Improve StringIndexer performance and optimize flink-ml-bench

### DIFF
--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/Benchmark.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/Benchmark.java
@@ -77,6 +77,7 @@ public class Benchmark {
         String saveFile = commandLine.getOptionValue(OUTPUT_FILE_OPTION.getLongOpt());
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.getConfig().enableObjectReuse();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
         int index = 0;

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DoubleGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DoubleGenerator.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark.datagenerator.common;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Arrays;
+
+/** A DataGenerator which creates a table of doubles. */
+public class DoubleGenerator extends InputTableGenerator<DoubleGenerator> {
+
+    @Override
+    protected RowGenerator[] getRowGenerators() {
+        String[][] colNames = getColNames();
+        Preconditions.checkState(colNames.length == 1);
+        int numOutputCols = colNames[0].length;
+
+        return new RowGenerator[] {
+            new RowGenerator(getNumValues(), getSeed()) {
+                @Override
+                public Row nextRow() {
+                    Row r = new Row(numOutputCols);
+                    for (int i = 0; i < numOutputCols; i++) {
+                        r.setField(i, random.nextDouble());
+                    }
+                    return r;
+                }
+
+                @Override
+                protected RowTypeInfo getRowTypeInfo() {
+                    TypeInformation[] outputTypes = new TypeInformation[colNames[0].length];
+                    Arrays.fill(outputTypes, Types.DOUBLE);
+                    return new RowTypeInfo(outputTypes, colNames[0]);
+                }
+            }
+        };
+    }
+}

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/InputTableGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/InputTableGenerator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark.datagenerator.common;
+
+import org.apache.flink.ml.benchmark.datagenerator.InputDataGenerator;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Base class for generating data as input table arrays. */
+public abstract class InputTableGenerator<T extends InputTableGenerator<T>>
+        implements InputDataGenerator<T> {
+    protected final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public InputTableGenerator() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public final Table[] getData(StreamTableEnvironment tEnv) {
+        StreamExecutionEnvironment env = TableUtils.getExecutionEnvironment(tEnv);
+
+        RowGenerator[] rowGenerators = getRowGenerators();
+        Table[] dataTables = new Table[rowGenerators.length];
+        for (int i = 0; i < rowGenerators.length; i++) {
+            DataStream<Row> dataStream =
+                    env.addSource(rowGenerators[i], "sourceOp-" + i)
+                            .returns(rowGenerators[i].getRowTypeInfo());
+            dataTables[i] = tEnv.fromDataStream(dataStream);
+        }
+
+        return dataTables;
+    }
+
+    /** Gets generators for all input tables. */
+    protected abstract RowGenerator[] getRowGenerators();
+
+    @Override
+    public final Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+}

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/RandomStringGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/RandomStringGenerator.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark.datagenerator.common;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Arrays;
+
+/** A DataGenerator which creates a table of random strings. */
+public class RandomStringGenerator extends InputTableGenerator<RandomStringGenerator> {
+    public static final Param<Integer> NUM_DISTINCT_VALUE =
+            new IntParam(
+                    "numDistinctValue",
+                    "Number of distinct values of the data to be generated.",
+                    10,
+                    ParamValidators.gt(0));
+
+    public int getNumDistinctValue() {
+        return get(NUM_DISTINCT_VALUE);
+    }
+
+    public RandomStringGenerator setNumDistinctValue(int value) {
+        return set(NUM_DISTINCT_VALUE, value);
+    }
+
+    @Override
+    protected RowGenerator[] getRowGenerators() {
+        String[][] colNames = getColNames();
+        Preconditions.checkState(colNames.length == 1);
+        int numOutputCols = colNames[0].length;
+        int numDistinctValues = getNumDistinctValue();
+
+        return new RowGenerator[] {
+            new RowGenerator(getNumValues(), getSeed()) {
+                @Override
+                public Row nextRow() {
+                    Row r = new Row(numOutputCols);
+                    for (int i = 0; i < numOutputCols; i++) {
+                        r.setField(i, Integer.toString(random.nextInt(numDistinctValues)));
+                    }
+                    return r;
+                }
+
+                @Override
+                protected RowTypeInfo getRowTypeInfo() {
+                    TypeInformation[] outputTypes = new TypeInformation[colNames[0].length];
+                    Arrays.fill(outputTypes, Types.STRING);
+                    return new RowTypeInfo(outputTypes, colNames[0]);
+                }
+            }
+        };
+    }
+}

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/RowGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/RowGenerator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.benchmark.datagenerator.common;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.types.Row;
+
+import java.util.Random;
+
+/** A parallel source to generate user defined rows. */
+public abstract class RowGenerator extends RichParallelSourceFunction<Row> {
+    /** Random instance to generate data. */
+    protected Random random;
+    /** Number of values to generate in total. */
+    private final long numValues;
+    /** The init seed to generate data. */
+    private final long initSeed;
+    /** Number of tasks to generate in one local task. */
+    private long numValuesOnThisTask;
+    /** Whether this source is still running. */
+    private volatile boolean isRunning = true;
+
+    public RowGenerator(long numValues, long initSeed) {
+        this.numValues = numValues;
+        this.initSeed = initSeed;
+    }
+
+    @Override
+    public final void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        int taskIdx = getRuntimeContext().getIndexOfThisSubtask();
+        int numTasks = getRuntimeContext().getNumberOfParallelSubtasks();
+        random = new Random(Tuple2.of(initSeed, taskIdx).hashCode());
+        long div = numValues / numTasks;
+        long mod = numValues % numTasks;
+        numValuesOnThisTask = mod > taskIdx ? div + 1 : div;
+    }
+
+    @Override
+    public final void run(SourceContext<Row> ctx) throws Exception {
+        long cnt = 0;
+        while (isRunning && cnt < numValuesOnThisTask) {
+            ctx.collect(nextRow());
+            cnt++;
+        }
+    }
+
+    @Override
+    public final void cancel() {
+        isRunning = false;
+    }
+
+    /** Generates a new data point. */
+    protected abstract Row nextRow();
+
+    /** Returns the output type information for this generator. */
+    protected abstract RowTypeInfo getRowTypeInfo();
+}

--- a/flink-ml-benchmark/src/main/resources/bucketizer-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/bucketizer-benchmark.json
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "version": 1,
+  "bucketizer100000000": {
+    "inputData": {
+      "className": "org.apache.flink.ml.benchmark.datagenerator.common.DoubleGenerator",
+      "paramMap": {
+        "colNames": [
+          [
+            "col0"
+          ]
+        ],
+        "seed": 2,
+        "numValues": 100000000
+      }
+    },
+    "stage": {
+      "className": "org.apache.flink.ml.feature.bucketizer.Bucketizer",
+      "paramMap": {
+        "outputCols": [
+          "outputCol0"
+        ],
+        "handleInvalid": "skip",
+        "inputCols": [
+          "col0"
+        ],
+        "splitsArray": [
+          [
+            -1.0,
+            0.0,
+            0.5,
+            1.0,
+            2.0
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/flink-ml-benchmark/src/main/resources/standardscaler-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/standardscaler-benchmark.json
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "version": 1,
+  "standardscaler10000000": {
+    "inputData": {
+      "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
+      "paramMap": {
+        "vectorDim": 100,
+        "colNames": [
+          [
+            "features"
+          ]
+        ],
+        "seed": 2,
+        "numValues": 10000000
+      }
+    },
+    "stage": {
+      "className": "org.apache.flink.ml.feature.standardscaler.StandardScaler",
+      "paramMap": {
+        "inputCol": "features",
+        "withMean": true,
+        "withStd": true,
+        "outputCol": "outputCol"
+      }
+    }
+  }
+}

--- a/flink-ml-benchmark/src/main/resources/stringindexer-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/stringindexer-benchmark.json
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "version": 1,
+  "stringindexer100000000": {
+    "inputData": {
+      "className": "org.apache.flink.ml.benchmark.datagenerator.common.RandStringGenerator",
+      "paramMap": {
+        "colNames": [
+          [
+            "col0"
+          ]
+        ],
+        "seed": 2,
+        "numValues": 100000000,
+        "numDistinctValue": 100
+      }
+    },
+    "stage": {
+      "className": "org.apache.flink.ml.feature.stringindexer.StringIndexer",
+      "paramMap": {
+        "outputCols": [
+          "outputCol0"
+        ],
+        "handleInvalid": "skip",
+        "inputCols": [
+          "col0"
+        ],
+        "stringOrderType": "arbitrary"
+      }
+    }
+  }
+}

--- a/flink-ml-benchmark/src/test/java/org/apache/flink/ml/benchmark/DataGeneratorTest.java
+++ b/flink-ml-benchmark/src/test/java/org/apache/flink/ml/benchmark/DataGeneratorTest.java
@@ -22,7 +22,9 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorArrayGenerator;
 import org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator;
+import org.apache.flink.ml.benchmark.datagenerator.common.DoubleGenerator;
 import org.apache.flink.ml.benchmark.datagenerator.common.LabeledPointWithWeightGenerator;
+import org.apache.flink.ml.benchmark.datagenerator.common.RandomStringGenerator;
 import org.apache.flink.ml.linalg.DenseVector;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -133,6 +135,55 @@ public class DataGeneratorTest {
             double weight = (double) row.getField(weightCol);
             assertTrue(weight >= 0);
             assertTrue(weight < 1);
+        }
+        assertEquals(generator.getNumValues(), count);
+    }
+
+    @Test
+    public void testRandomStringGenerator() {
+        String col1 = "col1";
+        String col2 = "col2";
+
+        RandomStringGenerator generator =
+                new RandomStringGenerator()
+                        .setColNames(new String[] {col1, col2})
+                        .setSeed(2L)
+                        .setNumValues(5)
+                        .setNumDistinctValue(2);
+
+        int count = 0;
+        for (CloseableIterator<Row> it = generator.getData(tEnv)[0].execute().collect();
+                it.hasNext(); ) {
+            Row row = it.next();
+            count++;
+            String value1 = (String) row.getField(col1);
+            String value2 = (String) row.getField(col2);
+            assertTrue(Integer.parseInt(value1) < generator.getNumDistinctValue());
+            assertTrue(Integer.parseInt(value2) < generator.getNumDistinctValue());
+        }
+        assertEquals(generator.getNumValues(), count);
+    }
+
+    @Test
+    public void testDoubleGenerator() {
+        String col1 = "col1";
+        String col2 = "col2";
+
+        DoubleGenerator generator =
+                new DoubleGenerator()
+                        .setColNames(new String[] {"col1", "col2"})
+                        .setSeed(2L)
+                        .setNumValues(5);
+
+        int count = 0;
+        for (CloseableIterator<Row> it = generator.getData(tEnv)[0].execute().collect();
+                it.hasNext(); ) {
+            Row row = it.next();
+            count++;
+            double value1 = (Double) row.getField(col1);
+            double value2 = (Double) row.getField(col2);
+            assertTrue(value1 <= 1 && value1 >= 0);
+            assertTrue(value2 <= 1 && value2 >= 0);
         }
         assertEquals(generator.getNumValues(), count);
     }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexer.java
@@ -18,31 +18,40 @@
 
 package org.apache.flink.ml.feature.stringindexer;
 
-import org.apache.flink.api.common.functions.FlatMapFunction;
-import org.apache.flink.api.common.functions.MapPartitionFunction;
-import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.iteration.operator.OperatorStateUtils;
 import org.apache.flink.ml.api.Estimator;
 import org.apache.flink.ml.common.datastream.DataStreamUtils;
 import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableImpl;
 import org.apache.flink.types.Row;
-import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * An Estimator which implements the string indexing algorithm.
@@ -91,19 +100,34 @@ public class StringIndexer
         StreamTableEnvironment tEnv =
                 (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
 
-        DataStream<Tuple2<Integer, String>> columnIdAndString =
-                tEnv.toDataStream(inputs[0]).flatMap(new ExtractColumnIdAndString(inputCols));
+        DataStream<HashMap<String, Long>[]> localCountedString =
+                tEnv.toDataStream(inputs[0])
+                        .transform(
+                                "countStringOperator",
+                                TypeInformation.of(new TypeHint<HashMap<String, Long>[]>() {}),
+                                new CountStringOperator(inputCols));
 
-        DataStream<Tuple3<Integer, String, Long>> columnIdAndStringAndCnt =
-                DataStreamUtils.mapPartition(
-                        columnIdAndString.keyBy(
-                                (KeySelector<Tuple2<Integer, String>, Integer>) Tuple2::hashCode),
-                        new CountStringsByColumn(inputCols.length));
+        DataStream<HashMap<String, Long>[]> countedString =
+                DataStreamUtils.reduce(
+                        localCountedString,
+                        (ReduceFunction<HashMap<String, Long>[]>)
+                                (value1, value2) -> {
+                                    for (int i = 0; i < value1.length; i++) {
+                                        for (Entry<String, Long> stringAndCnt :
+                                                value2[i].entrySet()) {
+                                            value1[i].compute(
+                                                    stringAndCnt.getKey(),
+                                                    (k, v) ->
+                                                            (v == null
+                                                                    ? stringAndCnt.getValue()
+                                                                    : v + stringAndCnt.getValue()));
+                                        }
+                                    }
+                                    return value1;
+                                });
 
         DataStream<StringIndexerModelData> modelData =
-                DataStreamUtils.mapPartition(
-                        columnIdAndStringAndCnt,
-                        new GenerateModel(inputCols.length, getStringOrderType()));
+                countedString.map(new ModelGenerator(getStringOrderType()));
         modelData.getTransformation().setParallelism(1);
 
         StringIndexerModel model =
@@ -112,38 +136,93 @@ public class StringIndexer
         return model;
     }
 
+    /** Computes the occurrence time of each string by columns. */
+    private static class CountStringOperator extends AbstractStreamOperator<HashMap<String, Long>[]>
+            implements OneInputStreamOperator<Row, HashMap<String, Long>[]>, BoundedOneInput {
+        /** The name of input columns. */
+        private final String[] inputCols;
+        /** The occurrence time of each string by column. */
+        private HashMap<String, Long>[] stringCntByColumn;
+        /** The state of stringCntByColumn. */
+        private ListState<HashMap<String, Long>[]> stringCntByColumnState;
+
+        public CountStringOperator(String[] inputCols) {
+            this.inputCols = inputCols;
+            stringCntByColumn = new HashMap[inputCols.length];
+            for (int i = 0; i < stringCntByColumn.length; i++) {
+                stringCntByColumn[i] = new HashMap<>();
+            }
+        }
+
+        @Override
+        public void endInput() {
+            output.collect(new StreamRecord<>(stringCntByColumn));
+            stringCntByColumnState.clear();
+        }
+
+        @Override
+        public void processElement(StreamRecord<Row> element) {
+            Row r = element.getValue();
+            for (int i = 0; i < inputCols.length; i++) {
+                Object objVal = r.getField(inputCols[i]);
+                String stringVal;
+                if (objVal instanceof String) {
+                    stringVal = (String) objVal;
+                } else if (objVal instanceof Number) {
+                    stringVal = String.valueOf(objVal);
+                } else {
+                    throw new RuntimeException(
+                            "The input column only supports string and numeric type.");
+                }
+                stringCntByColumn[i].compute(stringVal, (k, v) -> (v == null ? 1 : v + 1));
+            }
+        }
+
+        @Override
+        public void initializeState(StateInitializationContext context) throws Exception {
+            super.initializeState(context);
+            stringCntByColumnState =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>(
+                                            "stringCntByColumnState",
+                                            TypeInformation.of(
+                                                    new TypeHint<HashMap<String, Long>[]>() {})));
+
+            OperatorStateUtils.getUniqueElement(stringCntByColumnState, "stringCntByColumnState")
+                    .ifPresent(x -> stringCntByColumn = x);
+        }
+
+        @Override
+        public void snapshotState(StateSnapshotContext context) throws Exception {
+            super.snapshotState(context);
+            stringCntByColumnState.update(Collections.singletonList(stringCntByColumn));
+        }
+    }
+
     /**
      * Merges all the extracted strings and generates the {@link StringIndexerModelData} according
      * to the specified string order type.
      */
-    private static class GenerateModel
-            implements MapPartitionFunction<Tuple3<Integer, String, Long>, StringIndexerModelData> {
-        private final int numCols;
+    private static class ModelGenerator
+            implements MapFunction<HashMap<String, Long>[], StringIndexerModelData> {
         private final String stringOrderType;
 
-        public GenerateModel(int numCols, String stringOrderType) {
-            this.numCols = numCols;
+        public ModelGenerator(String stringOrderType) {
             this.stringOrderType = stringOrderType;
         }
 
         @Override
-        @SuppressWarnings("unchecked")
-        public void mapPartition(
-                Iterable<Tuple3<Integer, String, Long>> values,
-                Collector<StringIndexerModelData> out) {
+        public StringIndexerModelData map(HashMap<String, Long>[] value) {
+            int numCols = value.length;
             String[][] stringArrays = new String[numCols][];
-            ArrayList<Tuple2<String, Long>>[] stringsAndCntsByColumn = new ArrayList[numCols];
+            ArrayList<Tuple2<String, Long>> stringsAndCnts = new ArrayList<>();
             for (int i = 0; i < numCols; i++) {
-                stringsAndCntsByColumn[i] = new ArrayList<>();
-            }
-
-            for (Tuple3<Integer, String, Long> colIdAndStringAndCnt : values) {
-                stringsAndCntsByColumn[colIdAndStringAndCnt.f0].add(
-                        Tuple2.of(colIdAndStringAndCnt.f1, colIdAndStringAndCnt.f2));
-            }
-
-            for (int i = 0; i < stringsAndCntsByColumn.length; i++) {
-                List<Tuple2<String, Long>> stringsAndCnts = stringsAndCntsByColumn[i];
+                stringsAndCnts.clear();
+                stringsAndCnts.ensureCapacity(value[i].size());
+                for (Map.Entry<String, Long> entry : value[i].entrySet()) {
+                    stringsAndCnts.add(Tuple2.of(entry.getKey(), entry.getValue()));
+                }
                 switch (stringOrderType) {
                     case ALPHABET_ASC_ORDER:
                         stringsAndCnts.sort(Comparator.comparing(valAndCnt -> valAndCnt.f0));
@@ -171,74 +250,10 @@ public class StringIndexer
                                         + stringOrderType
                                         + ".");
                 }
-
-                stringArrays[i] = new String[stringsAndCnts.size()];
-                for (int stringId = 0; stringId < stringArrays[i].length; stringId++) {
-                    stringArrays[i][stringId] = stringsAndCnts.get(stringId).f0;
-                }
+                stringArrays[i] = stringsAndCnts.stream().map(x -> x.f0).toArray(String[]::new);
             }
 
-            out.collect(new StringIndexerModelData(stringArrays));
-        }
-    }
-
-    /** Computes the frequency of strings in each column. */
-    private static class CountStringsByColumn
-            implements MapPartitionFunction<
-                    Tuple2<Integer, String>, Tuple3<Integer, String, Long>> {
-        private final int numCols;
-
-        public CountStringsByColumn(int numCols) {
-            this.numCols = numCols;
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public void mapPartition(
-                Iterable<Tuple2<Integer, String>> values,
-                Collector<Tuple3<Integer, String, Long>> out) {
-            HashMap<String, Long>[] string2CntByColumn = new HashMap[numCols];
-            for (int i = 0; i < numCols; i++) {
-                string2CntByColumn[i] = new HashMap<>();
-            }
-            for (Tuple2<Integer, String> columnIdAndString : values) {
-                int colId = columnIdAndString.f0;
-                String stringVal = columnIdAndString.f1;
-                long cnt = string2CntByColumn[colId].getOrDefault(stringVal, 0L) + 1;
-                string2CntByColumn[colId].put(stringVal, cnt);
-            }
-            for (int i = 0; i < numCols; i++) {
-                for (Map.Entry<String, Long> entry : string2CntByColumn[i].entrySet()) {
-                    out.collect(Tuple3.of(i, entry.getKey(), entry.getValue()));
-                }
-            }
-        }
-    }
-
-    /** Extracts strings by column. */
-    private static class ExtractColumnIdAndString
-            implements FlatMapFunction<Row, Tuple2<Integer, String>> {
-        private final String[] inputCols;
-
-        public ExtractColumnIdAndString(String[] inputCols) {
-            this.inputCols = inputCols;
-        }
-
-        @Override
-        public void flatMap(Row row, Collector<Tuple2<Integer, String>> out) {
-            for (int i = 0; i < inputCols.length; i++) {
-                Object objVal = row.getField(inputCols[i]);
-                String stringVal;
-                if (objVal instanceof String) {
-                    stringVal = (String) objVal;
-                } else if (objVal instanceof Number) {
-                    stringVal = String.valueOf(objVal);
-                } else {
-                    throw new RuntimeException(
-                            "The input column only supports string and numeric type.");
-                }
-                out.collect(Tuple2.of(i, stringVal));
-            }
+            return new StringIndexerModelData(stringArrays);
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
This PR optimizes the implementation of StringIndexer and introduces several optimizations to the flink-ml-bench.

## Brief change log
- Optimizes the implementation of StringIndexer.
- Reduce the length of the operator chain used in generating input tables in flink-ml-bench.
- Added DoubleGenerator and RandomStringGenerator.
- Added configuration for benchmarking StringIndexer, Bucketizer, Standardscaler.
- Enable object reuse in flink-ml-bench.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)