### PR TITLE
[hotfix] Update python tests to set execution.attached=True

### DIFF
--- a/flink-ml-python/pyflink/ml/tests/test_utils.py
+++ b/flink-ml-python/pyflink/ml/tests/test_utils.py
@@ -44,6 +44,7 @@ class PyFlinkMLTestCase(unittest.TestCase):
         config = Configuration(
             j_configuration=get_j_env_configuration(self.env._j_stream_execution_environment))
         config.set_boolean("execution.checkpointing.checkpoints-after-tasks-finish.enabled", True)
+        config.set_boolean("execution.attached", True)
 
         self.env.set_parallelism(4)
         self.env.enable_checkpointing(100)


### PR DESCRIPTION
## What is the purpose of the change

All python tests are currently run with execution.attached=false by default. Thus `env.execute()` can return the `JobExecutionResult` before the execution finishes. 

This breaks that tests such as `RobustScalerTest::test_save_load_predict()`, as the test will attempt to load model data from files before the data has been fully written to the files by the previous Flink job.

This PR fixes the issue described above by setting execution.attached=true for all python tests so that `env.execute()` will only return after the job finishes.

A followup PR is needed to set execution.attached=true for all Java tests.

## Brief change log

Updates `PyFlinkMLTestCase` to configure StreamExecutionEnvironment with execution.attached=True.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
