### PR TITLE
[FLINK-29193] Add Transformer for Normalizer

### DIFF
--- a/docs/content/docs/operators/feature/normalizer.md
+++ b/docs/content/docs/operators/feature/normalizer.md
@@ -1,0 +1,154 @@
+---
+title: "Normalizer"
+weight: 1
+type: docs
+aliases:
+- /operators/feature/normalizer.html
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## Normalizer
+
+A Transformer that normalizes a vector to have unit norm using the given p-norm.
+
+### Input Columns
+
+| Param name | Type   | Default   | Description               |
+|:-----------|:-------|:----------|:--------------------------|
+| inputCol   | Vector | `"input"` | Vectors to be normalized. |
+
+### Output Columns
+
+| Param name | Type   | Default    | Description         |
+|:-----------|:-------|:-----------|:--------------------|
+| outputCol  | Vector | `"output"` | Normalized vectors. |
+
+### Parameters
+
+| Key       | Default    | Type   | Required | Description         |
+|:----------|:-----------|:-------|:---------|:--------------------|
+| inputCol  | `"input"`  | String | no       | Input column name.  |
+| outputCol | `"output"` | String | no       | Output column name. |
+| p         | `2.0`      | Double | no       | The p norm value.   |
+
+### Examples
+
+{{< tabs examples >}}
+
+{{< tab "Java">}}
+
+```java
+import org.apache.flink.ml.feature.normalizer.Normalizer;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+/** Simple program that creates a Normalizer instance and uses it for feature engineering. */
+public class NormalizerExample {
+	public static void main(String[] args) {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+		// Generates input data.
+		DataStream<Row> inputStream =
+			env.fromElements(
+				Row.of(Vectors.dense(2.1, 3.1, 1.2, 3.1, 4.6)),
+				Row.of(Vectors.dense(1.2, 3.1, 4.6, 2.1, 3.1)));
+		Table inputTable = tEnv.fromDataStream(inputStream).as("inputVec");
+
+		// Creates a Normalizer object and initializes its parameters.
+		Normalizer normalizer =
+			new Normalizer().setInputCol("inputVec").setP(3.0).setOutputCol("outputVec");
+
+		// Uses the Normalizer object for feature transformations.
+		Table outputTable = normalizer.transform(inputTable)[0];
+
+		// Extracts and displays the results.
+		for (CloseableIterator<Row> it = outputTable.execute().collect(); it.hasNext(); ) {
+			Row row = it.next();
+
+			Vector inputValue = (Vector) row.getField(normalizer.getInputCol());
+
+			Vector outputValue = (Vector) row.getField(normalizer.getOutputCol());
+
+			System.out.printf("Input Value: %s \tOutput Value: %s\n", inputValue, outputValue);
+		}
+	}
+}
+
+```
+
+{{< /tab>}}
+
+{{< tab "Python">}}
+
+```python
+# Simple program that creates a Normalizer instance and uses it for feature
+# engineering.
+
+from pyflink.common import Types
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.ml.core.linalg import Vectors, DenseVectorTypeInfo
+from pyflink.ml.lib.feature.normalizer import Normalizer
+from pyflink.table import StreamTableEnvironment
+
+# create a new StreamExecutionEnvironment
+env = StreamExecutionEnvironment.get_execution_environment()
+
+# create a StreamTableEnvironment
+t_env = StreamTableEnvironment.create(env)
+
+# generate input data
+input_data_table = t_env.from_data_stream(
+    env.from_collection([
+        (1, Vectors.dense(2.1, 3.1, 1.2, 2.1)),
+        (2, Vectors.dense(2.3, 2.1, 1.3, 1.2)),
+    ],
+        type_info=Types.ROW_NAMED(
+            ['id', 'input_vec'],
+            [Types.INT(), DenseVectorTypeInfo()])))
+
+# create a normalizer object and initialize its parameters
+normalizer = Normalizer() \
+    .set_input_col('input_vec') \
+    .set_p(1.5) \
+    .set_output_col('output_vec')
+
+# use the normalizer model for feature engineering
+output = normalizer.transform(input_data_table)[0]
+
+# extract and display the results
+field_names = output.get_schema().get_field_names()
+for result in t_env.to_data_stream(output).execute_and_collect():
+    input_value = result[field_names.index(normalizer.get_input_col())]
+    output_value = result[field_names.index(normalizer.get_output_col())]
+    print('Input Value: ' + str(input_value) + '\tOutput Value: ' + str(output_value))
+
+```
+
+{{< /tab>}}
+
+{{< /tabs>}}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/BLAS.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/linalg/BLAS.java
@@ -129,9 +129,41 @@ public class BLAS {
         return JAVA_BLAS.dnrm2(x.values.length, x.values, 1);
     }
 
+    /** Calculates the p-norm of the vector x. */
+    public static double norm(Vector x, double p) {
+        Preconditions.checkArgument(p >= 1.0, "p value must >= 1.0, but the current p is : " + p);
+        double norm = 0.0;
+        double[] data =
+                (x instanceof DenseVector) ? ((DenseVector) x).values : ((SparseVector) x).values;
+
+        if (p == 1.0) {
+            for (double datum : data) {
+                norm += Math.abs(datum);
+            }
+        } else if (p == 2.0) {
+            norm = norm2(x);
+        } else if (p == Double.POSITIVE_INFINITY) {
+            for (double datum : data) {
+                norm = Math.max(Math.abs(datum), norm);
+            }
+        } else {
+            for (double datum : data) {
+                norm += Math.pow(Math.abs(datum), p);
+            }
+            norm = Math.pow(norm, 1.0 / p);
+        }
+
+        return norm;
+    }
+
     /** x = x * a . */
-    public static void scal(double a, DenseVector x) {
-        JAVA_BLAS.dscal(x.size(), a, x.values, 1);
+    public static void scal(double a, Vector x) {
+        if (x instanceof DenseVector) {
+            JAVA_BLAS.dscal(x.size(), a, ((DenseVector) x).values, 1);
+        } else {
+            double[] values = ((SparseVector) x).values;
+            JAVA_BLAS.dscal(values.length, a, values, 1);
+        }
     }
 
     /**

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/BLASTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/linalg/BLASTest.java
@@ -93,10 +93,31 @@ public class BLASTest {
     }
 
     @Test
+    public void testNorm() {
+        assertEquals(Math.sqrt(55), BLAS.norm(inputDenseVec, 2.0), TOLERANCE);
+
+        SparseVector sparseVector = Vectors.sparse(5, new int[] {0, 2, 4}, new double[] {1, 3, 5});
+        assertEquals(5.0, BLAS.norm(sparseVector, Double.POSITIVE_INFINITY), TOLERANCE);
+
+        assertEquals(5.348481241239363, BLAS.norm(sparseVector, 3.0), TOLERANCE);
+    }
+
+    @Test
     public void testScal() {
         BLAS.scal(2, inputDenseVec);
-        double[] expectedResult = new double[] {2, -4, 6, 8, -10};
-        assertArrayEquals(expectedResult, inputDenseVec.values, TOLERANCE);
+
+        double[] expectedDenseResult = new double[] {2, -4, 6, 8, -10};
+        assertArrayEquals(expectedDenseResult, inputDenseVec.values, TOLERANCE);
+
+        SparseVector inputSparseVector =
+                Vectors.sparse(5, new int[] {0, 2, 4}, new double[] {1, 3, 5});
+        BLAS.scal(1.5, inputSparseVector);
+
+        double[] expectedSparseResult = new double[] {1.5, 4.5, 7.5};
+        int[] expectedSparseIndices = new int[] {0, 2, 4};
+
+        assertArrayEquals(expectedSparseResult, inputSparseVector.values, TOLERANCE);
+        assertArrayEquals(expectedSparseIndices, inputSparseVector.indices);
     }
 
     @Test

--- a/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/NormalizerExample.java
+++ b/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/NormalizerExample.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.examples.feature;
+
+import org.apache.flink.ml.feature.normalizer.Normalizer;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+/** Simple program that creates a Normalizer instance and uses it for feature engineering. */
+public class NormalizerExample {
+    public static void main(String[] args) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        // Generates input data.
+        DataStream<Row> inputStream =
+                env.fromElements(
+                        Row.of(Vectors.dense(2.1, 3.1, 1.2, 3.1, 4.6)),
+                        Row.of(Vectors.dense(1.2, 3.1, 4.6, 2.1, 3.1)));
+        Table inputTable = tEnv.fromDataStream(inputStream).as("inputVec");
+
+        // Creates a Normalizer object and initializes its parameters.
+        Normalizer normalizer =
+                new Normalizer().setInputCol("inputVec").setP(3.0).setOutputCol("outputVec");
+
+        // Uses the Normalizer object for feature transformations.
+        Table outputTable = normalizer.transform(inputTable)[0];
+
+        // Extracts and displays the results.
+        for (CloseableIterator<Row> it = outputTable.execute().collect(); it.hasNext(); ) {
+            Row row = it.next();
+
+            Vector inputValue = (Vector) row.getField(normalizer.getInputCol());
+
+            Vector outputValue = (Vector) row.getField(normalizer.getOutputCol());
+
+            System.out.printf("Input Value: %s \tOutput Value: %s\n", inputValue, outputValue);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/normalizer/Normalizer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/normalizer/Normalizer.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.normalizer;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.api.Transformer;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.linalg.BLAS;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/** A Transformer that normalizes a vector to have unit norm using the given p-norm. */
+public class Normalizer implements Transformer<Normalizer>, NormalizerParams<Normalizer> {
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public Normalizer() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public Table[] transform(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(inputTypeInfo.getFieldTypes(), VectorTypeInfo.INSTANCE),
+                        ArrayUtils.addAll(inputTypeInfo.getFieldNames(), getOutputCol()));
+
+        DataStream<Row> output =
+                tEnv.toDataStream(inputs[0])
+                        .map(new NormalizationFunction(getP(), getInputCol()), outputTypeInfo);
+
+        Table outputTable = tEnv.fromDataStream(output);
+        return new Table[] {outputTable};
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+
+    public static Normalizer load(StreamTableEnvironment env, String path) throws IOException {
+        return ReadWriteUtils.loadStageParam(path);
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    /** Normalization function that transforms a vector to have unit norm. */
+    private static class NormalizationFunction implements MapFunction<Row, Row> {
+        private final double p;
+        private final String inputCol;
+
+        public NormalizationFunction(double p, String inputCol) {
+            this.p = p;
+            this.inputCol = inputCol;
+        }
+
+        @Override
+        public Row map(Row row) throws Exception {
+            Vector inputVec = row.getFieldAs(inputCol);
+            Vector outputVec = inputVec.clone();
+            double norm = BLAS.norm(inputVec, p);
+            BLAS.scal(1.0 / norm, outputVec);
+            return Row.join(row, Row.of(outputVec));
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/normalizer/NormalizerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/normalizer/NormalizerParams.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.normalizer;
+
+import org.apache.flink.ml.common.param.HasInputCol;
+import org.apache.flink.ml.common.param.HasOutputCol;
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+
+/**
+ * Params of {@link Normalizer}.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface NormalizerParams<T> extends HasInputCol<T>, HasOutputCol<T> {
+    Param<Double> P = new DoubleParam("p", "The p norm value.", 2.0, ParamValidators.gtEq(1.0));
+
+    default Double getP() {
+        return get(P);
+    }
+
+    default T setP(Double value) {
+        return set(P, value);
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/NormalizerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/NormalizerTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.feature.normalizer.Normalizer;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.util.TestUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/** Tests {@link Normalizer}. */
+public class NormalizerTest extends AbstractTestBase {
+
+    private StreamTableEnvironment tEnv;
+    private Table inputDataTable;
+
+    private static final List<Row> INPUT_DATA =
+            Arrays.asList(
+                    Row.of(
+                            Vectors.dense(2.1, 3.1, 2.3, 3.4, 5.3, 5.1),
+                            Vectors.sparse(5, new int[] {1, 3, 4}, new double[] {0.1, 0.2, 0.3})),
+                    Row.of(
+                            Vectors.dense(2.3, 4.1, 1.3, 2.4, 5.1, 4.1),
+                            Vectors.sparse(5, new int[] {1, 2, 4}, new double[] {0.1, 0.2, 0.3})));
+
+    private static final List<Vector> EXPECTED_DENSE_OUTPUT =
+            Arrays.asList(
+                    Vectors.dense(
+                            0.17386300895299714,
+                            0.25665491797823387,
+                            0.19042139075804446,
+                            0.28149249068580484,
+                            0.43879711783375464,
+                            0.42223873602870726),
+                    Vectors.dense(
+                            0.20785190042726007,
+                            0.3705186051094636,
+                            0.11748150893714701,
+                            0.2168889395762714,
+                            0.4608889965995767,
+                            0.3705186051094636));
+
+    private static final List<Vector> EXPECTED_SPARSE_OUTPUT =
+            Arrays.asList(
+                    Vectors.sparse(
+                            5,
+                            new int[] {1, 3, 4},
+                            new double[] {
+                                0.23070057753660791, 0.46140115507321583, 0.6921017326098237
+                            }),
+                    Vectors.sparse(
+                            5,
+                            new int[] {1, 2, 4},
+                            new double[] {
+                                0.23070057753660791, 0.46140115507321583, 0.6921017326098237
+                            }));
+
+    @Before
+    public void before() {
+        Configuration config = new Configuration();
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+
+        env.setParallelism(4);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+
+        tEnv = StreamTableEnvironment.create(env);
+        DataStream<Row> dataStream = env.fromCollection(INPUT_DATA);
+        inputDataTable = tEnv.fromDataStream(dataStream).as("denseVec", "sparseVec");
+    }
+
+    private void verifyOutputResult(Table output, String outputCol, List<Vector> expectedData)
+            throws Exception {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) output).getTableEnvironment();
+        DataStream<Row> stream = tEnv.toDataStream(output);
+
+        List<Row> results = IteratorUtils.toList(stream.executeAndCollect());
+        List<Vector> resultVec = new ArrayList<>(results.size());
+        for (Row row : results) {
+            if (row.getField(outputCol) != null) {
+                resultVec.add(row.getFieldAs(outputCol));
+            }
+        }
+        compareResultCollections(expectedData, resultVec, TestUtils::compare);
+    }
+
+    @Test
+    public void testParam() {
+        Normalizer normalizer = new Normalizer();
+        assertEquals("input", normalizer.getInputCol());
+        assertEquals("output", normalizer.getOutputCol());
+        assertEquals(2.0, normalizer.getP(), 1.0e-5);
+
+        normalizer.setInputCol("denseVec").setOutputCol("outputVec").setP(1.5);
+        assertEquals("denseVec", normalizer.getInputCol());
+        assertEquals("outputVec", normalizer.getOutputCol());
+        assertEquals(1.5, normalizer.getP(), 1.0e-5);
+    }
+
+    @Test
+    public void testOutputSchema() {
+        Normalizer normalizer =
+                new Normalizer().setInputCol("denseVec").setOutputCol("outputVec").setP(1.5);
+
+        Table output = normalizer.transform(inputDataTable)[0];
+
+        assertEquals(
+                Arrays.asList("denseVec", "sparseVec", "outputVec"),
+                output.getResolvedSchema().getColumnNames());
+    }
+
+    @Test
+    public void testSaveLoadAndTransform() throws Exception {
+        Normalizer normalizer =
+                new Normalizer().setInputCol("denseVec").setOutputCol("outputVec").setP(1.5);
+
+        Normalizer loadedNormalizer =
+                TestUtils.saveAndReload(
+                        tEnv, normalizer, TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+
+        Table output = loadedNormalizer.transform(inputDataTable)[0];
+        verifyOutputResult(output, loadedNormalizer.getOutputCol(), EXPECTED_DENSE_OUTPUT);
+    }
+
+    @Test
+    public void testInvalidP() {
+        try {
+            Normalizer normalizer =
+                    new Normalizer().setInputCol("denseVec").setOutputCol("outputVec").setP(0.5);
+            normalizer.transform(inputDataTable);
+            fail();
+        } catch (Exception e) {
+            assertEquals("Parameter p is given an invalid value 0.5", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDenseTransform() throws Exception {
+        Normalizer normalizer =
+                new Normalizer().setInputCol("denseVec").setOutputCol("outputVec").setP(1.5);
+
+        Table output = normalizer.transform(inputDataTable)[0];
+        verifyOutputResult(output, normalizer.getOutputCol(), EXPECTED_DENSE_OUTPUT);
+    }
+
+    @Test
+    public void testSparseTransform() throws Exception {
+        Normalizer normalizer =
+                new Normalizer().setInputCol("sparseVec").setOutputCol("outputVec").setP(1.5);
+
+        Table output = normalizer.transform(inputDataTable)[0];
+        verifyOutputResult(output, normalizer.getOutputCol(), EXPECTED_SPARSE_OUTPUT);
+    }
+}

--- a/flink-ml-python/pyflink/examples/ml/feature/normalizer_example.py
+++ b/flink-ml-python/pyflink/examples/ml/feature/normalizer_example.py
@@ -1,0 +1,58 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Simple program that creates a Normalizer instance and uses it for feature
+# engineering.
+
+from pyflink.common import Types
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.ml.core.linalg import Vectors, DenseVectorTypeInfo
+from pyflink.ml.lib.feature.normalizer import Normalizer
+from pyflink.table import StreamTableEnvironment
+
+# create a new StreamExecutionEnvironment
+env = StreamExecutionEnvironment.get_execution_environment()
+
+# create a StreamTableEnvironment
+t_env = StreamTableEnvironment.create(env)
+
+# generate input data
+input_data_table = t_env.from_data_stream(
+    env.from_collection([
+        (1, Vectors.dense(2.1, 3.1, 1.2, 2.1)),
+        (2, Vectors.dense(2.3, 2.1, 1.3, 1.2)),
+    ],
+        type_info=Types.ROW_NAMED(
+            ['id', 'input_vec'],
+            [Types.INT(), DenseVectorTypeInfo()])))
+
+# create a normalizer object and initialize its parameters
+normalizer = Normalizer() \
+    .set_input_col('input_vec') \
+    .set_p(1.5) \
+    .set_output_col('output_vec')
+
+# use the normalizer model for feature engineering
+output = normalizer.transform(input_data_table)[0]
+
+# extract and display the results
+field_names = output.get_schema().get_field_names()
+for result in t_env.to_data_stream(output).execute_and_collect():
+    input_value = result[field_names.index(normalizer.get_input_col())]
+    output_value = result[field_names.index(normalizer.get_output_col())]
+    print('Input Value: ' + str(input_value) + '\tOutput Value: ' + str(output_value))

--- a/flink-ml-python/pyflink/ml/lib/feature/normalizer.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/normalizer.py
@@ -1,0 +1,69 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import typing
+
+from pyflink.ml.core.wrapper import JavaWithParams
+from pyflink.ml.core.param import FloatParam, ParamValidators
+from pyflink.ml.lib.feature.common import JavaFeatureTransformer
+from pyflink.ml.lib.param import HasInputCol, HasOutputCol, Param
+
+
+class _NormalizerParams(
+    JavaWithParams,
+    HasInputCol,
+    HasOutputCol
+):
+    """
+    Params for :class:`Normalizer`.
+    """
+
+    P: Param[float] = FloatParam(
+        "p",
+        "The p norm value.",
+        2.0,
+        ParamValidators.gt_eq(1.0))
+
+    def __init__(self, java_params):
+        super(_NormalizerParams, self).__init__(java_params)
+
+    def set_p(self, value: float):
+        return typing.cast(_NormalizerParams, self.set(self.P, value))
+
+    def get_p(self) -> bool:
+        return self.get(self.P)
+
+    @property
+    def p(self):
+        return self.get_p()
+
+
+class Normalizer(JavaFeatureTransformer, _NormalizerParams):
+    """
+    A Transformer that normalizes a vector to have unit norm using the given p-norm.
+    """
+
+    def __init__(self, java_model=None):
+        super(Normalizer, self).__init__(java_model)
+
+    @classmethod
+    def _java_transformer_package_name(cls) -> str:
+        return "normalizer"
+
+    @classmethod
+    def _java_transformer_class_name(cls) -> str:
+        return "Normalizer"

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_normalizer.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_normalizer.py
@@ -1,0 +1,86 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import os
+
+from pyflink.common import Types
+
+from pyflink.ml.core.linalg import Vectors, DenseVectorTypeInfo
+from pyflink.ml.lib.feature.normalizer import Normalizer
+from pyflink.ml.tests.test_utils import PyFlinkMLTestCase
+
+
+class NormalizerTest(PyFlinkMLTestCase):
+    def setUp(self):
+        super(NormalizerTest, self).setUp()
+        self.input_data_table = self.t_env.from_data_stream(
+            self.env.from_collection([
+                (Vectors.dense(2.1, 3.1, 2.3, 3.4, 5.3, 5.1),),
+                (Vectors.dense(2.3, 4.1, 1.3, 2.4, 5.1, 4.1),),
+            ],
+                type_info=Types.ROW_NAMED(
+                    ["intput_vec"],
+                    [DenseVectorTypeInfo()])))
+        self.expected_output_data = [
+            Vectors.dense(
+                0.17386300895299714,
+                0.25665491797823387,
+                0.19042139075804446,
+                0.28149249068580484,
+                0.43879711783375464,
+                0.42223873602870726),
+            Vectors.dense(
+                0.20785190042726007,
+                0.3705186051094636,
+                0.11748150893714701,
+                0.2168889395762714,
+                0.4608889965995767,
+                0.3705186051094636)]
+
+    def test_param(self):
+        normalizer = Normalizer()
+
+        self.assertEqual('input', normalizer.get_input_col())
+        self.assertEqual('output', normalizer.get_output_col())
+        self.assertEqual(2.0, normalizer.get_p())
+
+        normalizer.set_input_col("intput_vec") \
+            .set_output_col('output_vec') \
+            .set_p(1.5)
+
+        self.assertEqual("intput_vec", normalizer.get_input_col())
+        self.assertEqual(1.5, normalizer.get_p())
+        self.assertEqual('output_vec', normalizer.get_output_col())
+
+    def test_save_load_transform(self):
+        normalizer = Normalizer() \
+            .set_input_col("intput_vec") \
+            .set_output_col('output_vec') \
+            .set_p(1.5)
+
+        path = os.path.join(self.temp_dir, 'test_save_load_transform_normalizer')
+        normalizer.save(path)
+        normalizer = Normalizer.load(self.t_env, path)
+
+        output_table = normalizer.transform(self.input_data_table)[0]
+        actual_outputs = [(result[1]) for result in
+                          self.t_env.to_data_stream(output_table).execute_and_collect()]
+
+        self.assertEqual(2, len(actual_outputs))
+        actual_outputs.sort(key=lambda x: (x[0], x[1], x[2], x[3], x[4], x[5]))
+        self.expected_output_data.sort(key=lambda x: (x[0], x[1], x[2], x[3], x[4], x[5]))
+        self.assertEqual(self.expected_output_data, actual_outputs)


### PR DESCRIPTION
## What is the purpose of the change
Add Transformer for Normalizer in Flink ML.

## Brief change log
Added java/python source/test/example for Transformer for Normalizer in Flink ML.
The public interface is consistent with Normalizer in Spark ML.
## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (yes)
The public API, i.e., is any changed class annotated with @public(Evolving): (no)
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (Java doc)