### PR TITLE
[FLINK-30348] Add HasSeed param for RandomSplitter

### DIFF
--- a/docs/content/docs/operators/feature/randomsplitter.md
+++ b/docs/content/docs/operators/feature/randomsplitter.md
@@ -31,9 +31,10 @@ An AlgoOperator which splits a table into N tables according to the given weight
 
 ### Parameters
 
-| Key     | Default      | Type     | Required | Description                    |
-|:--------|:-------------|:---------|:---------|:-------------------------------|
-| weights | `[1.0, 1.0]` | Double[] | no       | The weights of data splitting. |
+| Key     | Default      | Type     | Required | Description                                                                                                                                                  |
+|:--------|:-------------|:---------|:---------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| weights | `[1.0, 1.0]` | Double[] | no       | The weights of data splitting.                                                                                                                               |
+| seed    | `null`       | Long     | no       | The random seed. This parameter guarantees reproduciable output only when the paralleism is unchanged and each worker reads the same data in the same order. |
 
 ### Examples
 

--- a/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/RandomSplitterExample.java
+++ b/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/RandomSplitterExample.java
@@ -47,7 +47,7 @@ public class RandomSplitterExample {
         Table inputTable = tEnv.fromDataStream(inputStream).as("input");
 
         // Creates a RandomSplitter object and initializes its parameters.
-        RandomSplitter splitter = new RandomSplitter().setWeights(4.0, 6.0);
+        RandomSplitter splitter = new RandomSplitter().setWeights(4.0, 6.0).setSeed(0L);
 
         // Uses the RandomSplitter to split inputData.
         Table[] outputTable = splitter.transform(inputTable);

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/randomsplitter/RandomSplitterParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/randomsplitter/RandomSplitterParams.java
@@ -18,17 +18,17 @@
 
 package org.apache.flink.ml.feature.randomsplitter;
 
+import org.apache.flink.ml.common.param.HasSeed;
 import org.apache.flink.ml.param.DoubleArrayParam;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.param.ParamValidator;
-import org.apache.flink.ml.param.WithParams;
 
 /**
  * Params of {@link RandomSplitter}.
  *
  * @param <T> The class type of this instance.
  */
-public interface RandomSplitterParams<T> extends WithParams<T> {
+public interface RandomSplitterParams<T> extends HasSeed<T> {
     /**
      * Weights should be a non-empty array with all elements greater than zero. The weights will be
      * normalized such that the sum of all elements equals to one.
@@ -40,12 +40,12 @@ public interface RandomSplitterParams<T> extends WithParams<T> {
                     new Double[] {1.0, 1.0},
                     weightsValidator());
 
-    default Double[] getWeights() {
-        return get(WEIGHTS);
-    }
-
     default T setWeights(Double... value) {
         return set(WEIGHTS, value);
+    }
+
+    default Double[] getWeights() {
+        return get(WEIGHTS);
     }
 
     // Checks the weights parameter.

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/RandomSplitterTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/RandomSplitterTest.java
@@ -72,8 +72,9 @@ public class RandomSplitterTest extends AbstractTestBase {
     @Test
     public void testParam() {
         RandomSplitter splitter = new RandomSplitter();
-        splitter.setWeights(0.3, 0.4);
+        splitter.setWeights(0.3, 0.4).setSeed(5L);
         assertArrayEquals(new Double[] {0.3, 0.4}, splitter.getWeights());
+        assertEquals(5L, splitter.getSeed());
     }
 
     @Test
@@ -105,6 +106,32 @@ public class RandomSplitterTest extends AbstractTestBase {
         assertEquals(result1.size() / 200.0, 1.0, 0.1);
         assertEquals(result2.size() / 400.0, 1.0, 0.1);
         verifyResultTables(data, output);
+    }
+
+    @Test
+    public void testSeed() throws Exception {
+        Table data = getTable(100);
+        RandomSplitter splitter = new RandomSplitter().setWeights(2.0, 1.0, 2.0);
+
+        Table[] output0 = splitter.transform(data);
+        List<Row> result00 =
+                IteratorUtils.toList(tEnv.toDataStream(output0[0]).executeAndCollect());
+        List<Row> result01 =
+                IteratorUtils.toList(tEnv.toDataStream(output0[1]).executeAndCollect());
+        List<Row> result02 =
+                IteratorUtils.toList(tEnv.toDataStream(output0[2]).executeAndCollect());
+
+        Table[] output1 = splitter.transform(data);
+        List<Row> result10 =
+                IteratorUtils.toList(tEnv.toDataStream(output1[0]).executeAndCollect());
+        List<Row> result11 =
+                IteratorUtils.toList(tEnv.toDataStream(output1[1]).executeAndCollect());
+        List<Row> result12 =
+                IteratorUtils.toList(tEnv.toDataStream(output1[2]).executeAndCollect());
+
+        assertEquals(result00.size(), result10.size());
+        assertEquals(result01.size(), result11.size());
+        assertEquals(result02.size(), result12.size());
     }
 
     @Test

--- a/flink-ml-python/pyflink/examples/ml/feature/randomsplitter_example.py
+++ b/flink-ml-python/pyflink/examples/ml/feature/randomsplitter_example.py
@@ -48,7 +48,7 @@ input_table = t_env.from_data_stream(
             [Types.INT(), Types.INT(), Types.INT()])))
 
 # Creates a RandomSplitter object and initializes its parameters.
-splitter = RandomSplitter().set_weights(4.0, 6.0)
+splitter = RandomSplitter().set_weights(4.0, 6.0).set_seed(0)
 
 # Uses the RandomSplitter to split the dataset.
 output = splitter.transform(input_table)

--- a/flink-ml-python/pyflink/ml/lib/feature/randomsplitter.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/randomsplitter.py
@@ -20,10 +20,12 @@ from typing import Tuple
 from pyflink.ml.core.param import Param, FloatArrayParam, ParamValidator
 from pyflink.ml.core.wrapper import JavaWithParams
 from pyflink.ml.lib.feature.common import JavaFeatureTransformer
+from pyflink.ml.lib.param import HasSeed
 
 
 class _RandomSplitterParams(
-    JavaWithParams
+    JavaWithParams,
+    HasSeed
 ):
     """
     Checks the weights parameter.

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_randomsplitter.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_randomsplitter.py
@@ -39,9 +39,10 @@ class RandomSplitterTest(PyFlinkMLTestCase):
 
     def test_param(self):
         splitter = RandomSplitter()
-        splitter.set_weights(0.2, 0.8)
+        splitter.set_weights(0.2, 0.8).set_seed(5)
         self.assertEqual(0.2, splitter.weights[0])
         self.assertEqual(0.8, splitter.weights[1])
+        self.assertEqual(5, splitter.seed)
 
     def test_output_schema(self):
         splitter = RandomSplitter()
@@ -52,7 +53,7 @@ class RandomSplitterTest(PyFlinkMLTestCase):
                 type_info=Types.ROW_NAMED(
                     ['test_input', 'dummy_input'],
                     [Types.STRING(), Types.STRING()])))
-        output = splitter.set_weights(0.5, 0.5) \
+        output = splitter.set_weights(0.5, 0.5).set_seed(0) \
             .transform(input_data_table)[0]
 
         self.assertEqual(
@@ -60,14 +61,14 @@ class RandomSplitterTest(PyFlinkMLTestCase):
             output.get_schema().get_field_names())
 
     def test_transform(self):
-        splitter = RandomSplitter().set_weights(0.4, 0.6)
+        splitter = RandomSplitter().set_weights(0.4, 0.6).set_seed(0)
 
         output = splitter.transform(self.input_table)
         results = [result for result in self.t_env.to_data_stream(output[0]).execute_and_collect()]
         self.assertAlmostEqual(len(results) / 4000.0, 1.0, delta=0.1)
 
     def test_save_load_transform(self):
-        splitter = RandomSplitter().set_weights(0.4, 0.6)
+        splitter = RandomSplitter().set_weights(0.4, 0.6).set_seed(0)
         path = os.path.join(self.temp_dir, 'test_save_load_random_splitter')
         splitter.save(path)
         splitter = RandomSplitter.load(self.t_env, path)


### PR DESCRIPTION
## What is the purpose of the change 
 - Add HasSeed param for RandomSplitter.

## Brief change log
  - Add API setSeed() for RandomSplitter Transformer in Java and Python. 
  - This parameter guarantees reproduciable output only when the paralleism is unchanged and each worker reads the same data in the same order.
  - Add ut for this new API.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
