### PR TITLE
[FLINK-27535] Optimize the unit test execution time

### DIFF
--- a/.github/workflows/java8-build.yml
+++ b/.github/workflows/java8-build.yml
@@ -3,9 +3,11 @@ name: Java 8 Build
 on: [push, pull_request]
 
 jobs:
-  build:
+  java-tests:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        stage: ['core', 'lib', 'tests', 'misc']
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -13,6 +15,5 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Build
-        run: mvn clean install --no-transfer-progress
-
+      - name: Build and test
+        run: ./tools/ci/java_test_controller.sh "${{ matrix.stage }}"

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -11,12 +11,11 @@ on:
 jobs:
   tests:
     name: python tests on ${{ matrix.os }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ['macOS-latest', 'ubuntu-latest']
         python-version: ['3.6', '3.7', '3.8']
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/util/ReadWriteUtils.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/util/ReadWriteUtils.java
@@ -417,7 +417,8 @@ public class ReadWriteUtils {
             method.setAccessible(true);
             return (Stage<?>) method.invoke(null, tEnv, path);
         } catch (NoSuchMethodException e) {
-            String methodName = String.format("%s::load(String)", className);
+            String methodName =
+                    String.format("%s::load(StreamTableEnvironment, String)", className);
             throw new RuntimeException(
                     "Failed to load stage because the static method "
                             + methodName

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/KnnTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/KnnTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
 import org.apache.commons.collections.IteratorUtils;
@@ -56,7 +57,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /** Tests {@link Knn} and {@link KnnModel}. */
-public class KnnTest {
+public class KnnTest extends AbstractTestBase {
     @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
     private StreamExecutionEnvironment env;
     private StreamTableEnvironment tEnv;

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/NaiveBayesTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/NaiveBayesTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
@@ -51,7 +52,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /** Tests {@link NaiveBayes} and {@link NaiveBayesModel}. */
-public class NaiveBayesTest {
+public class NaiveBayesTest extends AbstractTestBase {
     @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
 
     private StreamExecutionEnvironment env;

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/KMeansTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/KMeansTest.java
@@ -159,11 +159,6 @@ public class KMeansTest extends AbstractTestBase {
         assertEquals(
                 Arrays.asList("test_feature", "test_prediction"),
                 output.getResolvedSchema().getColumnNames());
-        List<Row> results = IteratorUtils.toList(output.execute().collect());
-        List<Set<DenseVector>> actualGroups =
-                groupFeaturesByPrediction(
-                        results, kmeans.getFeaturesCol(), kmeans.getPredictionCol());
-        assertTrue(CollectionUtils.isEqualCollection(expectedGroups, actualGroups));
     }
 
     @Test

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/MinMaxScalerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/MinMaxScalerTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
 import org.apache.commons.collections.IteratorUtils;
@@ -52,7 +53,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /** Tests {@link MinMaxScaler} and {@link MinMaxScalerModel}. */
-public class MinMaxScalerTest {
+public class MinMaxScalerTest extends AbstractTestBase {
     @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
     private StreamExecutionEnvironment env;
     private StreamTableEnvironment tEnv;

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/OneHotEncoderTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/OneHotEncoderTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
@@ -54,7 +55,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /** Tests OneHotEncoder and OneHotEncoderModel. */
-public class OneHotEncoderTest {
+public class OneHotEncoderTest extends AbstractTestBase {
     @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
 
     private StreamExecutionEnvironment env;

--- a/pom.xml
+++ b/pom.xml
@@ -553,7 +553,6 @@ under the License.
           <trimStackTrace>false</trimStackTrace>
           <systemPropertyVariables>
             <forkNumber>0${surefire.forkNumber}</forkNumber>
-            <checkpointing.randomization>true</checkpointing.randomization>
             <project.basedir>${project.basedir}</project.basedir>
             <!--suppress MavenModelInspection -->
             <test.randomization.seed>${test.randomization.seed}</test.randomization.seed>

--- a/tools/ci/controller_utils.sh
+++ b/tools/ci/controller_utils.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+function exit_if_error() {
+  local EXIT_CODE=$1
+  local ERROR_MESSAGE=$2
+
+  if [ $EXIT_CODE != 0 ]; then
+    echo "=============================================================================="
+    echo $ERROR_MESSAGE
+    echo "=============================================================================="
+    exit $EXIT_CODE
+  fi
+}

--- a/tools/ci/java_test_controller.sh
+++ b/tools/ci/java_test_controller.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+#
+# This file contains generic control over the execution of Flink ML's java tests.
+#
+
+HERE="`dirname \"$0\"`"             # relative
+HERE="`( cd \"$HERE\" && pwd )`"    # absolutized and normalized
+if [ -z "$HERE" ] ; then
+	exit 1
+fi
+
+source "${HERE}/controller_utils.sh"
+source "${HERE}/stage.sh"
+
+STAGE=$1
+
+if [ -z "${STAGE:-}" ] ; then
+	echo "ERROR: Environment variable 'STAGE' is not set but expected by java_test_controller.sh. The variable refers to the stage being executed."
+	exit 1
+fi
+
+# =============================================================================
+# Step 1: Rebuild jars and install Flink ML to local maven repository
+# =============================================================================
+
+MVN_COMMON_OPTIONS="--no-transfer-progress"
+MVN_COMPILE_OPTIONS="-DskipTests"
+MVN_COMPILE_MODULES=$(get_compile_modules_for_stage ${STAGE})
+exit_if_error $? "Error: Unexpected STAGE value ${STAGE}"
+
+mvn clean install $MVN_COMMON_OPTIONS $MVN_COMPILE_OPTIONS $MVN_COMPILE_MODULES
+exit_if_error $? "Compilation failure detected, skipping test execution."
+
+# =============================================================================
+# Step 2: Run tests
+# =============================================================================
+
+MVN_TEST_MODULES=$(get_test_modules_for_stage ${STAGE})
+exit_if_error $? "Error: Unexpected STAGE value ${STAGE}"
+
+mvn verify $MVN_COMMON_OPTIONS $MVN_TEST_MODULES

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+STAGE_CORE="core"
+STAGE_LIB="lib"
+STAGE_TESTS="tests"
+STAGE_MISC="misc"
+
+MODULES_CORE="\
+flink-ml-core,\
+flink-ml-iteration,\
+"
+
+MODULES_LIB="\
+flink-ml-lib,\
+"
+
+MODULES_TESTS="\
+flink-ml-tests,\
+"
+
+function get_compile_modules_for_stage() {
+    local stage=$1
+
+    case ${stage} in
+        (${STAGE_CORE})
+            echo "-pl $MODULES_CORE -am"
+        ;;
+        (${STAGE_LIB})
+            echo "-pl $MODULES_LIB -am"
+        ;;
+        (${STAGE_TESTS})
+            echo "-pl $MODULES_TESTS -am"
+        ;;
+        (${STAGE_MISC})
+            # compile everything; using the -am switch does not work with negated module lists!
+            # the negation takes precedence, thus not all required modules would be built
+            echo ""
+        ;;
+        (*)
+            return 1
+        ;;
+    esac
+}
+
+function get_test_modules_for_stage() {
+    local stage=$1
+
+    local modules_core=$MODULES_CORE
+    local modules_lib=$MODULES_LIB
+    local modules_tests=$MODULES_TESTS
+    local negated_core=\!${MODULES_CORE//,/,\!}
+    local negated_lib=\!${MODULES_LIB//,/,\!}
+    local negated_tests=\!${MODULES_TESTS//,/,\!}
+    local modules_misc="$negated_core,$negated_lib,$negated_tests"
+
+    case ${stage} in
+        (${STAGE_CORE})
+            echo "-pl $modules_core"
+        ;;
+        (${STAGE_LIB})
+            echo "-pl $modules_lib"
+        ;;
+        (${STAGE_TESTS})
+            echo "-pl $modules_tests"
+        ;;
+        (${STAGE_MISC})
+            echo "-pl $modules_misc"
+        ;;
+        (*)
+            return 1
+        ;;
+    esac
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR reduces the total execution time of Flink ML CIs so as to improve the efficiency of Flink ML development.

This PR mainly focuses on optimizing the execution time of Java tests. Python tests might be further optimized in separate PRs.

Compared with the current CI on the master branch, which took about 15 minutes[1], the CI of this PR would complete the same Java tests in about three minutes[2].

[1] https://github.com/apache/flink-ml/actions/runs/2872725840
[2] https://github.com/apache/flink-ml/actions/runs/2879967153

## Brief change log
- Make sure all flink-ml-lib tests create a static mini-cluster for all test cases in its class, reducing the overhead to start and shut down clusters
- Disable unaligned checkpoints in test cases
- Split maven tests into multiple CI jobs to improve concurrency.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (N/A)