### PR TITLE
[FLINK-28894] Add Transformer for Interaction

### DIFF
--- a/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/InteractionExample.java
+++ b/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/InteractionExample.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.examples.feature;
+
+import org.apache.flink.ml.feature.interaction.Interaction;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import java.util.Arrays;
+
+/** Simple program that creates an Interaction instance and uses it for feature engineering. */
+public class InteractionExample {
+    public static void main(String[] args) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        // Generates input data.
+        DataStream<Row> inputStream =
+                env.fromElements(
+                        Row.of(0, Vectors.dense(1.1, 3.2), Vectors.dense(2, 3)),
+                        Row.of(1, Vectors.dense(2.1, 3.1), Vectors.dense(1, 3)));
+
+        Table inputTable = tEnv.fromDataStream(inputStream).as("f0", "f1", "f2");
+
+        // Creates an Interaction object and initializes its parameters.
+        Interaction interaction =
+                new Interaction().setInputCols("f0", "f1", "f2").setOutputCol("outputVec");
+
+        // Transforms input data.
+        Table outputTable = interaction.transform(inputTable)[0];
+
+        // Extracts and displays the results.
+        for (CloseableIterator<Row> it = outputTable.execute().collect(); it.hasNext(); ) {
+            Row row = it.next();
+            Object[] inputValues = new Object[interaction.getInputCols().length];
+            for (int i = 0; i < inputValues.length; i++) {
+                inputValues[i] = row.getField(interaction.getInputCols()[i]);
+            }
+            Vector outputValue = (Vector) row.getField(interaction.getOutputCol());
+            System.out.printf(
+                    "Input Values: %s \tOutput Value: %s\n",
+                    Arrays.toString(inputValues), outputValue);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/interaction/Interaction.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/interaction/Interaction.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.interaction;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.api.Transformer;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.SparseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A Transformer that takes vector or numerical columns, and generates a single vector column that
+ * contains the product of all combinations of one value from each input column.
+ *
+ * <p>For example, when the input feature values are Double(2) and Vector(3, 4), the output would be
+ * Vector(6, 8). When the input feature values are Vector(1, 2) and Vector(3, 4), the output would
+ * be Vector(3, 4, 6, 8). If you change the position of these two input Vectors, the output would be
+ * Vector(3, 6, 4, 8).
+ */
+public class Interaction implements Transformer<Interaction>, InteractionParams<Interaction> {
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public Interaction() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public Table[] transform(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(inputTypeInfo.getFieldTypes(), VectorTypeInfo.INSTANCE),
+                        ArrayUtils.addAll(inputTypeInfo.getFieldNames(), getOutputCol()));
+
+        DataStream<Row> output =
+                tEnv.toDataStream(inputs[0])
+                        .map(new InteractionFunction(getInputCols()), outputTypeInfo);
+        Table outputTable = tEnv.fromDataStream(output);
+
+        return new Table[] {outputTable};
+    }
+
+    private static class InteractionFunction implements MapFunction<Row, Row> {
+        private final String[] inputCols;
+        private final int[] featureSize;
+        private final int[][] featureIndices;
+        private final double[][] featureValues;
+
+        public InteractionFunction(String[] inputCols) {
+            this.inputCols = inputCols;
+            this.featureSize = new int[inputCols.length];
+            this.featureIndices = new int[inputCols.length][];
+            this.featureValues = new double[inputCols.length][];
+        }
+
+        @Override
+        public Row map(Row value) {
+            int nnz = 1;
+            boolean hasSparse = false;
+
+            for (int i = 0; i < inputCols.length; ++i) {
+                Object obj = value.getField(inputCols[i]);
+                if (obj == null) {
+                    return Row.join(value, Row.of((Object) null));
+                }
+
+                if (obj instanceof DenseVector) {
+                    featureSize[i] = ((Vector) obj).size();
+                    if (featureIndices[i] == null || featureIndices[i].length != featureSize[i]) {
+                        featureIndices[i] = new int[featureSize[i]];
+                        for (int j = 0; j < featureSize[i]; ++j) {
+                            featureIndices[i][j] = j;
+                        }
+                    }
+
+                    featureValues[i] = ((DenseVector) obj).values;
+                    nnz *= featureSize[i];
+                } else if (obj instanceof SparseVector) {
+                    featureSize[i] = ((Vector) obj).size();
+                    featureIndices[i] = ((SparseVector) obj).indices;
+                    featureValues[i] = ((SparseVector) obj).values;
+                    nnz *= ((SparseVector) obj).values.length;
+                    hasSparse = true;
+                } else {
+                    featureSize[i] = 1;
+                    featureIndices[i] = new int[] {0};
+                    featureValues[i] = new double[] {Double.parseDouble(obj.toString())};
+                }
+            }
+
+            Vector ret;
+            int featureIter = inputCols.length - 1;
+            if (hasSparse) {
+                int[] indices = new int[nnz];
+                double[] values = new double[nnz];
+                Arrays.fill(values, 1.0);
+                int offset = 1;
+                int size = 1;
+
+                while (featureIter >= 0) {
+                    int[] prevIndices = featureIndices[featureIter];
+                    double[] prevValues = featureValues[featureIter];
+
+                    for (int i = 0; i < nnz / offset; ++i) {
+                        int idxOffset = i * offset;
+                        int idx = i % prevValues.length;
+                        for (int j = 0; j < offset; ++j) {
+                            values[idxOffset + j] *= prevValues[idx];
+                            indices[idxOffset + j] += prevIndices[idx] * size;
+                        }
+                    }
+
+                    offset *= prevValues.length;
+                    size *= featureSize[featureIter--];
+                }
+                ret = Vectors.sparse(size, indices, values);
+            } else {
+                double[] values = new double[nnz];
+                Arrays.fill(values, 1.0);
+                int idxOffset = 1;
+
+                while (featureIter >= 0) {
+                    double[] prevValues = featureValues[featureIter--];
+                    for (int i = 0; i < nnz / idxOffset; ++i) {
+                        int innerOffset = i * idxOffset;
+                        int idx = i % prevValues.length;
+                        for (int j = 0; j < idxOffset; ++j) {
+                            values[innerOffset + j] *= prevValues[idx];
+                        }
+                    }
+                    idxOffset *= prevValues.length;
+                }
+                ret = new DenseVector(values);
+            }
+
+            return Row.join(value, Row.of(ret));
+        }
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+
+    public static Interaction load(StreamTableEnvironment env, String path) throws IOException {
+        return ReadWriteUtils.loadStageParam(path);
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/interaction/InteractionParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/interaction/InteractionParams.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.interaction;
+
+import org.apache.flink.ml.common.param.HasInputCols;
+import org.apache.flink.ml.common.param.HasOutputCol;
+
+/**
+ * Params of {@link Interaction}.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface InteractionParams<T> extends HasInputCols<T>, HasOutputCol<T> {}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/InteractionTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/InteractionTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.feature.interaction.Interaction;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.SparseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.util.TestUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/** Tests {@link Interaction}. */
+public class InteractionTest extends AbstractTestBase {
+
+    private StreamTableEnvironment tEnv;
+    private Table inputDataTable;
+
+    private static final List<Row> INPUT_DATA =
+            Arrays.asList(
+                    Row.of(
+                            1,
+                            Vectors.dense(1, 2),
+                            Vectors.dense(3, 4),
+                            Vectors.sparse(17, new int[] {0, 3, 9}, new double[] {1.0, 2.0, 7.0})),
+                    Row.of(
+                            2,
+                            Vectors.dense(2, 8),
+                            Vectors.dense(3, 4, 5),
+                            Vectors.sparse(17, new int[] {0, 2, 14}, new double[] {5.0, 4.0, 1.0})),
+                    Row.of(3, null, null, null));
+
+    private static final List<Vector> EXPECTED_DENSE_OUTPUT =
+            Arrays.asList(
+                    new DenseVector(new double[] {3.0, 4.0, 6.0, 8.0}),
+                    new DenseVector(new double[] {12.0, 16.0, 20.0, 48.0, 64.0, 80.0}));
+
+    private static final List<Vector> EXPECTED_SPARSE_OUTPUT =
+            Arrays.asList(
+                    new SparseVector(
+                            68,
+                            new int[] {0, 3, 9, 17, 20, 26, 34, 37, 43, 51, 54, 60},
+                            new double[] {
+                                3.0, 6.0, 21.0, 4.0, 8.0, 28.0, 6.0, 12.0, 42.0, 8.0, 16.0, 56.0
+                            }),
+                    new SparseVector(
+                            102,
+                            new int[] {
+                                0, 2, 14, 17, 19, 31, 34, 36, 48, 51, 53, 65, 68, 70, 82, 85, 87, 99
+                            },
+                            new double[] {
+                                60.0, 48.0, 12.0, 80.0, 64.0, 16.0, 100.0, 80.0, 20.0, 240.0, 192.0,
+                                48.0, 320.0, 256.0, 64.0, 400.0, 320.0, 80.0
+                            }));
+
+    @Before
+    public void before() {
+        Configuration config = new Configuration();
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+
+        env.setParallelism(4);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+
+        tEnv = StreamTableEnvironment.create(env);
+        DataStream<Row> dataStream = env.fromCollection(INPUT_DATA);
+        inputDataTable = tEnv.fromDataStream(dataStream).as("f0", "f1", "f2", "f3");
+    }
+
+    private void verifyOutputResult(Table output, String outputCol, List<Vector> expectedData)
+            throws Exception {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) output).getTableEnvironment();
+        DataStream<Row> stream = tEnv.toDataStream(output);
+
+        List<Row> results = IteratorUtils.toList(stream.executeAndCollect());
+        List<Vector> resultVec = new ArrayList<>(results.size());
+        for (Row row : results) {
+            if (row.getField(outputCol) != null) {
+                resultVec.add(row.getFieldAs(outputCol));
+            }
+        }
+        compareResultCollections(expectedData, resultVec, TestUtils::compare);
+    }
+
+    @Test
+    public void testParam() {
+        Interaction interaction = new Interaction();
+        assertEquals("output", interaction.getOutputCol());
+
+        interaction.setInputCols("f0", "f1", "f2").setOutputCol("interactionVecVec");
+
+        assertArrayEquals(new String[] {"f0", "f1", "f2"}, interaction.getInputCols());
+        assertEquals("interactionVecVec", interaction.getOutputCol());
+    }
+
+    @Test
+    public void testOutputSchema() {
+        Interaction interaction =
+                new Interaction().setInputCols("f0", "f1", "f2", "f3").setOutputCol("outputVec");
+
+        Table output = interaction.transform(inputDataTable)[0];
+
+        assertEquals(
+                Arrays.asList("f0", "f1", "f2", "f3", "outputVec"),
+                output.getResolvedSchema().getColumnNames());
+    }
+
+    @Test
+    public void testSaveLoadAndTransformSparse() throws Exception {
+        Interaction interaction =
+                new Interaction()
+                        .setInputCols("f0", "f1", "f2", "f3")
+                        .setOutputCol("interactionVecVec");
+
+        Interaction loadedInteraction =
+                TestUtils.saveAndReload(
+                        tEnv, interaction, TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+
+        Table output = loadedInteraction.transform(inputDataTable)[0];
+        verifyOutputResult(output, loadedInteraction.getOutputCol(), EXPECTED_SPARSE_OUTPUT);
+    }
+
+    @Test
+    public void testSaveLoadAndTransformDense() throws Exception {
+        Interaction interaction =
+                new Interaction().setInputCols("f0", "f1", "f2").setOutputCol("interactionVecVec");
+
+        Interaction loadedInteraction =
+                TestUtils.saveAndReload(
+                        tEnv, interaction, TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+
+        Table output = loadedInteraction.transform(inputDataTable)[0];
+        verifyOutputResult(output, loadedInteraction.getOutputCol(), EXPECTED_DENSE_OUTPUT);
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/util/TestUtils.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/util/TestUtils.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.ml.api.Stage;
 import org.apache.flink.ml.common.datastream.TableUtils;
-import org.apache.flink.ml.linalg.DenseVector;
 import org.apache.flink.ml.linalg.Vector;
 import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
 import org.apache.flink.ml.linalg.typeinfo.SparseVectorTypeInfo;
@@ -34,7 +33,6 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -118,12 +116,15 @@ public class TestUtils {
     }
 
     /** Note: this comparator imposes orderings that are inconsistent with equals. */
-    public static int compare(DenseVector first, DenseVector second) {
-        Preconditions.checkArgument(first.size() == second.size(), "Vector size mismatched.");
-        for (int i = 0; i < first.size(); i++) {
-            int cmp = Double.compare(first.get(i), second.get(i));
-            if (cmp != 0) {
-                return cmp;
+    public static int compare(Vector first, Vector second) {
+        if (first.size() != second.size()) {
+            return Integer.compare(first.size(), second.size());
+        } else {
+            for (int i = 0; i < first.size(); i++) {
+                int cmp = Double.compare(first.get(i), second.get(i));
+                if (cmp != 0) {
+                    return cmp;
+                }
             }
         }
         return 0;

--- a/flink-ml-python/pyflink/examples/ml/feature/interaction_example.py
+++ b/flink-ml-python/pyflink/examples/ml/feature/interaction_example.py
@@ -1,0 +1,69 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Simple program that creates a Interaction instance and uses it for feature
+# engineering.
+#
+# Before executing this program, please make sure you have followed Flink ML's
+# quick start guideline to set up Flink ML and Flink environment. The guideline
+# can be found at
+#
+# https://nightlies.apache.org/flink/flink-ml-docs-master/docs/try-flink-ml/quick-start/
+
+from pyflink.common import Types
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.ml.core.linalg import Vectors, DenseVectorTypeInfo
+from pyflink.ml.lib.feature.interaction import Interaction
+from pyflink.table import StreamTableEnvironment
+
+# create a new StreamExecutionEnvironment
+env = StreamExecutionEnvironment.get_execution_environment()
+
+# create a StreamTableEnvironment
+t_env = StreamTableEnvironment.create(env)
+
+# generate input data
+input_data_table = t_env.from_data_stream(
+    env.from_collection([
+        (1,
+         Vectors.dense(1, 2),
+         Vectors.dense(3, 4)),
+        (2,
+         Vectors.dense(2, 8),
+         Vectors.dense(3, 4))
+    ],
+        type_info=Types.ROW_NAMED(
+            ['f0', 'f1', 'f2'],
+            [Types.INT(), DenseVectorTypeInfo(), DenseVectorTypeInfo()])))
+
+# create an interaction object and initialize its parameters
+interaction = Interaction() \
+    .set_input_cols('f0', 'f1', 'f2') \
+    .set_output_col('interaction_vec')
+
+# use the interaction for feature engineering
+output = interaction.transform(input_data_table)[0]
+
+# extract and display the results
+field_names = output.get_schema().get_field_names()
+input_values = [None for _ in interaction.get_input_cols()]
+for result in t_env.to_data_stream(output).execute_and_collect():
+    for i in range(len(interaction.get_input_cols())):
+        input_values[i] = result[field_names.index(interaction.get_input_cols()[i])]
+    output_value = result[field_names.index(interaction.get_output_col())]
+    print('Input Values: ' + str(input_values) + '\tOutput Value: ' + str(output_value))

--- a/flink-ml-python/pyflink/ml/lib/feature/interaction.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/interaction.py
@@ -1,0 +1,57 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from pyflink.ml.core.wrapper import JavaWithParams
+from pyflink.ml.lib.feature.common import JavaFeatureTransformer
+from pyflink.ml.lib.param import HasInputCols, HasOutputCol
+
+
+class _InteractionParams(
+    JavaWithParams,
+    HasInputCols,
+    HasOutputCol
+):
+    """
+    Params for :class:`Interaction`.
+    """
+
+    def __init__(self, java_params):
+        super(_InteractionParams, self).__init__(java_params)
+
+
+class Interaction(JavaFeatureTransformer, _InteractionParams):
+    """
+    A Transformer that takes vector or numerical columns, and generates a single vector column
+    that contains the product of all combinations of one value from each input column.
+
+    For example, when the input feature values are Double(2) and Vector(3, 4), the output would be
+    Vector(6, 8). When the input feature values are Vector(1, 2) and Vector(3, 4), the output would
+    be Vector(3, 4, 6, 8). If you change the position of these two input Vectors, the output would
+    be Vector(3, 6, 4, 8).
+    """
+
+    def __init__(self, java_model=None):
+        super(Interaction, self).__init__(java_model)
+
+    @classmethod
+    def _java_transformer_package_name(cls) -> str:
+        return "interaction"
+
+    @classmethod
+    def _java_transformer_class_name(cls) -> str:
+        return "Interaction"

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_interaction.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_interaction.py
@@ -1,0 +1,79 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import os
+
+from pyflink.common import Types
+
+from pyflink.ml.core.linalg import Vectors, DenseVectorTypeInfo
+from pyflink.ml.lib.feature.interaction import Interaction
+from pyflink.ml.tests.test_utils import PyFlinkMLTestCase
+
+
+class InteractionTest(PyFlinkMLTestCase):
+    def setUp(self):
+        super(InteractionTest, self).setUp()
+        self.input_data_table = self.t_env.from_data_stream(
+            self.env.from_collection([
+                (1,
+                 Vectors.dense(1, 2),
+                 Vectors.dense(3, 4)),
+                (2,
+                 Vectors.dense(2, 8),
+                 Vectors.dense(3, 4))
+            ],
+                type_info=Types.ROW_NAMED(
+                    ['f0', 'f1', 'f2'],
+                    [Types.INT(), DenseVectorTypeInfo(), DenseVectorTypeInfo()])))
+
+        self.expected_output_data_1 = Vectors.dense(3.0, 4.0, 6.0, 8.0)
+        self.expected_output_data_2 = Vectors.dense(12.0, 16.0, 48.0, 64.0)
+
+    def test_param(self):
+        interaction = Interaction()
+        self.assertEqual('output', interaction.output_col)
+
+        interaction.set_input_cols('f0', 'f1', 'f2') \
+            .set_output_col('interaction_vec')
+
+        self.assertEqual(('f0', 'f1', 'f2'), interaction.input_cols)
+        self.assertEqual('interaction_vec', interaction.output_col)
+
+    def test_save_load_transform(self):
+        interaction = Interaction() \
+            .set_input_cols('f0', 'f1', 'f2') \
+            .set_output_col('interaction_vec')
+
+        path = os.path.join(self.temp_dir, 'test_save_load_transform_interaction')
+        interaction.save(path)
+        interaction = Interaction.load(self.t_env, path)
+
+        output_table = interaction.transform(self.input_data_table)[0]
+        actual_outputs = [(result[0], result[3]) for result in
+                          self.t_env.to_data_stream(output_table).execute_and_collect()]
+
+        self.assertEqual(2, len(actual_outputs))
+        for actual_output in actual_outputs:
+            self.assertEqual(4, len(actual_output[1]))
+            if actual_output[0] == 1:
+                for i in range(len(actual_output[1])):
+                    self.assertAlmostEqual(self.expected_output_data_1.get(i),
+                                           actual_output[1].get(i), delta=1e-5)
+            else:
+                for i in range(len(actual_output[1])):
+                    self.assertAlmostEqual(self.expected_output_data_2.get(i),
+                                           actual_output[1].get(i), delta=1e-5)


### PR DESCRIPTION
## What is the purpose of the change
Add Transformer for Interaction

## Brief change log
* Add Transformer for Interaction in Flink ML (Java & Python).
* Add unit test for Interaction (Java & Python)
* Add example code for Interaction (Java&Python)
* Comparing with interaction in spark-ml, we made the following changes:
   If the input has nominal features, these features should be one-hot encoded before inputting to this algorithm.

## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @public(Evolving): (no)
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (Java doc)