### PR TITLE
[FLINK-29824] Stop clustering when size of the active clusters is one

### DIFF
--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/agglomerativeclustering/AgglomerativeClustering.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/agglomerativeclustering/AgglomerativeClustering.java
@@ -258,12 +258,12 @@ public class AgglomerativeClustering
         private void doClustering(
                 List<Cluster> activeClusters,
                 ProcessAllWindowFunction<Row, Row, ?>.Context context) {
-            int clusterOffset1 = -1, clusterOffset2 = -1;
             boolean clusteringRunning =
                     (numCluster != null && activeClusters.size() > numCluster)
                             || (distanceThreshold != null);
 
             while (clusteringRunning || (computeFullTree && activeClusters.size() > 1)) {
+                int clusterOffset1 = -1, clusterOffset2 = -1;
                 // Computes the distance between two clusters.
                 double minDistance = Double.MAX_VALUE;
                 for (int i = 0; i < activeClusters.size(); i++) {
@@ -309,7 +309,9 @@ public class AgglomerativeClustering
 
                 clusteringRunning =
                         (numCluster != null && activeClusters.size() > numCluster)
-                                || (distanceThreshold != null && distanceThreshold > minDistance);
+                                || (distanceThreshold != null
+                                        && distanceThreshold > minDistance
+                                        && activeClusters.size() > 1);
             }
         }
 

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/AgglomerativeClusteringTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/AgglomerativeClusteringTest.java
@@ -240,6 +240,23 @@ public class AgglomerativeClusteringTest extends AbstractTestBase {
     }
 
     @Test
+    public void testLargeDistanceThreshold() throws Exception {
+        AgglomerativeClustering agglomerativeClustering =
+                new AgglomerativeClustering()
+                        .setNumClusters(null)
+                        .setDistanceThreshold(Double.MAX_VALUE);
+        Table output = agglomerativeClustering.transform(inputDataTable)[0];
+        HashSet<Integer> clusterIds = new HashSet<>();
+        tEnv.toDataStream(output)
+                .executeAndCollect()
+                .forEachRemaining(
+                        x ->
+                                clusterIds.add(
+                                        x.getFieldAs(agglomerativeClustering.getPredictionCol())));
+        assertEquals(1, clusterIds.size());
+    }
+
+    @Test
     public void testTransformWithCountTumblingWindows() throws Exception {
         env.setParallelism(1);
 


### PR DESCRIPTION
## What is the purpose of the change

Fix the bug in AgglomerativeClustering that we did not stop the clustering process when the size of the active clusters is already one.

## Brief change log

  - Stops the clustering process when size of the active clusters is one
  - Add unit test to cover the bug.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
