### PR TITLE
[FLINK-29843] Avoid negative euclidean distance square

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/distance/EuclideanDistanceMeasure.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/distance/EuclideanDistanceMeasure.java
@@ -39,7 +39,14 @@ public class EuclideanDistanceMeasure implements DistanceMeasure {
     }
 
     private double distanceSquare(VectorWithNorm v1, VectorWithNorm v2) {
-        return v1.l2Norm * v1.l2Norm + v2.l2Norm * v2.l2Norm - 2.0 * BLAS.dot(v1.vector, v2.vector);
+        // Computing the distance square between two vectors that are close enough might result in
+        // a negative value, due to the loss of data accuracy. A Math.max helps to guarantee that
+        // a non-negative value is returned.
+        return Math.max(
+                0.0,
+                v1.l2Norm * v1.l2Norm
+                        + v2.l2Norm * v2.l2Norm
+                        - 2.0 * BLAS.dot(v1.vector, v2.vector));
     }
 
     @Override

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/common/distance/DistanceMeasureTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/common/distance/DistanceMeasureTest.java
@@ -55,6 +55,13 @@ public class DistanceMeasureTest {
     }
 
     @Test
+    public void testEuclideanOfIdenticalVectors() {
+        VectorWithNorm vector = new VectorWithNorm(Vectors.dense(3.0, 3.0));
+        DistanceMeasure distanceMeasure = EuclideanDistanceMeasure.getInstance();
+        assertEquals(0, distanceMeasure.distance(vector, vector));
+    }
+
+    @Test
     public void testManhattan() {
         DistanceMeasure distanceMeasure = ManhattanDistanceMeasure.getInstance();
         assertEquals(


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the bug that `EuclideanDistanceMeasure.distanceSquare(...)` method might return negative values due to loss of data accuracy.

## Brief change log

  - Fixes the bug by setting distance square as `Math.max(0, norm1 * norm1 + norm2 * norm2 - 2 * vec1 \dot vec2) `
  - Adds corresponding test cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
