### PR TITLE
[FLINK-27096] Optimize OneHotEncoder performance

### DIFF
--- a/flink-ml-benchmark/src/main/resources/onehotencoder-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/onehotencoder-benchmark.json
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "version": 1,
+  "OneHotEncoder": {
+    "stage": {
+      "className": "org.apache.flink.ml.feature.onehotencoder.OneHotEncoder",
+      "paramMap": {
+        "inputCols":  ["input"],
+        "outputCols":  ["output"]
+      }
+    },
+    "inputData": {
+      "className": "org.apache.flink.ml.benchmark.datagenerator.common.DoubleGenerator",
+      "paramMap": {
+        "colNames": [["input"]],
+        "arity": 10,
+        "numValues": 100000
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR optimizes the performance of one-hot encoder algorithm with the following modifications:

- Restructures the DAG of OneHotEncoder, so that the very first stream operator can pre-process input data with aggregation operations, so that the data transmission overhead is reduced.
- Avoids unnecessary `String.format()` operation when passing error message to `Precondition.checkArgument`.

These optimizations together reduces the net runtime of OneHotEncoder benchmark jobs to about 1/6.

This PR also does the following:
- Adds example benchmark json file for OneHotEncoder
- Supports generating distinct double values in `DoubleGenerator`.
  - This modification has only slight influence on the performance of DoubleGenerator.