### PR TITLE
[hotfix][docs] Mark docs as outdated

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -27,7 +27,7 @@ pygmentsUseClasses = true
   IsStable = true
 
   # Flag to indicate whether an outdated warning should be shown.
-  ShowOutDatedWarning = false
+  ShowOutDatedWarning = true
 
   # This is the version referenced in the docs. Please only use these variables
   # to reference a specific Flink version, because this is the only place where


### PR DESCRIPTION
This PR marks Flink ML 2.0's document as outdated, provided that the document of Flink ML 2.1 is published.