### PR TITLE
[FLINK-30099] Add test case for algorithms' python APIs

### DIFF
--- a/flink-ml-python/pyflink/ml/lib/classification/tests/test_knn.py
+++ b/flink-ml-python/pyflink/ml/lib/classification/tests/test_knn.py
@@ -21,7 +21,7 @@ from pyflink.common import Types
 from pyflink.table import Table
 
 from pyflink.ml.core.linalg import Vectors, DenseVectorTypeInfo, DenseMatrix, DenseVector
-from pyflink.ml.lib.classification.knn import KNN
+from pyflink.ml.lib.classification.knn import KNN, KNNModel
 from pyflink.ml.tests.test_utils import PyFlinkMLTestCase
 
 
@@ -156,6 +156,19 @@ class KNNTest(PyFlinkMLTestCase):
         self.assertEqual(2, packed_features.num_rows())
         self.assertEqual(packed_features.num_cols(), labels.size())
         self.assertEqual(feature_norm_squares.size(), labels.size())
+
+    def test_set_model_data(self):
+        knn = KNN()
+        model_a = knn.fit(self.train_data)
+        model_data = model_a.get_model_data()[0]
+
+        model_b = KNNModel().set_model_data(model_data)
+        output = model_b.transform(self.predict_data)[0]
+        field_names = output.get_schema().get_field_names()
+        self.verify_predict_result(
+            output,
+            field_names.index(knn.label_col),
+            field_names.index(knn.prediction_col))
 
     def verify_predict_result(
             self, output: Table, label_index, prediction_index):

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_idf.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_idf.py
@@ -22,7 +22,7 @@ from pyflink.common import Types
 
 from pyflink.ml.core.linalg import Vectors, DenseVectorTypeInfo
 from pyflink.ml.lib.feature.idf import IDF, IDFModel
-from pyflink.ml.tests.test_utils import PyFlinkMLTestCase
+from pyflink.ml.tests.test_utils import PyFlinkMLTestCase, update_existing_params
 
 
 class IDFTest(PyFlinkMLTestCase):
@@ -111,6 +111,27 @@ class IDFTest(PyFlinkMLTestCase):
         idf.set_min_doc_freq(2)
         output = idf.fit(self.input_data).transform(self.input_data)[0]
         self.verify_prediction_result(self.expected_output_min_doc_freq_as_two, output)
+
+    def test_get_model_data(self):
+        idf = IDF()
+        model = idf.fit(self.input_data)
+        model_data = model.get_model_data()[0]
+        expected_field_names = ['idf', 'docFreq', 'numDocs']
+        self.assertEqual(expected_field_names, model_data.get_schema().get_field_names())
+
+        # TODO: Add test to collect and verify the model data results after Flink dependency
+        #  is upgraded to 1.15.3, 1.16.0 or a higher version. Related ticket: FLINK-29477
+
+    def test_set_model_data(self):
+        idf = IDF()
+        model_a = idf.fit(self.input_data)
+        model_data = model_a.get_model_data()[0]
+
+        model_b = IDFModel().set_model_data(model_data)
+        update_existing_params(model_b, model_a)
+
+        output = model_b.transform(self.input_data)[0]
+        self.verify_prediction_result(self.expected_output, output)
 
     def test_save_load_predict(self):
         idf = IDF()

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_indextostringmodel.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_indextostringmodel.py
@@ -75,3 +75,31 @@ class IndexToStringModelTest(PyFlinkMLTestCase):
         predicted_results.sort(key=lambda x: x[0])
 
         self.assertEqual(predicted_results, self.expected_prediction)
+
+    def test_get_model_data(self):
+        model = IndexToStringModel() \
+            .set_input_cols('input_col1', 'input_col2') \
+            .set_output_cols('output_col1', 'output_col2') \
+            .set_model_data(self.model_data_table)
+        model_data = model.get_model_data()[0]
+        expected_field_names = ['stringArrays']
+        self.assertEqual(expected_field_names, model_data.get_schema().get_field_names())
+
+        # TODO: Add test to collect and verify the model data results after FLINK-30122 is resolved.
+
+    def test_save_load_and_predict(self):
+        model = IndexToStringModel() \
+            .set_input_cols('input_col1', 'input_col2') \
+            .set_output_cols('output_col1', 'output_col2') \
+            .set_model_data(self.model_data_table)
+
+        reloaded_model = self.save_and_reload(model)
+
+        output = reloaded_model.transform(self.predict_table)[0]
+
+        predicted_results = [result for result in
+                             self.t_env.to_data_stream(output).execute_and_collect()]
+
+        predicted_results.sort(key=lambda x: x[0])
+
+        self.assertEqual(predicted_results, self.expected_prediction)

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_stringindexer.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_stringindexer.py
@@ -18,8 +18,8 @@
 
 from pyflink.common import Types, Row
 
-from pyflink.ml.lib.feature.stringindexer import StringIndexer
-from pyflink.ml.tests.test_utils import PyFlinkMLTestCase
+from pyflink.ml.lib.feature.stringindexer import StringIndexer, StringIndexerModel
+from pyflink.ml.tests.test_utils import PyFlinkMLTestCase, update_existing_params
 
 
 class StringIndexerTest(PyFlinkMLTestCase):
@@ -117,4 +117,54 @@ class StringIndexerTest(PyFlinkMLTestCase):
 
         predicted_results.sort(key=lambda x: x[0])
 
+        self.assertEqual(predicted_results, self.expected_alphabetic_asc_predict_data)
+
+    def test_get_model_data(self):
+        string_indexer = StringIndexer() \
+            .set_input_cols('input_col1', 'input_col2') \
+            .set_output_cols('output_col1', 'output_col2') \
+            .set_string_order_type('alphabetAsc')
+        model = string_indexer.fit(self.train_table)
+        model_data = model.get_model_data()[0]
+        expected_field_names = ['stringArrays']
+        self.assertEqual(expected_field_names, model_data.get_schema().get_field_names())
+
+        # TODO: Add test to collect and verify the model data results after FLINK-30122 is resolved.
+
+    def test_set_model_data(self):
+        string_indexer = StringIndexer() \
+            .set_input_cols('input_col1', 'input_col2') \
+            .set_output_cols('output_col1', 'output_col2') \
+            .set_string_order_type('alphabetAsc') \
+            .set_handle_invalid('keep')
+        model_a = string_indexer.fit(self.train_table)
+        model_data = model_a.get_model_data()[0]
+
+        model_b = StringIndexerModel().set_model_data(model_data)
+        update_existing_params(model_b, model_a)
+
+        output = model_b.transform(self.predict_table)[0]
+
+        predicted_results = [result for result in
+                             self.t_env.to_data_stream(output).execute_and_collect()]
+
+        predicted_results.sort(key=lambda x: x[0])
+
+        self.assertEqual(predicted_results, self.expected_alphabetic_asc_predict_data)
+
+    def test_save_load_and_predict(self):
+        string_indexer = StringIndexer() \
+            .set_input_cols('input_col1', 'input_col2') \
+            .set_output_cols('output_col1', 'output_col2') \
+            .set_string_order_type('alphabetAsc') \
+            .set_handle_invalid('keep')
+        reloaded_string_indexer = self.save_and_reload(string_indexer)
+
+        model = reloaded_string_indexer.fit(self.train_table)
+        reloaded_model = self.save_and_reload(model)
+
+        output = reloaded_model.transform(self.predict_table)[0]
+        predicted_results = [result for result in
+                             self.t_env.to_data_stream(output).execute_and_collect()]
+        predicted_results.sort(key=lambda x: x[0])
         self.assertEqual(predicted_results, self.expected_alphabetic_asc_predict_data)

--- a/flink-ml-python/pyflink/ml/tests/test_utils.py
+++ b/flink-ml-python/pyflink/ml/tests/test_utils.py
@@ -24,8 +24,16 @@ import uuid
 
 from pyflink.common import RestartStrategies, Configuration
 from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.java_gateway import get_gateway
 from pyflink.table import StreamTableEnvironment
 from pyflink.util.java_utils import get_j_env_configuration
+
+from pyflink.ml.core.wrapper import JavaWithParams
+
+
+def update_existing_params(target: JavaWithParams, source: JavaWithParams):
+    get_gateway().jvm.org.apache.flink.ml.util.ReadWriteUtils \
+        .updateExistingParams(target._java_obj, source._java_obj.getParamMap())
 
 
 class PyFlinkMLTestCase(unittest.TestCase):
@@ -84,3 +92,10 @@ class PyFlinkMLTestCase(unittest.TestCase):
                 raise e
         load_func = getattr(stage, 'load')
         return load_func(self.t_env, path)
+
+    def assertListAlmostEqual(self, expected_list, actual_list, places=None, msg=None,
+                              delta=None):
+        self.assertEqual(len(expected_list), len(actual_list))
+        for i in range(len(expected_list)):
+            self.assertAlmostEqual(expected_list[i], actual_list[i],
+                                   places=places, msg=msg, delta=delta)


### PR DESCRIPTION
## What is the purpose of the change

This PR adds python tests for the public APIs of Flink ML algorithms.

## Brief change log

Adds test cases for the following APIs for all existing offline algorithms in Flink ML. The tests added in this PR are as follows.

| Name of Algorithm         | setModelData() | getModelData()  | Save/load |
| ------------------------- | -------------- | --------------- | --------- |
| KNN                       | O              | O               | --        |
| LinearSVC                 | O              | O               | O         |
| LogisticRegression        | --             | --              | --        |
| NaiveBayes                | O              | X (FLINK-30124) | --        |
| AgglomerativeClustering   | -              | -               | --        |
| KMeans                    | O              | X (FLINK-30122) | --        |
| BinaryClassification      | -              | -               | --        |
| Binarizer                 | -              | -               | --        |
| Bucketizer                | -              | -               | --        |
| DCT                       | -              | -               | --        |
| ELementWiseProduct        | -              | -               | --        |
| FeatureHasher             | -              | -               | --        |
| HashingTF                 | -              | -               | --        |
| IDF                       | O              | X (FLINK-29477) | --        |
| Imputer                   | O              | X (FLINK-30124) | --        |
| Interaction               | -              | -               | --        |
| KbinsDiscretizer          | O              | X (FLINK-30122) | --        |
| MaxAbsScaler              | O              | O               | O         |
| MinMaxScaler              | O              | O               | O         |
| NGram                     | -              | -               | --        |
| Normalizer                | -              | -               | --        |
| OneHotEncoder             | O              | O               | O         |
| PolynomialExpansion       | -              | -               | --        |
| RandomSplitter            | -              | -               | --        |
| RegexTokenizer            | -              | -               | --        |
| RobustScaler              | O              | O               | --        |
| StandardScaler            | O              | O               | O         |
| StringIndexer             | O              | X (FLINK-30122) | O         |
| IndexToStringModel        | -              | X (FLINK-30122) | O         |
| Tokenizer                 | -              | -               | --        |
| VarianceThresholdSelector | O              | X (FLINK-29477) | --        |
| VectorAssembler           | -              | -               | --        |
| VectorIndexer             | O              | X (FLINK-30124) | --        |
| VectorSlicer              | -              | -               | --        |
| LinearRegression          | --             | --              | --        |
| ChiSqTest                 | -              | -               | --        |

The marks in the table above have the following meanings:

- `-`: The algorithm does not need to test this API. For example, a `Transformer` or `AlgoOperator` do not need to test `getModelData()` and `setModelData()`.
- `--`: The algorithm needs to test this API, and the test has already been added in previous commits.
- `O`: The algorithm needs to test this API, and the test is added in this PR.
- `X`: The algorithm needs to test this API, but this API fails with an exception. The exceptions have all been recorded by Jira tickets as in the parentheses.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)