### PR TITLE
[hotfix] Update examples module and doc's version to 2.2-SNAPSHOT

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -34,11 +34,11 @@ pygmentsUseClasses = true
   # we change the version for the complete docs when forking of a release branch
   # etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "2.1-SNAPSHOT"
+  Version = "2.2-SNAPSHOT"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version
-  VersionTitle = "2.1-SNAPSHOT"
+  VersionTitle = "2.2-SNAPSHOT"
 
   # The branch for this version of Apache Flink Machine Learning Library
   Branch = "master"

--- a/flink-ml-examples/pom.xml
+++ b/flink-ml-examples/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>flink-ml-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This PR is a complement to #117 . It updates the version of flink-ml-examples and docs to 2.2-SNAPSHOT.