### PR TITLE
[FLINK-28906] Support windowing in AgglomerativeClustering

### DIFF
--- a/docs/content/docs/operators/clustering/agglomerativeclustering.md
+++ b/docs/content/docs/operators/clustering/agglomerativeclustering.md
@@ -49,15 +49,16 @@ format of the merging information is
 
 ### Parameters
 
-| Key               | Default        | Type    | Required | Description                                                                                                         |
-|:------------------|:---------------|:--------|:---------|:--------------------------------------------------------------------------------------------------------------------|
-| numClusters       | `2`            | Integer | no       | The max number of clusters to create.                                                                               |
-| distanceThreshold | `null`         | Double  | no       | Threshold to decide whether two clusters should be merged.                                                          |
-| linkage           | `"ward"`       | String  | no       | Criterion for computing distance between two clusters. Supported values: `'ward', 'complete', 'single', 'average'`. |
-| computeFullTree   | `false`        | Boolean | no       | Whether computes the full tree after convergence.                                                                   |
-| distanceMeasure   | `"euclidean"`  | String  | no       | Distance measure. Supported values: `'euclidean', 'manhattan', 'cosine'`.                                           |
-| featuresCol       | `"features"`   | String  | no       | Features column name.                                                                                               |
-| predictionCol     | `"prediction"` | String  | no       | Prediction column name.                                                                                             |
+| Key               | Default                       | Type    | Required | Description                                                                    |
+|:------------------|:------------------------------|:--------|:---------|:-------------------------------------------------------------------------------|
+| numClusters       | `2`                           | Integer | no       | The max number of clusters to create.                                          |
+| distanceThreshold | `null`                        | Double  | no       | Threshold to decide whether two clusters should be merged.                     |
+| linkage           | `"ward"`                      | String  | no       | Criterion for computing distance between two clusters.                         |
+| computeFullTree   | `false`                       | Boolean | no       | Whether computes the full tree after convergence.                              |
+| distanceMeasure   | `"euclidean"`                 | String  | no       | Distance measure.                                                              |
+| featuresCol       | `"features"`                  | String  | no       | Features column name.                                                          |
+| predictionCol     | `"prediction"`                | String  | no       | Prediction column name.                                                        |
+| windows           | `GlobalWindows.getInstance()` | Windows | no       | Windowing strategy that determines how to create mini-batches from input data. |
 
 ### Examples
 

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/CountTumblingWindows.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/CountTumblingWindows.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.window;
+
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A windowing strategy that groups elements into fixed-size windows based on the count number of
+ * the elements. Windows do not overlap.
+ */
+public class CountTumblingWindows implements Windows {
+    /** Size of this window as row-count interval. */
+    private final long size;
+
+    private CountTumblingWindows(long size) {
+        Preconditions.checkArgument(
+                size > 0, "The size of a count window must be a positive value");
+        this.size = size;
+    }
+
+    /**
+     * Creates a new {@link CountTumblingWindows}.
+     *
+     * @param size the size of the window as row-count interval.
+     */
+    public static CountTumblingWindows of(long size) {
+        return new CountTumblingWindows(size);
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(size);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof CountTumblingWindows)) {
+            return false;
+        }
+
+        CountTumblingWindows windows = (CountTumblingWindows) obj;
+        return this.size == windows.size;
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/EventTimeSessionWindows.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/EventTimeSessionWindows.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.window;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A windowing strategy that groups elements into sessions based on the timestamp of the elements.
+ * Windows do not overlap.
+ */
+public class EventTimeSessionWindows implements Windows {
+    /** The session timeout, i.e. the time gap between sessions. */
+    private final Time gap;
+
+    private EventTimeSessionWindows(Time gap) {
+        this.gap = Preconditions.checkNotNull(gap);
+    }
+
+    /**
+     * Creates a new {@link EventTimeSessionWindows}.
+     *
+     * @param gap The session timeout, i.e. the time gap between sessions
+     */
+    public static EventTimeSessionWindows withGap(Time gap) {
+        return new EventTimeSessionWindows(gap);
+    }
+
+    public Time getGap() {
+        return gap;
+    }
+
+    @Override
+    public int hashCode() {
+        return gap.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof EventTimeSessionWindows)) {
+            return false;
+        }
+
+        EventTimeSessionWindows window = (EventTimeSessionWindows) obj;
+
+        return this.gap.equals(window.gap);
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/EventTimeTumblingWindows.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/EventTimeTumblingWindows.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.window;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A windowing strategy that groups elements into fixed-size windows based on the timestamp of the
+ * elements. Windows do not overlap.
+ */
+public class EventTimeTumblingWindows implements Windows {
+    /** Size of this window as time interval. */
+    private final Time size;
+
+    private EventTimeTumblingWindows(Time size) {
+        this.size = Preconditions.checkNotNull(size);
+    }
+
+    /**
+     * Creates a new {@link EventTimeTumblingWindows}.
+     *
+     * @param size the size of the window as time interval.
+     */
+    public static EventTimeTumblingWindows of(Time size) {
+        return new EventTimeTumblingWindows(size);
+    }
+
+    public Time getSize() {
+        return size;
+    }
+
+    @Override
+    public int hashCode() {
+        return size.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof EventTimeTumblingWindows)) {
+            return false;
+        }
+
+        EventTimeTumblingWindows window = (EventTimeTumblingWindows) obj;
+
+        return this.size.equals(window.size);
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/GlobalWindows.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/GlobalWindows.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.window;
+
+/**
+ * A windowing strategy that groups all elements into a single global window. This strategy assumes
+ * that the input strategy is bounded.
+ */
+public class GlobalWindows implements Windows {
+    private static final GlobalWindows INSTANCE = new GlobalWindows();
+
+    private GlobalWindows() {}
+
+    /** Gets a {@link GlobalWindows} instance. */
+    public static GlobalWindows getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public int hashCode() {
+        return GlobalWindows.class.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof GlobalWindows;
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/ProcessingTimeSessionWindows.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/ProcessingTimeSessionWindows.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.window;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A windowing strategy that groups elements into sessions based on the current system time of the
+ * machine the operation is running on. Windows do not overlap.
+ */
+public class ProcessingTimeSessionWindows implements Windows {
+    /** The session timeout, i.e. the time gap between sessions. */
+    private final Time gap;
+
+    private ProcessingTimeSessionWindows(Time gap) {
+        this.gap = Preconditions.checkNotNull(gap);
+    }
+
+    /**
+     * Creates a new {@link ProcessingTimeSessionWindows}.
+     *
+     * @param gap The session timeout, i.e. the time gap between sessions
+     */
+    public static ProcessingTimeSessionWindows withGap(Time gap) {
+        return new ProcessingTimeSessionWindows(gap);
+    }
+
+    public Time getGap() {
+        return gap;
+    }
+
+    @Override
+    public int hashCode() {
+        return gap.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof ProcessingTimeSessionWindows)) {
+            return false;
+        }
+
+        ProcessingTimeSessionWindows window = (ProcessingTimeSessionWindows) obj;
+
+        return this.gap.equals(window.gap);
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/ProcessingTimeTumblingWindows.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/ProcessingTimeTumblingWindows.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.window;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A windowing strategy that groups elements into fixed-size windows based on the current system
+ * time of the machine the operation is running on. Windows do not overlap.
+ */
+public class ProcessingTimeTumblingWindows implements Windows {
+    /** Size of this window as time interval. */
+    private final Time size;
+
+    private ProcessingTimeTumblingWindows(Time size) {
+        this.size = Preconditions.checkNotNull(size);
+    }
+
+    /**
+     * Creates a new {@link ProcessingTimeTumblingWindows}.
+     *
+     * @param size the size of the window as time interval.
+     */
+    public static ProcessingTimeTumblingWindows of(Time size) {
+        return new ProcessingTimeTumblingWindows(size);
+    }
+
+    public Time getSize() {
+        return size;
+    }
+
+    @Override
+    public int hashCode() {
+        return size.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof ProcessingTimeTumblingWindows)) {
+            return false;
+        }
+
+        ProcessingTimeTumblingWindows window = (ProcessingTimeTumblingWindows) obj;
+
+        return this.size.equals(window.size);
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/Windows.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/window/Windows.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.window;
+
+/** Windowing strategy that determines how to create mini-batches from input data. */
+public interface Windows {}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/param/WindowsParam.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/param/WindowsParam.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.param;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.ml.common.window.CountTumblingWindows;
+import org.apache.flink.ml.common.window.EventTimeSessionWindows;
+import org.apache.flink.ml.common.window.EventTimeTumblingWindows;
+import org.apache.flink.ml.common.window.GlobalWindows;
+import org.apache.flink.ml.common.window.ProcessingTimeSessionWindows;
+import org.apache.flink.ml.common.window.ProcessingTimeTumblingWindows;
+import org.apache.flink.ml.common.window.Windows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Class for the {@link Windows} parameter. */
+public class WindowsParam extends Param<Windows> {
+    public WindowsParam(
+            String name,
+            String description,
+            Windows defaultValue,
+            ParamValidator<Windows> validator) {
+        super(name, Windows.class, description, defaultValue, validator);
+    }
+
+    @Override
+    public Object jsonEncode(Windows value) {
+        Map<String, Object> map = new HashMap<>();
+
+        map.put("class", value.getClass().getName());
+        if (value instanceof GlobalWindows) {
+            return map;
+        } else if (value instanceof CountTumblingWindows) {
+            map.put("size", ((CountTumblingWindows) value).getSize());
+        } else if (value instanceof ProcessingTimeTumblingWindows) {
+            map.put("size", ((ProcessingTimeTumblingWindows) value).getSize().toMilliseconds());
+        } else if (value instanceof EventTimeTumblingWindows) {
+            map.put("size", ((EventTimeTumblingWindows) value).getSize().toMilliseconds());
+        } else if (value instanceof ProcessingTimeSessionWindows) {
+            map.put("gap", ((ProcessingTimeSessionWindows) value).getGap().toMilliseconds());
+        } else if (value instanceof EventTimeSessionWindows) {
+            map.put("gap", ((EventTimeSessionWindows) value).getGap().toMilliseconds());
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format("Unsupported %s subclass: %s", Windows.class, value.getClass()));
+        }
+        return map;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Windows jsonDecode(Object json) {
+        Map<String, Object> map = (Map<String, Object>) json;
+
+        String classString = (String) map.get("class");
+        if (classString.equals(GlobalWindows.class.getName())) {
+            return GlobalWindows.getInstance();
+        } else if (classString.equals(CountTumblingWindows.class.getName())) {
+            long size = ((Number) map.get("size")).longValue();
+            return CountTumblingWindows.of(size);
+        } else if (classString.equals(ProcessingTimeTumblingWindows.class.getName())) {
+            Time size = Time.milliseconds(((Number) map.get("size")).longValue());
+            return ProcessingTimeTumblingWindows.of(size);
+        } else if (classString.equals(EventTimeTumblingWindows.class.getName())) {
+            Time size = Time.milliseconds(((Number) map.get("size")).longValue());
+            return EventTimeTumblingWindows.of(size);
+        } else if (classString.equals(ProcessingTimeSessionWindows.class.getName())) {
+            Time gap = Time.milliseconds(((Number) map.get("gap")).longValue());
+            return ProcessingTimeSessionWindows.withGap(gap);
+        } else if (classString.equals(EventTimeSessionWindows.class.getName())) {
+            Time gap = Time.milliseconds(((Number) map.get("gap")).longValue());
+            return EventTimeSessionWindows.withGap(gap);
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format("Unsupported %s subclass: %s", Windows.class, classString));
+        }
+    }
+}

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/common/window/WindowsTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/common/window/WindowsTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.window;
+
+import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.ml.common.datastream.DataStreamUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.windowing.ProcessAllWindowFunction;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.Collector;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests the {@link Windows}. */
+@SuppressWarnings("unchecked")
+public class WindowsTest extends AbstractTestBase {
+    private static final int RECORD_NUM = 100;
+
+    private static List<Long> inputData;
+
+    private static DataStream<Long> inputStream;
+    private static DataStream<Long> inputStreamWithProcessingTimeGap;
+    private static DataStream<Long> inputStreamWithEventTime;
+
+    @BeforeClass
+    public static void beforeClass() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        inputData = new ArrayList<>();
+        for (long i = 0; i < RECORD_NUM; i++) {
+            inputData.add(i);
+        }
+        inputStream = env.fromCollection(inputData);
+
+        inputStreamWithProcessingTimeGap =
+                inputStream
+                        .map(
+                                new MapFunction<Long, Long>() {
+                                    private int count = 0;
+
+                                    @Override
+                                    public Long map(Long value) throws Exception {
+                                        count++;
+                                        if (count % (RECORD_NUM / 2) == 0) {
+                                            Thread.sleep(1000);
+                                        }
+                                        return value;
+                                    }
+                                })
+                        .setParallelism(1);
+
+        inputStreamWithEventTime =
+                inputStream.assignTimestampsAndWatermarks(
+                        WatermarkStrategy.<Long>forMonotonousTimestamps()
+                                .withTimestampAssigner(
+                                        (SerializableTimestampAssigner<Long>)
+                                                (element, recordTimestamp) -> element));
+    }
+
+    @Test
+    public void testGlobalWindows() throws Exception {
+        DataStream<List<Long>> outputStream =
+                DataStreamUtils.windowAllAndProcess(
+                        inputStream,
+                        GlobalWindows.getInstance(),
+                        new CreateAllWindowBatchFunction<>());
+        List<List<Long>> actualBatches = IteratorUtils.toList(outputStream.executeAndCollect());
+        assertEquals(1, actualBatches.size());
+        assertEquals(new HashSet<>(inputData), new HashSet<>(actualBatches.get(0)));
+    }
+
+    @Test
+    public void testCountTumblingWindows() throws Exception {
+        DataStream<List<Long>> outputStream =
+                DataStreamUtils.windowAllAndProcess(
+                        inputStream,
+                        CountTumblingWindows.of(RECORD_NUM / 7),
+                        new CreateAllWindowBatchFunction<>());
+        List<List<Long>> actualBatches = IteratorUtils.toList(outputStream.executeAndCollect());
+        assertEquals(7, actualBatches.size());
+        int count = 0;
+        for (List<Long> batch : actualBatches) {
+            count += batch.size();
+        }
+        assertEquals(RECORD_NUM - (RECORD_NUM % 7), count);
+    }
+
+    @Test
+    public void testProcessingTimeTumblingWindows() throws Exception {
+        DataStream<List<Long>> outputStream =
+                DataStreamUtils.windowAllAndProcess(
+                        inputStreamWithProcessingTimeGap,
+                        ProcessingTimeTumblingWindows.of(Time.milliseconds(100)),
+                        new CreateAllWindowBatchFunction<>());
+        List<List<Long>> actualBatches = IteratorUtils.toList(outputStream.executeAndCollect());
+        assertTrue(actualBatches.size() > 1);
+        List<Long> mergedBatches = new ArrayList<>();
+        for (List<Long> batch : actualBatches) {
+            mergedBatches.addAll(batch);
+        }
+        assertTrue(mergedBatches.containsAll(inputData.subList(0, RECORD_NUM - 1)));
+    }
+
+    @Test
+    public void testEventTimeTumblingWindows() throws Exception {
+        DataStream<List<Long>> outputStream =
+                DataStreamUtils.windowAllAndProcess(
+                        inputStreamWithEventTime,
+                        EventTimeTumblingWindows.of(Time.milliseconds(RECORD_NUM / 7)),
+                        new CreateAllWindowBatchFunction<>());
+        List<List<Long>> actualBatches = IteratorUtils.toList(outputStream.executeAndCollect());
+        assertEquals(8, actualBatches.size());
+        List<Long> mergedBatches = new ArrayList<>();
+        for (List<Long> batch : actualBatches) {
+            mergedBatches.addAll(batch);
+        }
+        assertEquals(RECORD_NUM, mergedBatches.size());
+        assertEquals(new HashSet<>(inputData), new HashSet<>(mergedBatches));
+    }
+
+    @Test
+    public void testProcessingTimeSessionWindows() throws Exception {
+        DataStream<List<Long>> outputStream =
+                DataStreamUtils.windowAllAndProcess(
+                        inputStreamWithProcessingTimeGap,
+                        ProcessingTimeSessionWindows.withGap(Time.milliseconds(100)),
+                        new CreateAllWindowBatchFunction<>());
+        List<List<Long>> actualBatches = IteratorUtils.toList(outputStream.executeAndCollect());
+        assertTrue(actualBatches.size() > 1);
+        List<Long> mergedBatches = new ArrayList<>();
+        for (List<Long> batch : actualBatches) {
+            mergedBatches.addAll(batch);
+        }
+        assertTrue(mergedBatches.containsAll(inputData.subList(0, RECORD_NUM - 1)));
+    }
+
+    @Test
+    public void testEventTimeSessionWindows() throws Exception {
+        DataStream<List<Long>> outputStream =
+                DataStreamUtils.windowAllAndProcess(
+                        inputStreamWithEventTime,
+                        EventTimeSessionWindows.withGap(Time.milliseconds(RECORD_NUM / 7)),
+                        new CreateAllWindowBatchFunction<>());
+        List<List<Long>> actualBatches = IteratorUtils.toList(outputStream.executeAndCollect());
+        assertEquals(1, actualBatches.size());
+        assertEquals(new HashSet<>(inputData), new HashSet<>(actualBatches.get(0)));
+    }
+
+    private static class CreateAllWindowBatchFunction<IN, W extends Window>
+            extends ProcessAllWindowFunction<IN, List<IN>, W> {
+        @Override
+        public void process(
+                ProcessAllWindowFunction<IN, List<IN>, W>.Context context,
+                Iterable<IN> elements,
+                Collector<List<IN>> out) {
+            List<IN> list = new ArrayList<>();
+            elements.forEach(list::add);
+            out.collect(list);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/agglomerativeclustering/AgglomerativeClusteringParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/agglomerativeclustering/AgglomerativeClusteringParams.java
@@ -21,6 +21,7 @@ package org.apache.flink.ml.clustering.agglomerativeclustering;
 import org.apache.flink.ml.common.param.HasDistanceMeasure;
 import org.apache.flink.ml.common.param.HasFeaturesCol;
 import org.apache.flink.ml.common.param.HasPredictionCol;
+import org.apache.flink.ml.common.param.HasWindows;
 import org.apache.flink.ml.param.BooleanParam;
 import org.apache.flink.ml.param.DoubleParam;
 import org.apache.flink.ml.param.IntParam;
@@ -34,7 +35,7 @@ import org.apache.flink.ml.param.StringParam;
  * @param <T> The class type of this instance.
  */
 public interface AgglomerativeClusteringParams<T>
-        extends HasDistanceMeasure<T>, HasFeaturesCol<T>, HasPredictionCol<T> {
+        extends HasDistanceMeasure<T>, HasFeaturesCol<T>, HasPredictionCol<T>, HasWindows<T> {
     Param<Integer> NUM_CLUSTERS =
             new IntParam("numClusters", "The max number of clusters to create.", 2);
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasWindows.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasWindows.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.common.window.GlobalWindows;
+import org.apache.flink.ml.common.window.Windows;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WindowsParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared windows param. */
+public interface HasWindows<T> extends WithParams<T> {
+    Param<Windows> WINDOWS =
+            new WindowsParam(
+                    "windows",
+                    "Windowing strategy that determines how to create mini-batches from input data.",
+                    GlobalWindows.getInstance(),
+                    ParamValidators.notNull());
+
+    default Windows getWindows() {
+        return get(WINDOWS);
+    }
+
+    default T setWindows(Windows windows) {
+        return set(WINDOWS, windows);
+    }
+}

--- a/flink-ml-python/pyflink/ml/core/param.py
+++ b/flink-ml-python/pyflink/ml/core/param.py
@@ -19,6 +19,7 @@
 from abc import ABC, abstractmethod
 from typing import TypeVar, Generic, List, Dict, Any, Optional, Tuple, Union
 from pyflink.ml.core.linalg import Vector
+from pyflink.ml.core.windows import Windows
 
 import jsonpickle
 
@@ -87,9 +88,7 @@ class WithParams(Generic[T], ABC):
     @staticmethod
     def _is_compatible_type(param: 'Param[V]', value: V) -> bool:
         if value is not None and param.type != type(value):
-            if type(value).__name__ == 'DenseVector' or type(value).__name__ == 'SparseVector':
-                return issubclass(type(value), param.type)
-            return False
+            return issubclass(type(value), param.type)
         if isinstance(value, list):
             for item in value:
                 if param.type_name != f'list[{type(item).__name__}]':
@@ -392,3 +391,14 @@ class VectorParam(Param[Vector]):
                  validator: ParamValidator[Vector] = ParamValidators.always_true()):
         super(VectorParam, self).__init__(name, Vector, "str", description, default_value,
                                           validator)
+
+
+class WindowsParam(Param[Windows]):
+    """
+    Class for the Windows parameter.
+    """
+
+    def __init__(self, name: str, description: str, default_value: Optional[Windows],
+                 validator: ParamValidator[Windows] = ParamValidators.always_true()):
+        super(WindowsParam, self).__init__(name, Windows, "str", description, default_value,
+                                           validator)

--- a/flink-ml-python/pyflink/ml/core/tests/test_param.py
+++ b/flink-ml-python/pyflink/ml/core/tests/test_param.py
@@ -21,13 +21,16 @@ from typing import Dict, Any
 from pyflink.ml.core.param import Param
 from pyflink.ml.lib.param import HasDistanceMeasure, HasFeaturesCol, HasGlobalBatchSize, \
     HasHandleInvalid, HasInputCols, HasLabelCol, HasLearningRate, HasMaxIter, HasMultiClass, \
-    HasOutputCols, HasPredictionCol, HasRawPredictionCol, HasReg, HasSeed, HasTol, HasWeightCol
+    HasOutputCols, HasPredictionCol, HasRawPredictionCol, HasReg, HasSeed, HasTol, HasWeightCol, \
+    HasWindows
+
+from pyflink.ml.core.windows import GlobalWindows, CountTumblingWindows
 
 
 class TestParams(HasDistanceMeasure, HasFeaturesCol, HasGlobalBatchSize, HasHandleInvalid,
                  HasInputCols, HasLabelCol, HasLearningRate, HasMaxIter, HasMultiClass,
                  HasOutputCols, HasPredictionCol, HasRawPredictionCol, HasReg, HasSeed, HasTol,
-                 HasWeightCol):
+                 HasWeightCol, HasWindows):
     def __init__(self):
         self._param_map = {}
 
@@ -200,3 +203,15 @@ class ParamTests(unittest.TestCase):
 
         param.set_weight_col('test_weight_col')
         self.assertEqual(param.get_weight_col(), 'test_weight_col')
+
+    def test_windows(self):
+        param = TestParams()
+        windows = param.WINDOWS
+        self.assertEqual(windows.name, "windows")
+        self.assertEqual(windows.description,
+                         "Windowing strategy that determines how to create "
+                         "mini-batches from input data.")
+        self.assertEqual(windows.default_value, GlobalWindows())
+
+        param.set_windows(CountTumblingWindows.of(100))
+        self.assertEqual(param.get_windows(), CountTumblingWindows.of(100))

--- a/flink-ml-python/pyflink/ml/core/tests/test_stage.py
+++ b/flink-ml-python/pyflink/ml/core/tests/test_stage.py
@@ -18,13 +18,19 @@
 import os
 from typing import Dict, Any
 
+from pyflink.common import Time
 from pyflink.table import StreamTableEnvironment
 
 from pyflink.ml.core.api import Stage
 from pyflink.ml.core.linalg import Vectors
 from pyflink.ml.core.param import ParamValidators, Param, BooleanParam, IntParam, \
-    FloatParam, StringParam, VectorParam, IntArrayParam, FloatArrayParam, StringArrayParam
+    FloatParam, StringParam, VectorParam, IntArrayParam, FloatArrayParam, StringArrayParam, \
+    WindowsParam
 from pyflink.ml.tests.test_utils import PyFlinkMLTestCase
+
+from pyflink.ml.core.windows import ProcessingTimeSessionWindows, GlobalWindows, \
+    CountTumblingWindows, EventTimeTumblingWindows, ProcessingTimeTumblingWindows, \
+    EventTimeSessionWindows
 
 BOOLEAN_PARAM = BooleanParam("boolean_param", "Description", False)
 INT_PARAM = IntParam("int_param", "Description", 1, ParamValidators.lt(100))
@@ -34,6 +40,8 @@ INT_ARRAY_PARAM = IntArrayParam("int_array_param", "Description", (6, 7))
 FLOAT_ARRAY_PARAM = FloatArrayParam("float_array_param", "Description", (10.0, 11.0))
 STRING_ARRAY_PARAM = StringArrayParam("string_array_param", "Description", ("14", "15"))
 VECTOR_PARAM = VectorParam('vector_param', "Description", Vectors.dense(1, 2, 3))
+WINDOWS_PARAM = WindowsParam('windows_param', "Description",
+                             ProcessingTimeSessionWindows.with_gap(Time.milliseconds(100)))
 EXTRA_INT_PARAM = IntParam("extra_int_param",
                            "Description",
                            20,
@@ -105,6 +113,11 @@ class StageTest(PyFlinkMLTestCase):
                                  ".Vector'> is incompatible with the type of <class 'int'>"):
             stage.set(VECTOR_PARAM, 100)
 
+        with pytest.raises(TypeError,
+                           match="Parameter windows_param's type <class 'pyflink.ml.core.windows"
+                                 ".Windows'> is incompatible with the type of <class 'int'>"):
+            stage.set(WINDOWS_PARAM, 100)
+
     def test_param_set_valid_value(self):
         stage = MyStage()
 
@@ -131,6 +144,19 @@ class StageTest(PyFlinkMLTestCase):
         self.assertEqual(sparse_vec.get(1), stage.get(VECTOR_PARAM).get(1))
         self.assertEqual(sparse_vec.get(2), stage.get(VECTOR_PARAM).get(2))
 
+        windows_list = [
+            GlobalWindows(),
+            CountTumblingWindows.of(100),
+            EventTimeTumblingWindows.of(Time.milliseconds(100)),
+            ProcessingTimeTumblingWindows.of(Time.seconds(100)),
+            EventTimeSessionWindows.with_gap(Time.minutes(100)),
+            ProcessingTimeSessionWindows.with_gap(Time.hours(100))
+        ]
+
+        for windows in windows_list:
+            stage.set(WINDOWS_PARAM, windows)
+            self.assertEqual(windows, stage.get(WINDOWS_PARAM))
+
         stage.set(INT_ARRAY_PARAM, (50, 51))
         self.assertEqual((50, 51), stage.get(INT_ARRAY_PARAM))
 
@@ -139,6 +165,26 @@ class StageTest(PyFlinkMLTestCase):
 
         stage.set(STRING_ARRAY_PARAM, ("50", "51"))
         self.assertEqual(("50", "51"), stage.get(STRING_ARRAY_PARAM))
+
+    def test_save_load_windows_params(self):
+        stage = MyStage()
+        stage.set(PARAM_WITH_NONE_DEFAULT, 1)
+
+        windows_list = [
+            GlobalWindows(),
+            CountTumblingWindows.of(100),
+            EventTimeTumblingWindows.of(Time.milliseconds(100)),
+            ProcessingTimeTumblingWindows.of(Time.seconds(100)),
+            EventTimeSessionWindows.with_gap(Time.minutes(100)),
+            ProcessingTimeSessionWindows.with_gap(Time.hours(100))
+        ]
+
+        for windows in windows_list:
+            stage.set(WINDOWS_PARAM, windows)
+            path = os.path.join(self.temp_dir, "test_save_load_windows_params" + str(windows))
+            stage.save(path)
+            loaded_stage = MyStage.load(self.env, path)
+            self.assertEqual(windows, loaded_stage.get(WINDOWS_PARAM))
 
     def test_stage_save_load(self):
         stage = MyStage()
@@ -223,6 +269,7 @@ class MyStage(Stage):
         self._param_map[FLOAT_PARAM] = FLOAT_PARAM.default_value
         self._param_map[STRING_PARAM] = STRING_PARAM.default_value
         self._param_map[VECTOR_PARAM] = VECTOR_PARAM.default_value
+        self._param_map[WINDOWS_PARAM] = WINDOWS_PARAM.default_value
         self._param_map[INT_ARRAY_PARAM] = INT_ARRAY_PARAM.default_value
         self._param_map[FLOAT_ARRAY_PARAM] = FLOAT_ARRAY_PARAM.default_value
         self._param_map[STRING_ARRAY_PARAM] = STRING_ARRAY_PARAM.default_value

--- a/flink-ml-python/pyflink/ml/core/windows.py
+++ b/flink-ml-python/pyflink/ml/core/windows.py
@@ -1,0 +1,150 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from abc import ABC
+
+from pyflink.common.time import Time
+
+
+class Windows(ABC):
+    """
+    Windowing strategy that determines how to create mini-batches from input data.
+    """
+    pass
+
+
+class GlobalWindows(Windows):
+    """
+    A windowing strategy that groups all elements into a single global window.
+    This strategy assumes that the input strategy is bounded.
+    """
+
+    def __eq__(self, other):
+        return isinstance(other, GlobalWindows)
+
+
+class CountTumblingWindows(Windows):
+    """
+    A windowing strategy that groups elements into fixed-size windows based on
+    the count number of the elements. Windows do not overlap.
+    """
+
+    def __init__(self, size: int):
+        super().__init__()
+        self._size = size
+
+    @staticmethod
+    def of(size: int) -> 'CountTumblingWindows':
+        return CountTumblingWindows(size)
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    def __eq__(self, other):
+        return isinstance(other, CountTumblingWindows) and self._size == other._size
+
+
+class EventTimeTumblingWindows(Windows):
+    """
+    A windowing strategy that groups elements into fixed-size windows based on
+    the timestamp of the elements. Windows do not overlap.
+    """
+
+    def __init__(self, size: Time):
+        super().__init__()
+        self._size = size
+
+    @staticmethod
+    def of(size: Time) -> 'EventTimeTumblingWindows':
+        return EventTimeTumblingWindows(size)
+
+    @property
+    def size(self) -> Time:
+        return self._size
+
+    def __eq__(self, other):
+        return isinstance(other, EventTimeTumblingWindows) and self._size == other._size
+
+
+class ProcessingTimeTumblingWindows(Windows):
+    """
+    A windowing strategy that groups elements into fixed-size windows based on
+    the current system time of the machine the operation is running on. Windows
+    do not overlap.
+    """
+
+    def __init__(self, size: Time):
+        super().__init__()
+        self._size = size
+
+    @staticmethod
+    def of(size: Time) -> 'ProcessingTimeTumblingWindows':
+        return ProcessingTimeTumblingWindows(size)
+
+    @property
+    def size(self) -> Time:
+        return self._size
+
+    def __eq__(self, other):
+        return isinstance(other, ProcessingTimeTumblingWindows) and self._size == other._size
+
+
+class EventTimeSessionWindows(Windows):
+    """
+    A windowing strategy that groups elements into sessions based on the
+    timestamp of the elements. Windows do not overlap.
+    """
+
+    def __init__(self, gap: Time):
+        super().__init__()
+        self._gap = gap
+
+    @staticmethod
+    def with_gap(gap: Time) -> 'EventTimeSessionWindows':
+        return EventTimeSessionWindows(gap)
+
+    @property
+    def gap(self) -> Time:
+        return self._gap
+
+    def __eq__(self, other):
+        return isinstance(other, EventTimeSessionWindows) and self._gap == other._gap
+
+
+class ProcessingTimeSessionWindows(Windows):
+    """
+    A windowing strategy that groups elements into sessions based on the current
+    system time of the machine the operation is running on. Windows do
+    not overlap.
+    """
+
+    def __init__(self, gap: Time):
+        super().__init__()
+        self._gap = gap
+
+    @staticmethod
+    def with_gap(gap: Time) -> 'ProcessingTimeSessionWindows':
+        return ProcessingTimeSessionWindows(gap)
+
+    @property
+    def gap(self) -> Time:
+        return self._gap
+
+    def __eq__(self, other):
+        return isinstance(other, ProcessingTimeSessionWindows) and self._gap == other._gap

--- a/flink-ml-python/pyflink/ml/lib/clustering/agglomerativeclustering.py
+++ b/flink-ml-python/pyflink/ml/lib/clustering/agglomerativeclustering.py
@@ -21,14 +21,15 @@ from pyflink.ml.core.param import Param, StringParam, IntParam, FloatParam, \
     BooleanParam, ParamValidators
 from pyflink.ml.core.wrapper import JavaWithParams
 from pyflink.ml.lib.clustering.common import JavaClusteringAlgoOperator
-from pyflink.ml.lib.param import HasDistanceMeasure, HasFeaturesCol, HasPredictionCol
+from pyflink.ml.lib.param import HasDistanceMeasure, HasFeaturesCol, HasPredictionCol, HasWindows
 
 
 class _AgglomerativeClusteringParams(
     JavaWithParams,
     HasDistanceMeasure,
     HasFeaturesCol,
-    HasPredictionCol
+    HasPredictionCol,
+    HasWindows
 ):
     """
     Params for :class:`AgglomerativeClustering`.
@@ -112,16 +113,21 @@ class _AgglomerativeClusteringParams(
 class AgglomerativeClustering(JavaClusteringAlgoOperator, _AgglomerativeClusteringParams):
     """
     An AlgoOperator that performs a hierarchical clustering using a bottom-up approach. Each
-    observation starts in its own cluster and the clusters are merged together one by one.
-    Users can choose different strategies to merge two clusters by setting
-    {@link AgglomerativeClusteringParams#LINKAGE} and different distance measures by setting
-    {@link AgglomerativeClusteringParams#DISTANCE_MEASURE}.
+    observation starts in its own cluster and the clusters are merged together one by one. Users can
+    choose different strategies to merge two clusters by setting
+    AgglomerativeClusteringParams#LINKAGE and different distance measures by setting
+    AgglomerativeClusteringParams#DISTANCE_MEASURE.
 
-    <p>The output contains two tables. The first one assigns one cluster Id for each data point.
+    The output contains two tables. The first one assigns one cluster Id for each data point.
     The second one contains the information of merging two clusters at each step. The data format
     of the merging information is (clusterId1, clusterId2, distance, sizeOfMergedCluster).
 
-    <p>See https://en.wikipedia.org/wiki/Hierarchical_clustering.
+    This AlgoOperator splits input stream into mini-batches of elements according to the windowing
+    strategy specified by the HasWindows parameter, and performs the hierarchical clustering on each
+    mini-batch independently. The clustering result of each element depends only on the elements in
+    the same mini-batch.
+
+    See https://en.wikipedia.org/wiki/Hierarchical_clustering.
     """
 
     def __init__(self, java_algo_operator=None):

--- a/flink-ml-python/pyflink/ml/lib/param.py
+++ b/flink-ml-python/pyflink/ml/lib/param.py
@@ -19,7 +19,8 @@ from abc import ABC
 from typing import Tuple
 
 from pyflink.ml.core.param import WithParams, Param, ParamValidators, StringParam, IntParam, \
-    StringArrayParam, FloatParam
+    StringArrayParam, FloatParam, WindowsParam
+from pyflink.ml.core.windows import Windows, GlobalWindows
 
 
 class HasDistanceMeasure(WithParams, ABC):
@@ -513,3 +514,25 @@ class HasElasticNet(WithParams, ABC):
     @property
     def elastic_net(self):
         return self.get(self.ELASTIC_NET)
+
+
+class HasWindows(WithParams, ABC):
+    """
+    Base class for the shared windows param.
+    """
+    WINDOWS: Param[Windows] = WindowsParam(
+        "windows",
+        "Windowing strategy that determines how to create mini-batches from input data.",
+        GlobalWindows(),
+        ParamValidators.not_null())
+
+    def set_windows(self, value: Windows):
+        self.set(self.WINDOWS, value)
+        return self
+
+    def get_windows(self) -> Windows:
+        return self.get(self.WINDOWS)
+
+    @property
+    def windows(self):
+        return self.get(self.WINDOWS)


### PR DESCRIPTION
## What is the purpose of the change
This PR introduces the `Windows` interface and several implementations of this interface that can be used to slice input streams into finite batches and fed them into Flink ML stages. On the basis of these changes, this PR adds a `windows` parameter to AgglomerativeClustering so that it can work on unbounded input streams.

## Brief change log
- Add `Windows` interface and its subclasses, `Count/EventTime/ProcessingTime + Tumbling/Session + Windows`.
- Add `windows` parameter on AgglomerativeClustering and make it able to deal with the infinite input stream.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (Java doc)