### PR TITLE
[FLINK-30037] Use shared mini-cluster in python tests

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   tests:
-    name: python tests on ${{ matrix.os }}
+    name: python ${{ matrix.python-version }} tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/flink-ml-python/pom.xml
+++ b/flink-ml-python/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flink-ml-parent</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>2.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flink-ml-python</artifactId>
+
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.flink</groupId>
+                                    <artifactId>flink-runtime</artifactId>
+                                    <!-- Don't use test-jar type because of a bug in the plugin (MDEP-587). -->
+                                    <classifier>tests</classifier>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.flink</groupId>
+                                    <artifactId>flink-test-utils</artifactId>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/test-dependencies</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>junit</includeGroupIds>
+                            <outputDirectory>${project.build.directory}/test-dependencies</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@ under the License.
     <module>flink-ml-benchmark</module>
     <module>flink-ml-dist</module>
     <module>flink-ml-examples</module>
+    <module>flink-ml-python</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
## What is the purpose of the change

This pull request optimizes the efficiency of Flink ML python tests by enabling the use of shared mini cluster in python tests. The using of shared mini cluster is implemented in reference to https://github.com/apache/flink/pull/20685.

### Performance comparison

Before optimization: https://github.com/apache/flink-ml/actions/runs/3569792445

| Name of test                  | Duration |
| ----------------------------- | -------- |
| Python tests on macOS-latest  | 27m11s   |
| Python tests on macOS-latest  | 1h13m    |
| Python tests on macOS-latest  | 37m21s   |
| Python tests on ubuntu-latest | 19m9s    |
| Python tests on ubuntu-latest | 27m37s   |
| Python tests on ubuntu-latest | 33m45s   |

After optimization: https://github.com/apache/flink-ml/actions/runs/3571587319

| Name of test                      | Duration |
| --------------------------------- | -------- |
| Python 3.6 tests on macOS-latest  | 9m44s    |
| Python 3.7 tests on macOS-latest  | 9m12s    |
| Python 3.8 tests on macOS-latest  | 7m53s    |
| Python 3.6 tests on ubuntu-latest | 5m9s     |
| Python 3.7 tests on ubuntu-latest | 4m37s    |
| Python 3.8 tests on ubuntu-latest | 4m35s    |

## Brief change log

  - Adds `flink-ml-python` module with java dependencies to be used in python tests
  - Creates a shared mini cluster for each python unit test class and reuses the cluster through all python test cases in a class.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)