### PR TITLE
[FLINK-29323] Add inputSizes parameter for VectorAssembler

### DIFF
--- a/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/VectorAssemblerExample.java
+++ b/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/VectorAssemblerExample.java
@@ -56,7 +56,8 @@ public class VectorAssemblerExample {
         VectorAssembler vectorAssembler =
                 new VectorAssembler()
                         .setInputCols("vec", "num", "sparseVec")
-                        .setOutputCol("assembledVec");
+                        .setOutputCol("assembledVec")
+                        .setInputSizes(2, 1, 5);
 
         // Uses the VectorAssembler object for feature transformations.
         Table outputTable = vectorAssembler.transform(inputTable)[0];

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssemblerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssemblerParams.java
@@ -21,6 +21,9 @@ package org.apache.flink.ml.feature.vectorassembler;
 import org.apache.flink.ml.common.param.HasHandleInvalid;
 import org.apache.flink.ml.common.param.HasInputCols;
 import org.apache.flink.ml.common.param.HasOutputCol;
+import org.apache.flink.ml.param.IntArrayParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidator;
 
 /**
  * Params of {@link VectorAssembler}.
@@ -28,4 +31,34 @@ import org.apache.flink.ml.common.param.HasOutputCol;
  * @param <T> The class type of this instance.
  */
 public interface VectorAssemblerParams<T>
-        extends HasInputCols<T>, HasOutputCol<T>, HasHandleInvalid<T> {}
+        extends HasInputCols<T>, HasOutputCol<T>, HasHandleInvalid<T> {
+    Param<Integer[]> INPUT_SIZES =
+            new IntArrayParam(
+                    "inputSizes",
+                    "Sizes of the input elements to be assembled.",
+                    null,
+                    sizesValidator());
+
+    default Integer[] getInputSizes() {
+        return get(INPUT_SIZES);
+    }
+
+    default T setInputSizes(Integer... value) {
+        return set(INPUT_SIZES, value);
+    }
+
+    // Checks the inputSizes parameter.
+    static ParamValidator<Integer[]> sizesValidator() {
+        return inputSizes -> {
+            if (inputSizes == null) {
+                return false;
+            }
+            for (Integer size : inputSizes) {
+                if (size <= 0) {
+                    return false;
+                }
+            }
+            return inputSizes.length != 0;
+        };
+    }
+}

--- a/flink-ml-python/pyflink/examples/ml/feature/vectorassembler_example.py
+++ b/flink-ml-python/pyflink/examples/ml/feature/vectorassembler_example.py
@@ -50,6 +50,7 @@ input_data_table = t_env.from_data_stream(
 vector_assembler = VectorAssembler() \
     .set_input_cols('vec', 'num', 'sparse_vec') \
     .set_output_col('assembled_vec') \
+    .set_input_sizes(2, 1, 5) \
     .set_handle_invalid('keep')
 
 # use the vector assembler for feature engineering

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_vectorassembler.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_vectorassembler.py
@@ -55,16 +55,19 @@ class VectorAssemblerTest(PyFlinkMLTestCase):
 
         vector_assembler.set_input_cols('vec', 'num', 'sparse_vec') \
             .set_output_col('assembled_vec') \
+            .set_input_sizes(2, 1, 5) \
             .set_handle_invalid('skip')
 
         self.assertEqual(('vec', 'num', 'sparse_vec'), vector_assembler.input_cols)
-        self.assertEqual('skip', vector_assembler.handle_invalid)
         self.assertEqual('assembled_vec', vector_assembler.output_col)
+        self.assertEqual((2, 1, 5), vector_assembler.input_sizes)
+        self.assertEqual('skip', vector_assembler.handle_invalid)
 
     def test_save_load_transform(self):
         vector_assembler = VectorAssembler() \
             .set_input_cols('vec', 'num', 'sparse_vec') \
             .set_output_col('assembled_vec') \
+            .set_input_sizes(2, 1, 5) \
             .set_handle_invalid('keep')
 
         path = os.path.join(self.temp_dir, 'test_save_load_transform_vector_assembler')

--- a/flink-ml-python/pyflink/ml/lib/feature/vectorassembler.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/vectorassembler.py
@@ -16,9 +16,11 @@
 # limitations under the License.
 ################################################################################
 
+from typing import Tuple
 from pyflink.ml.core.wrapper import JavaWithParams
+from pyflink.ml.core.param import IntArrayParam, ParamValidator
 from pyflink.ml.lib.feature.common import JavaFeatureTransformer
-from pyflink.ml.lib.param import HasInputCols, HasOutputCol, HasHandleInvalid
+from pyflink.ml.lib.param import HasInputCols, HasOutputCol, HasHandleInvalid, Param
 
 
 class _VectorAssemblerParams(
@@ -27,21 +29,61 @@ class _VectorAssemblerParams(
     HasOutputCol,
     HasHandleInvalid
 ):
+
+    """
+    Checks the inputSizes parameter.
+    """
+    def SizesValidator(self) -> ParamValidator[Tuple[int]]:
+        class SizesValidator(ParamValidator[Tuple[int]]):
+            def validate(self, indices: Tuple[int]) -> bool:
+                if indices is None:
+                    return False
+                for val in indices:
+                    if val <= 0:
+                        return False
+                return len(indices) != 0
+        return SizesValidator()
+
     """
     Params for :class:`VectorAssembler`.
     """
 
+    INPUT_SIZES: Param[Tuple[int, ...]] = IntArrayParam(
+        "input_sizes",
+        "Sizes of the input elements to be assembled.",
+        None,
+        SizesValidator(None))
+
     def __init__(self, java_params):
         super(_VectorAssemblerParams, self).__init__(java_params)
+
+    def set_input_sizes(self, *sizes: int):
+        return self.set(self.INPUT_SIZES, sizes)
+
+    def get_input_sizes(self) -> Tuple[int, ...]:
+        return self.get(self.INPUT_SIZES)
+
+    @property
+    def input_sizes(self) -> Tuple[int, ...]:
+        return self.get_input_sizes()
 
 
 class VectorAssembler(JavaFeatureTransformer, _VectorAssemblerParams):
     """
-    A Transformer which combines a given list of input columns into a vector column. Types of
-    input columns must be either vector or numerical value.
-
-    The `keep` option of :class:HasHandleInvalid means that we output bad rows with output column
-    set to null.
+     A Transformer which combines a given list of input columns into a vector column. Input columns
+     would be numerical or vectors whose sizes are specified by the :class:INPUT_SIZES parameter.
+     Invalid input data with null values or values with wrong sizes would be dealt with according to
+     the strategy specified by the :class:HasHandleInvalid parameter as follows:
+     <ul>
+       <li>keep: If the input column data is null, a vector would be created with the specified size
+           and NaN values. The vector would be used in the assembling process to represent the input
+           column data. If the input column data is a vector, the data would be used in the
+           assembling process even if it has a wrong size.
+       <li>skip: If the input column data is null or a vector with wrong size, the input row would
+           be filtered out and not be sent to downstream operators.
+       <li>error: If the input column data is null or a vector with wrong size, an exception would
+           be thrown.
+     </ul>
     """
 
     def __init__(self, java_model=None):


### PR DESCRIPTION
## What is the purpose of the change
Add inputSizes parameter for VectorAssembler

## Brief change log
Add inputSizes parameter for VectorAssembler.

## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @public(Evolving): (yes)
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (Java doc)