### PR TITLE
[FLINK-30124] Support collecting model data with arrays and maps

### DIFF
--- a/flink-ml-dist/pom.xml
+++ b/flink-ml-dist/pom.xml
@@ -46,6 +46,12 @@ under the License.
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-ml-python</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Stateful Functions Dependencies -->
 
         <dependency>

--- a/flink-ml-dist/src/main/assemblies/bin.xml
+++ b/flink-ml-dist/src/main/assemblies/bin.xml
@@ -37,6 +37,7 @@ under the License.
                 <include>org.apache.flink:statefun-flink-core</include>
                 <include>org.apache.flink:flink-ml-uber</include>
                 <include>org.apache.flink:flink-ml-examples</include>
+                <include>org.apache.flink:flink-ml-python</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/imputer/Imputer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/imputer/Imputer.java
@@ -27,6 +27,8 @@ import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableImpl;
@@ -90,7 +92,13 @@ public class Imputer implements Estimator<Imputer, ImputerModel>, ImputerParams<
             default:
                 throw new RuntimeException("Unsupported strategy of Imputer: " + getStrategy());
         }
-        ImputerModel model = new ImputerModel().setModelData(tEnv.fromDataStream(modelData));
+
+        Schema schema =
+                Schema.newBuilder()
+                        .column("surrogates", DataTypes.MAP(DataTypes.STRING(), DataTypes.DOUBLE()))
+                        .build();
+        ImputerModel model =
+                new ImputerModel().setModelData(tEnv.fromDataStream(modelData, schema));
         ReadWriteUtils.updateExistingParams(model, getParamMap());
         return model;
     }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorindexer/VectorIndexer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorindexer/VectorIndexer.java
@@ -39,6 +39,8 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableImpl;
@@ -117,8 +119,17 @@ public class VectorIndexer
                 distinctDoubles.map(new ModelGenerator(maxCategories));
         modelData.getTransformation().setParallelism(1);
 
+        Schema schema =
+                Schema.newBuilder()
+                        .column(
+                                "categoryMaps",
+                                DataTypes.MAP(
+                                        DataTypes.INT(),
+                                        DataTypes.MAP(DataTypes.DOUBLE(), DataTypes.INT())))
+                        .build();
+
         VectorIndexerModel model =
-                new VectorIndexerModel().setModelData(tEnv.fromDataStream(modelData));
+                new VectorIndexerModel().setModelData(tEnv.fromDataStream(modelData, schema));
         ReadWriteUtils.updateExistingParams(model, paramMap);
         return model;
     }

--- a/flink-ml-python/pom.xml
+++ b/flink-ml-python/pom.xml
@@ -32,6 +32,20 @@ under the License.
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-python_2.12</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
             <artifactId>flink-runtime</artifactId>
             <version>${flink.version}</version>
             <type>test-jar</type>

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_idf.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_idf.py
@@ -119,8 +119,15 @@ class IDFTest(PyFlinkMLTestCase):
         expected_field_names = ['idf', 'docFreq', 'numDocs']
         self.assertEqual(expected_field_names, model_data.get_schema().get_field_names())
 
-        # TODO: Add test to collect and verify the model data results after Flink dependency
-        #  is upgraded to 1.15.3, 1.16.0 or a higher version. Related ticket: FLINK-29477
+        model_rows = [result for result in
+                      self.t_env.to_data_stream(model_data).execute_and_collect()]
+        self.assertEqual(1, len(model_rows))
+        self.assertEqual(3, model_rows[0][expected_field_names.index('numDocs')])
+        self.assertListEqual([0, 3, 1, 2], model_rows[0][expected_field_names.index('docFreq')])
+        self.assertListAlmostEqual(
+            [1.3862943, 0, 0.6931471, 0.2876820],
+            model_rows[0][expected_field_names.index('idf')].to_array(),
+            delta=self.tolerance)
 
     def test_set_model_data(self):
         idf = IDF()

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_imputer.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_imputer.py
@@ -69,6 +69,7 @@ class ImputerTest(PyFlinkMLTestCase):
             'median': self.expected_median_strategy_output,
             'most_frequent': self.expected_most_frequent_strategy_output
         }
+        self.eps = 1e-5
 
     def test_param(self):
         imputer = Imputer().\
@@ -116,7 +117,13 @@ class ImputerTest(PyFlinkMLTestCase):
         expected_field_names = ['surrogates']
         self.assertEqual(expected_field_names, model_data.get_schema().get_field_names())
 
-        # TODO: Add test to collect and verify the model data results after FLINK-30124 is resolved.
+        model_rows = [result for result in
+                      self.t_env.to_data_stream(model_data).execute_and_collect()]
+        self.assertEqual(1, len(model_rows))
+        surrogates = model_rows[0][expected_field_names.index('surrogates')]
+        self.assertAlmostEqual(2.0, surrogates['f1'], delta=self.eps)
+        self.assertAlmostEqual(6.8, surrogates['f2'], delta=self.eps)
+        self.assertAlmostEqual(2.0, surrogates['f3'], delta=self.eps)
 
     def test_set_model_data(self):
         imputer = Imputer().\

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_indextostringmodel.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_indextostringmodel.py
@@ -85,7 +85,12 @@ class IndexToStringModelTest(PyFlinkMLTestCase):
         expected_field_names = ['stringArrays']
         self.assertEqual(expected_field_names, model_data.get_schema().get_field_names())
 
-        # TODO: Add test to collect and verify the model data results after FLINK-30122 is resolved.
+        model_rows = [result for result in
+                      self.t_env.to_data_stream(model_data).execute_and_collect()]
+        self.assertEqual(1, len(model_rows))
+        string_arrays = model_rows[0][expected_field_names.index('stringArrays')]
+        self.assertListEqual(["a", "b", "c", "d"], string_arrays[0])
+        self.assertListEqual(["-1.0", "0.0", "1.0", "2.0"], string_arrays[1])
 
     def test_save_load_and_predict(self):
         model = IndexToStringModel() \

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_stringindexer.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_stringindexer.py
@@ -129,7 +129,12 @@ class StringIndexerTest(PyFlinkMLTestCase):
         expected_field_names = ['stringArrays']
         self.assertEqual(expected_field_names, model_data.get_schema().get_field_names())
 
-        # TODO: Add test to collect and verify the model data results after FLINK-30122 is resolved.
+        model_rows = [result for result in
+                      self.t_env.to_data_stream(model_data).execute_and_collect()]
+        self.assertEqual(1, len(model_rows))
+        string_arrays = model_rows[0][expected_field_names.index('stringArrays')]
+        self.assertListEqual(["a", "b", "c", "d"], string_arrays[0])
+        self.assertListEqual(["-1.0", "0.0", "1.0", "2.0"], string_arrays[1])
 
     def test_set_model_data(self):
         string_indexer = StringIndexer() \

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_variancethresholdselector.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_variancethresholdselector.py
@@ -121,8 +121,11 @@ class VarianceThresholdSelectorTest(PyFlinkMLTestCase):
         expected_field_names = ['numOfFeatures', 'indices']
         self.assertEqual(expected_field_names, model_data.get_schema().get_field_names())
 
-        # TODO: Add test to collect and verify the model data results after Flink dependency
-        #  is upgraded to 1.15.3, 1.16.0 or a higher version. Related ticket: FLINK-29477
+        model_rows = [result for result in
+                      self.t_env.to_data_stream(model_data).execute_and_collect()]
+        self.assertEqual(1, len(model_rows))
+        self.assertEqual(6, model_rows[0][expected_field_names.index('numOfFeatures')])
+        self.assertListEqual([0, 3, 5], model_rows[0][expected_field_names.index('indices')])
 
     def test_set_model_data(self):
         variance_threshold_selector = VarianceThresholdSelector() \

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_vectorindexer.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_vectorindexer.py
@@ -103,13 +103,17 @@ class VectorIndexerTest(PyFlinkMLTestCase):
         self.assertEqual(self.expected_output, predicted_results)
 
     def test_get_model_data(self):
-        vector_indexer = VectorIndexer().set_handle_invalid('keep')
+        vector_indexer = VectorIndexer().set_max_categories(3)
         model = vector_indexer.fit(self.train_table)
         model_data = model.get_model_data()[0]
         expected_field_names = ['categoryMaps']
         self.assertEqual(expected_field_names, model_data.get_schema().get_field_names())
 
-        # TODO: Add test to collect and verify the model data results after FLINK-30124 is resolved.
+        model_rows = [result for result in
+                      self.t_env.to_data_stream(model_data).execute_and_collect()]
+        self.assertEqual(1, len(model_rows))
+        self.assertEqual(
+            {1: {-1.: 1, 0.: 0, 1.: 2}}, model_rows[0][expected_field_names.index('categoryMaps')])
 
     def test_set_model_data(self):
         vector_indexer = VectorIndexer().set_handle_invalid('keep')

--- a/flink-ml-python/src/main/java/org/apache/flink/ml/python/PythonBridgeUtils.java
+++ b/flink-ml-python/src/main/java/org/apache/flink/ml/python/PythonBridgeUtils.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.python;
+
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.typeutils.ListTypeInfo;
+import org.apache.flink.api.java.typeutils.MapTypeInfo;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfoBase;
+import org.apache.flink.api.python.shaded.net.razorvine.pickle.Pickler;
+import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.sql.Date;
+import java.sql.Time;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.FLOAT_TYPE_INFO;
+import static org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.DATE;
+import static org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIME;
+
+/**
+ * Utility functions used to override PyFlink methods to provide a temporary solution for certain
+ * bugs.
+ */
+// TODO: Remove this class after Flink ML depends on a Flink version with FLINK-30168 and
+// FLINK-29477 fixed.
+public class PythonBridgeUtils {
+    public static Object getPickledBytesFromJavaObject(Object obj, TypeInformation<?> dataType)
+            throws IOException {
+        Pickler pickler = new Pickler();
+
+        // triggers the initialization process
+        org.apache.flink.api.common.python.PythonBridgeUtils.getPickledBytesFromJavaObject(
+                null, null);
+
+        if (obj == null) {
+            return new byte[0];
+        } else {
+            if (dataType instanceof SqlTimeTypeInfo) {
+                SqlTimeTypeInfo<?> sqlTimeTypeInfo =
+                        SqlTimeTypeInfo.getInfoFor(dataType.getTypeClass());
+                if (sqlTimeTypeInfo == DATE) {
+                    return pickler.dumps(((Date) obj).toLocalDate().toEpochDay());
+                } else if (sqlTimeTypeInfo == TIME) {
+                    return pickler.dumps(((Time) obj).toLocalTime().toNanoOfDay() / 1000);
+                }
+            } else if (dataType instanceof RowTypeInfo || dataType instanceof TupleTypeInfo) {
+                TypeInformation<?>[] fieldTypes = ((TupleTypeInfoBase<?>) dataType).getFieldTypes();
+                int arity =
+                        dataType instanceof RowTypeInfo
+                                ? ((Row) obj).getArity()
+                                : ((Tuple) obj).getArity();
+
+                List<Object> fieldBytes = new ArrayList<>(arity + 1);
+                if (dataType instanceof RowTypeInfo) {
+                    fieldBytes.add(new byte[] {((Row) obj).getKind().toByteValue()});
+                }
+                for (int i = 0; i < arity; i++) {
+                    Object field =
+                            dataType instanceof RowTypeInfo
+                                    ? ((Row) obj).getField(i)
+                                    : ((Tuple) obj).getField(i);
+                    fieldBytes.add(getPickledBytesFromJavaObject(field, fieldTypes[i]));
+                }
+                return fieldBytes;
+            } else if (dataType instanceof BasicArrayTypeInfo
+                    || dataType instanceof PrimitiveArrayTypeInfo
+                    || dataType instanceof ObjectArrayTypeInfo) {
+                Object[] objects;
+                TypeInformation<?> elementType;
+                if (dataType instanceof BasicArrayTypeInfo) {
+                    objects = (Object[]) obj;
+                    elementType = ((BasicArrayTypeInfo<?, ?>) dataType).getComponentInfo();
+                } else if (dataType instanceof PrimitiveArrayTypeInfo) {
+                    objects = primitiveArrayConverter(obj, dataType);
+                    elementType = ((PrimitiveArrayTypeInfo<?>) dataType).getComponentType();
+                } else {
+                    objects = (Object[]) obj;
+                    elementType = ((ObjectArrayTypeInfo<?, ?>) dataType).getComponentInfo();
+                }
+
+                List<Object> serializedElements = new ArrayList<>(objects.length);
+
+                for (Object object : objects) {
+                    serializedElements.add(getPickledBytesFromJavaObject(object, elementType));
+                }
+                return pickler.dumps(serializedElements);
+            } else if (dataType instanceof MapTypeInfo) {
+                List<List<Object>> serializedMapKV = new ArrayList<>(2);
+                Map<Object, Object> mapObj = (Map) obj;
+                List<Object> keyBytesList = new ArrayList<>(mapObj.size());
+                List<Object> valueBytesList = new ArrayList<>(mapObj.size());
+                for (Map.Entry entry : mapObj.entrySet()) {
+                    keyBytesList.add(
+                            getPickledBytesFromJavaObject(
+                                    entry.getKey(), ((MapTypeInfo) dataType).getKeyTypeInfo()));
+                    valueBytesList.add(
+                            getPickledBytesFromJavaObject(
+                                    entry.getValue(), ((MapTypeInfo) dataType).getValueTypeInfo()));
+                }
+                serializedMapKV.add(keyBytesList);
+                serializedMapKV.add(valueBytesList);
+                return pickler.dumps(serializedMapKV);
+            } else if (dataType instanceof ListTypeInfo) {
+                List objects = (List) obj;
+                List<Object> serializedElements = new ArrayList<>(objects.size());
+                TypeInformation elementType = ((ListTypeInfo) dataType).getElementTypeInfo();
+                for (Object object : objects) {
+                    serializedElements.add(getPickledBytesFromJavaObject(object, elementType));
+                }
+                return pickler.dumps(serializedElements);
+            }
+            if (dataType instanceof BasicTypeInfo
+                    && BasicTypeInfo.getInfoFor(dataType.getTypeClass()) == FLOAT_TYPE_INFO) {
+                // Serialization of float type with pickler loses precision.
+                return pickler.dumps(String.valueOf(obj));
+            } else if (dataType instanceof PickledByteArrayTypeInfo
+                    || dataType instanceof BasicTypeInfo) {
+                return pickler.dumps(obj);
+            } else {
+                // other typeinfos will use the corresponding serializer to serialize data.
+                TypeSerializer serializer = dataType.createSerializer(null);
+                ByteArrayOutputStreamWithPos baos = new ByteArrayOutputStreamWithPos();
+                DataOutputViewStreamWrapper baosWrapper = new DataOutputViewStreamWrapper(baos);
+                serializer.serialize(obj, baosWrapper);
+                return pickler.dumps(baos.toByteArray());
+            }
+        }
+    }
+
+    private static Object[] primitiveArrayConverter(
+            Object array, TypeInformation<?> arrayTypeInfo) {
+        Preconditions.checkArgument(arrayTypeInfo instanceof PrimitiveArrayTypeInfo);
+        Preconditions.checkArgument(array.getClass().isArray());
+        Object[] objects;
+        if (PrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO.equals(arrayTypeInfo)) {
+            boolean[] booleans = (boolean[]) array;
+            objects = new Object[booleans.length];
+            for (int i = 0; i < booleans.length; i++) {
+                objects[i] = booleans[i];
+            }
+        } else if (PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO.equals(arrayTypeInfo)) {
+            byte[] bytes = (byte[]) array;
+            objects = new Object[bytes.length];
+            for (int i = 0; i < bytes.length; i++) {
+                objects[i] = bytes[i];
+            }
+        } else if (PrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO.equals(arrayTypeInfo)) {
+            short[] shorts = (short[]) array;
+            objects = new Object[shorts.length];
+            for (int i = 0; i < shorts.length; i++) {
+                objects[i] = shorts[i];
+            }
+        } else if (PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO.equals(arrayTypeInfo)) {
+            int[] ints = (int[]) array;
+            objects = new Object[ints.length];
+            for (int i = 0; i < ints.length; i++) {
+                objects[i] = ints[i];
+            }
+        } else if (PrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO.equals(arrayTypeInfo)) {
+            long[] longs = (long[]) array;
+            objects = new Object[longs.length];
+            for (int i = 0; i < longs.length; i++) {
+                objects[i] = longs[i];
+            }
+        } else if (PrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO.equals(arrayTypeInfo)) {
+            float[] floats = (float[]) array;
+            objects = new Object[floats.length];
+            for (int i = 0; i < floats.length; i++) {
+                objects[i] = floats[i];
+            }
+        } else if (PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO.equals(arrayTypeInfo)) {
+            double[] doubles = (double[]) array;
+            objects = new Object[doubles.length];
+            for (int i = 0; i < doubles.length; i++) {
+                objects[i] = doubles[i];
+            }
+        } else if (PrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO.equals(arrayTypeInfo)) {
+            char[] chars = (char[]) array;
+            objects = new Object[chars.length];
+            for (int i = 0; i < chars.length; i++) {
+                objects[i] = chars[i];
+            }
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Primitive array of %s is not supported in PyFlink yet",
+                            ((PrimitiveArrayTypeInfo<?>) arrayTypeInfo)
+                                    .getComponentType()
+                                    .getTypeClass()
+                                    .getSimpleName()));
+        }
+        return objects;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request provides solutions for FLINK-30124 and FLINK-30122 and temporary walkrounds for FLINK-29477 and FLINK-30168。

## Brief change log

- Adds `flink-ml-python` module, overriding certain methods in `org.apache.flink.api.common.python.PythonBridgeUtils` to provide proper support for records of object arrays and primitive arrays.
- Modifies the schema of the model data table of `NaiveBayes`, `Imputer,` and `VectorIndexer` from `GenericTypeInfo<java.util.Map>` to `MapTypeInfo`.
- Add Python tests for the getModelData() method of the algorithms affected by these problems.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

