### PR TITLE
[FLINK-30401] Add Estimator and Transformer for MinHashLSH

### DIFF
--- a/docs/content/docs/operators/feature/minhashlsh.md
+++ b/docs/content/docs/operators/feature/minhashlsh.md
@@ -31,6 +31,10 @@ MinHash LSH is a Locality Sensitive Hashing (LSH) scheme for Jaccard distance me
 The input features are sets of natural numbers represented as non-zero indices of vectors,
 either dense vectors or sparse vectors. Typically, sparse vectors are more efficient.
 
+In addition to transforming input feature vectors to multiple hash values, the MinHash LSH 
+model also supports approximate nearest neighbors search within a dataset regarding a key 
+vector and approximate similarity join between two datasets.
+
 ### Input Columns
 
 | Param name | Type   | Default   | Description            |
@@ -45,13 +49,13 @@ either dense vectors or sparse vectors. Typically, sparse vectors are more effic
 
 ### Parameters
 
-| Key                     | Default                                                   | Type    | Required | Description                                                        |
-|-------------------------|-----------------------------------------------------------|---------|----------|--------------------------------------------------------------------|
-| inputCol                | `"input"`                                                 | String  | no       | Input column name.                                                 |
-| outputCol               | `"output"`                                                | String  | no       | Output column name.                                                |
-| seed                    | `"org.apache.flink.ml.feature.lsh.MinHashLSH".hashCode()` | Long    | no       | The random seed.                                                   |
-| numHashTables           | `1`                                                       | Integer | no       | Default number of hash tables, for OR-amplification.               |
-| numHashFunctionPerTable | `1`                                                       | Integer | no       | Default number of hash functions per table, for AND-amplification. |
+| Key                     | Default    | Type    | Required | Description                                                        |
+|-------------------------|------------|---------|----------|--------------------------------------------------------------------|
+| inputCol                | `"input"`  | String  | no       | Input column name.                                                 |
+| outputCol               | `"output"` | String  | no       | Output column name.                                                |
+| seed                    | `null`     | Long    | no       | The random seed.                                                   |
+| numHashTables           | `1`        | Integer | no       | Default number of hash tables, for OR-amplification.               |
+| numHashFunctionPerTable | `1`        | Integer | no       | Default number of hash functions per table, for AND-amplification. |
 
 ### Examples
 

--- a/docs/content/docs/operators/feature/minhashlsh.md
+++ b/docs/content/docs/operators/feature/minhashlsh.md
@@ -1,0 +1,276 @@
+---
+title: "MinHash LSH"
+weight: 1
+type: docs
+aliases:
+- /operators/feature/minhashlsh.html
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## MinHash LSH
+
+MinHash LSH is a Locality Sensitive Hashing (LSH) scheme for Jaccard distance metric.
+The input features are sets of natural numbers represented as non-zero indices of vectors,
+either dense vectors or sparse vectors. Typically, sparse vectors are more efficient.
+
+### Input Columns
+
+| Param name | Type   | Default   | Description            |
+|:-----------|:-------|:----------|:-----------------------|
+| inputCol   | Vector | `"input"` | Features to be mapped. |
+
+### Output Columns
+
+| Param name | Type          | Default    | Description  |
+|:-----------|:--------------|:-----------|:-------------|
+| outputCol  | DenseVector[] | `"output"` | Hash values. |
+
+### Parameters
+
+| Key                     | Default                                                   | Type    | Required | Description                                                        |
+|-------------------------|-----------------------------------------------------------|---------|----------|--------------------------------------------------------------------|
+| inputCol                | `"input"`                                                 | String  | no       | Input column name.                                                 |
+| outputCol               | `"output"`                                                | String  | no       | Output column name.                                                |
+| seed                    | `"org.apache.flink.ml.feature.lsh.MinHashLSH".hashCode()` | Long    | no       | The random seed.                                                   |
+| numHashTables           | `1`                                                       | Integer | no       | Default number of hash tables, for OR-amplification.               |
+| numHashFunctionPerTable | `1`                                                       | Integer | no       | Default number of hash functions per table, for AND-amplification. |
+
+### Examples
+
+{{< tabs examples >}}
+
+{{< tab "Java">}}
+
+```java
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.ml.feature.lsh.MinHashLSH;
+import org.apache.flink.ml.feature.lsh.MinHashLSHModel;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.SparseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/**
+ * Simple program that trains a MinHashLSH model and uses it for approximate nearest neighbors and
+ * similarity join.
+ */
+public class MinHashLSHExample {
+    public static void main(String[] args) throws Exception {
+
+        // Creates a new StreamExecutionEnvironment
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // Creates a StreamTableEnvironment
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        // Generates two datasets
+        Table data =
+                tEnv.fromDataStream(
+                        env.fromCollection(
+                                Arrays.asList(
+                                        Row.of(
+                                                0,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {0, 1, 2},
+                                                        new double[] {1., 1., 1.})),
+                                        Row.of(
+                                                1,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {2, 3, 4},
+                                                        new double[] {1., 1., 1.})),
+                                        Row.of(
+                                                2,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {0, 2, 4},
+                                                        new double[] {1., 1., 1.}))),
+                                Types.ROW_NAMED(
+                                        new String[] {"id", "vec"},
+                                        Types.INT,
+                                        TypeInformation.of(SparseVector.class))));
+
+        Table dataB =
+                tEnv.fromDataStream(
+                        env.fromCollection(
+                                Arrays.asList(
+                                        Row.of(
+                                                3,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {1, 3, 5},
+                                                        new double[] {1., 1., 1.})),
+                                        Row.of(
+                                                4,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {2, 3, 5},
+                                                        new double[] {1., 1., 1.})),
+                                        Row.of(
+                                                5,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {1, 2, 4},
+                                                        new double[] {1., 1., 1.}))),
+                                Types.ROW_NAMED(
+                                        new String[] {"id", "vec"},
+                                        Types.INT,
+                                        TypeInformation.of(SparseVector.class))));
+
+        // Creates a MinHashLSH estimator object and initializes its parameters
+        MinHashLSH lsh =
+                new MinHashLSH()
+                        .setInputCol("vec")
+                        .setOutputCol("hashes")
+                        .setSeed(2022)
+                        .setNumHashTables(5);
+
+        // Trains the MinHashLSH model
+        MinHashLSHModel model = lsh.fit(data);
+
+        // Uses the MinHashLSH model for transformation
+        Table output = model.transform(data)[0];
+
+        // Extracts and displays the results
+        List<String> fieldNames = output.getResolvedSchema().getColumnNames();
+        for (Row result :
+                (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
+            Vector inputValue = result.getFieldAs(fieldNames.indexOf(lsh.getInputCol()));
+            DenseVector[] outputValue = result.getFieldAs(fieldNames.indexOf(lsh.getOutputCol()));
+            System.out.printf(
+                    "Vector: %s \tHash values: %s\n", inputValue, Arrays.toString(outputValue));
+        }
+
+        // Finds approximate nearest neighbors of the key
+        Vector key = Vectors.sparse(6, new int[] {1, 3}, new double[] {1., 1.});
+        output = model.approxNearestNeighbors(data, key, 2).select($("id"), $("distCol"));
+        for (Row result :
+                (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
+            int idValue = result.getFieldAs(fieldNames.indexOf("id"));
+            double distValue = result.getFieldAs(result.getArity() - 1);
+            System.out.printf("ID: %d \tDistance: %f\n", idValue, distValue);
+        }
+
+        // Approximately finds pairs from two datasets with distances smaller than the threshold
+        output = model.approxSimilarityJoin(data, dataB, .6, "id");
+        for (Row result :
+                (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
+            int idAValue = result.getFieldAs(0);
+            int idBValue = result.getFieldAs(1);
+            double distValue = result.getFieldAs(2);
+            System.out.printf(
+                    "ID from left: %d \tID from right: %d \t Distance: %f\n",
+                    idAValue, idAValue, distValue);
+        }
+    }
+}
+
+```
+
+{{< /tab>}}
+
+{{< tab "Python">}}
+
+```python
+# Simple program that trains a MinHashLSH model and uses it for approximate nearest neighbors 
+# and similarity join.
+
+
+from pyflink.common import Types
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.table import StreamTableEnvironment
+
+from pyflink.ml.core.linalg import Vectors, SparseVectorTypeInfo
+from pyflink.ml.lib.feature.lsh import MinHashLSH
+
+# Creates a new StreamExecutionEnvironment
+env = StreamExecutionEnvironment.get_execution_environment()
+
+# Creates a StreamTableEnvironment
+t_env = StreamTableEnvironment.create(env)
+
+# Generates two datasets
+data = t_env.from_data_stream(
+    env.from_collection([
+        (0, Vectors.sparse(6, [0, 1, 2], [1., 1., 1.])),
+        (1, Vectors.sparse(6, [2, 3, 4], [1., 1., 1.])),
+        (2, Vectors.sparse(6, [0, 2, 4], [1., 1., 1.])),
+    ], type_info=Types.ROW_NAMED(['id', 'vec'], [Types.INT(), SparseVectorTypeInfo()])))
+
+data_b = t_env.from_data_stream(
+    env.from_collection([
+        (3, Vectors.sparse(6, [1, 3, 5], [1., 1., 1.])),
+        (4, Vectors.sparse(6, [2, 3, 5], [1., 1., 1.])),
+        (5, Vectors.sparse(6, [1, 2, 4], [1., 1., 1.])),
+    ], type_info=Types.ROW_NAMED(['id', 'vec'], [Types.INT(), SparseVectorTypeInfo()])))
+
+# Creates a MinHashLSH estimator object and initializes its parameters
+lsh = MinHashLSH() \
+    .set_input_col('vec') \
+    .set_output_col('hashes') \
+    .set_seed(2022) \
+    .set_num_hash_tables(5)
+
+# Trains the MinHashLSH model
+model = lsh.fit(data)
+
+# Uses the MinHashLSH model for transformation
+output = model.transform(data)[0]
+
+# Extracts and displays the results
+field_names = output.get_schema().get_field_names()
+for result in t_env.to_data_stream(output).execute_and_collect():
+    input_value = result[field_names.index(lsh.get_input_col())]
+    output_value = result[field_names.index(lsh.get_output_col())]
+    print(f'Vector: {input_value} \tHash Values: {output_value}')
+
+# Finds approximate nearest neighbors of the key
+key = Vectors.sparse(6, [1, 3], [1., 1.])
+output = model.approx_nearest_neighbors(data, key, 2).select("id, distCol")
+for result in t_env.to_data_stream(output).execute_and_collect():
+    id_value = result[field_names.index("id")]
+    dist_value = result[-1]
+    print(f'ID: {id_value} \tDistance: {dist_value}')
+
+# Approximately finds pairs from two datasets with distances smaller than the threshold
+output = model.approx_similarity_join(data, data_b, .6, "id")
+for result in t_env.to_data_stream(output).execute_and_collect():
+    id_a_value, id_b_value, dist_value = result
+    print(f'ID from left: {id_a_value} \tID from right: {id_b_value} \t Distance: {dist_value}')
+
+```
+
+{{< /tab>}}
+
+{{< /tabs>}}

--- a/docs/content/docs/operators/feature/minhashlsh.md
+++ b/docs/content/docs/operators/feature/minhashlsh.md
@@ -98,13 +98,13 @@ import static org.apache.flink.table.api.Expressions.$;
 public class MinHashLSHExample {
     public static void main(String[] args) throws Exception {
 
-        // Creates a new StreamExecutionEnvironment
+        // Creates a new StreamExecutionEnvironment.
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-        // Creates a StreamTableEnvironment
+        // Creates a StreamTableEnvironment.
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
-        // Generates two datasets
+        // Generates two datasets.
         Table dataA =
                 tEnv.fromDataStream(
                         env.fromCollection(
@@ -159,7 +159,7 @@ public class MinHashLSHExample {
                                         Types.INT,
                                         TypeInformation.of(SparseVector.class))));
 
-        // Creates a MinHashLSH estimator object and initializes its parameters
+        // Creates a MinHashLSH estimator object and initializes its parameters.
         MinHashLSH lsh =
                 new MinHashLSH()
                         .setInputCol("vec")
@@ -167,13 +167,13 @@ public class MinHashLSHExample {
                         .setSeed(2022)
                         .setNumHashTables(5);
 
-        // Trains the MinHashLSH model
+        // Trains the MinHashLSH model.
         MinHashLSHModel model = lsh.fit(dataA);
 
-        // Uses the MinHashLSH model for transformation
+        // Uses the MinHashLSH model for transformation.
         Table output = model.transform(dataA)[0];
 
-        // Extracts and displays the results
+        // Extracts and displays the results.
         List<String> fieldNames = output.getResolvedSchema().getColumnNames();
         for (Row result :
                 (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
@@ -183,7 +183,7 @@ public class MinHashLSHExample {
                     "Vector: %s \tHash values: %s\n", inputValue, Arrays.toString(outputValue));
         }
 
-        // Finds approximate nearest neighbors of the key
+        // Finds approximate nearest neighbors of the key.
         Vector key = Vectors.sparse(6, new int[] {1, 3}, new double[] {1., 1.});
         output = model.approxNearestNeighbors(dataA, key, 2).select($("id"), $("distCol"));
         for (Row result :
@@ -193,7 +193,7 @@ public class MinHashLSHExample {
             System.out.printf("ID: %d \tDistance: %f\n", idValue, distValue);
         }
 
-        // Approximately finds pairs from two datasets with distances smaller than the threshold
+        // Approximately finds pairs from two datasets with distances smaller than the threshold.
         output = model.approxSimilarityJoin(dataA, dataB, .6, "id");
         for (Row result :
                 (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
@@ -225,13 +225,13 @@ from pyflink.table import StreamTableEnvironment
 from pyflink.ml.core.linalg import Vectors, SparseVectorTypeInfo
 from pyflink.ml.lib.feature.lsh import MinHashLSH
 
-# Creates a new StreamExecutionEnvironment
+# Creates a new StreamExecutionEnvironment.
 env = StreamExecutionEnvironment.get_execution_environment()
 
-# Creates a StreamTableEnvironment
+# Creates a StreamTableEnvironment.
 t_env = StreamTableEnvironment.create(env)
 
-# Generates two datasets
+# Generates two datasets.
 data_a = t_env.from_data_stream(
     env.from_collection([
         (0, Vectors.sparse(6, [0, 1, 2], [1., 1., 1.])),
@@ -246,27 +246,27 @@ data_b = t_env.from_data_stream(
         (5, Vectors.sparse(6, [1, 2, 4], [1., 1., 1.])),
     ], type_info=Types.ROW_NAMED(['id', 'vec'], [Types.INT(), SparseVectorTypeInfo()])))
 
-# Creates a MinHashLSH estimator object and initializes its parameters
+# Creates a MinHashLSH estimator object and initializes its parameters.
 lsh = MinHashLSH() \
     .set_input_col('vec') \
     .set_output_col('hashes') \
     .set_seed(2022) \
     .set_num_hash_tables(5)
 
-# Trains the MinHashLSH model
+# Trains the MinHashLSH model.
 model = lsh.fit(data_a)
 
-# Uses the MinHashLSH model for transformation
+# Uses the MinHashLSH model for transformation.
 output = model.transform(data_a)[0]
 
-# Extracts and displays the results
+# Extracts and displays the results.
 field_names = output.get_schema().get_field_names()
 for result in t_env.to_data_stream(output).execute_and_collect():
     input_value = result[field_names.index(lsh.get_input_col())]
     output_value = result[field_names.index(lsh.get_output_col())]
     print(f'Vector: {input_value} \tHash Values: {output_value}')
 
-# Finds approximate nearest neighbors of the key
+# Finds approximate nearest neighbors of the key.
 key = Vectors.sparse(6, [1, 3], [1., 1.])
 output = model.approx_nearest_neighbors(data_a, key, 2).select("id, distCol")
 for result in t_env.to_data_stream(output).execute_and_collect():
@@ -274,7 +274,7 @@ for result in t_env.to_data_stream(output).execute_and_collect():
     dist_value = result[-1]
     print(f'ID: {id_value} \tDistance: {dist_value}')
 
-# Approximately finds pairs from two datasets with distances smaller than the threshold
+# Approximately finds pairs from two datasets with distances smaller than the threshold.
 output = model.approx_similarity_join(data_a, data_b, .6, "id")
 for result in t_env.to_data_stream(output).execute_and_collect():
     id_a_value, id_b_value, dist_value = result

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/DataStreamUtils.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/DataStreamUtils.java
@@ -143,8 +143,8 @@ public class DataStreamUtils {
     }
 
     /**
-     * Apply a {@link ReduceFunction} on a bounded keyed data stream. The output stream contains one
-     * stream record for each key.
+     * Applies a {@link ReduceFunction} on a bounded keyed data stream. The output stream contains
+     * one stream record for each key.
      *
      * @param input The input keyed data stream.
      * @param func The user defined reduce function.
@@ -440,11 +440,11 @@ public class DataStreamUtils {
             IN currentValue = values.value();
 
             if (currentValue == null) {
-                // register a timer for emitting the result at the end when this is the
-                // first input for this key
+                // Registers a timer for emitting the result at the end when this is the
+                // first input for this key.
                 timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, Long.MAX_VALUE);
             } else {
-                // otherwise, reduce things
+                // Otherwise, reduces things.
                 value = userFunction.reduce(currentValue, value);
             }
             values.update(value);

--- a/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/MinHashLSHExample.java
+++ b/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/MinHashLSHExample.java
@@ -52,7 +52,7 @@ public class MinHashLSHExample {
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
         // Generates two datasets
-        Table data =
+        Table dataA =
                 tEnv.fromDataStream(
                         env.fromCollection(
                                 Arrays.asList(
@@ -115,10 +115,10 @@ public class MinHashLSHExample {
                         .setNumHashTables(5);
 
         // Trains the MinHashLSH model
-        MinHashLSHModel model = lsh.fit(data);
+        MinHashLSHModel model = lsh.fit(dataA);
 
         // Uses the MinHashLSH model for transformation
-        Table output = model.transform(data)[0];
+        Table output = model.transform(dataA)[0];
 
         // Extracts and displays the results
         List<String> fieldNames = output.getResolvedSchema().getColumnNames();
@@ -132,7 +132,7 @@ public class MinHashLSHExample {
 
         // Finds approximate nearest neighbors of the key
         Vector key = Vectors.sparse(6, new int[] {1, 3}, new double[] {1., 1.});
-        output = model.approxNearestNeighbors(data, key, 2).select($("id"), $("distCol"));
+        output = model.approxNearestNeighbors(dataA, key, 2).select($("id"), $("distCol"));
         for (Row result :
                 (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
             int idValue = result.getFieldAs(fieldNames.indexOf("id"));
@@ -141,7 +141,7 @@ public class MinHashLSHExample {
         }
 
         // Approximately finds pairs from two datasets with distances smaller than the threshold
-        output = model.approxSimilarityJoin(data, dataB, .6, "id");
+        output = model.approxSimilarityJoin(dataA, dataB, .6, "id");
         for (Row result :
                 (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
             int idAValue = result.getFieldAs(0);
@@ -149,7 +149,7 @@ public class MinHashLSHExample {
             double distValue = result.getFieldAs(2);
             System.out.printf(
                     "ID from left: %d \tID from right: %d \t Distance: %f\n",
-                    idAValue, idAValue, distValue);
+                    idAValue, idBValue, distValue);
         }
     }
 }

--- a/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/MinHashLSHExample.java
+++ b/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/MinHashLSHExample.java
@@ -45,13 +45,13 @@ import static org.apache.flink.table.api.Expressions.$;
 public class MinHashLSHExample {
     public static void main(String[] args) throws Exception {
 
-        // Creates a new StreamExecutionEnvironment
+        // Creates a new StreamExecutionEnvironment.
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-        // Creates a StreamTableEnvironment
+        // Creates a StreamTableEnvironment.
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
-        // Generates two datasets
+        // Generates two datasets.
         Table dataA =
                 tEnv.fromDataStream(
                         env.fromCollection(
@@ -106,7 +106,7 @@ public class MinHashLSHExample {
                                         Types.INT,
                                         TypeInformation.of(SparseVector.class))));
 
-        // Creates a MinHashLSH estimator object and initializes its parameters
+        // Creates a MinHashLSH estimator object and initializes its parameters.
         MinHashLSH lsh =
                 new MinHashLSH()
                         .setInputCol("vec")
@@ -114,13 +114,13 @@ public class MinHashLSHExample {
                         .setSeed(2022)
                         .setNumHashTables(5);
 
-        // Trains the MinHashLSH model
+        // Trains the MinHashLSH model.
         MinHashLSHModel model = lsh.fit(dataA);
 
-        // Uses the MinHashLSH model for transformation
+        // Uses the MinHashLSH model for transformation.
         Table output = model.transform(dataA)[0];
 
-        // Extracts and displays the results
+        // Extracts and displays the results.
         List<String> fieldNames = output.getResolvedSchema().getColumnNames();
         for (Row result :
                 (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
@@ -130,7 +130,7 @@ public class MinHashLSHExample {
                     "Vector: %s \tHash values: %s\n", inputValue, Arrays.toString(outputValue));
         }
 
-        // Finds approximate nearest neighbors of the key
+        // Finds approximate nearest neighbors of the key.
         Vector key = Vectors.sparse(6, new int[] {1, 3}, new double[] {1., 1.});
         output = model.approxNearestNeighbors(dataA, key, 2).select($("id"), $("distCol"));
         for (Row result :
@@ -140,7 +140,7 @@ public class MinHashLSHExample {
             System.out.printf("ID: %d \tDistance: %f\n", idValue, distValue);
         }
 
-        // Approximately finds pairs from two datasets with distances smaller than the threshold
+        // Approximately finds pairs from two datasets with distances smaller than the threshold.
         output = model.approxSimilarityJoin(dataA, dataB, .6, "id");
         for (Row result :
                 (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {

--- a/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/MinHashLSHExample.java
+++ b/flink-ml-examples/src/main/java/org/apache/flink/ml/examples/feature/MinHashLSHExample.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.examples.feature;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.ml.feature.lsh.MinHashLSH;
+import org.apache.flink.ml.feature.lsh.MinHashLSHModel;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.SparseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/**
+ * Simple program that trains a MinHashLSH model and uses it for approximate nearest neighbors and
+ * similarity join.
+ */
+public class MinHashLSHExample {
+    public static void main(String[] args) throws Exception {
+
+        // Creates a new StreamExecutionEnvironment
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // Creates a StreamTableEnvironment
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        // Generates two datasets
+        Table data =
+                tEnv.fromDataStream(
+                        env.fromCollection(
+                                Arrays.asList(
+                                        Row.of(
+                                                0,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {0, 1, 2},
+                                                        new double[] {1., 1., 1.})),
+                                        Row.of(
+                                                1,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {2, 3, 4},
+                                                        new double[] {1., 1., 1.})),
+                                        Row.of(
+                                                2,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {0, 2, 4},
+                                                        new double[] {1., 1., 1.}))),
+                                Types.ROW_NAMED(
+                                        new String[] {"id", "vec"},
+                                        Types.INT,
+                                        TypeInformation.of(SparseVector.class))));
+
+        Table dataB =
+                tEnv.fromDataStream(
+                        env.fromCollection(
+                                Arrays.asList(
+                                        Row.of(
+                                                3,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {1, 3, 5},
+                                                        new double[] {1., 1., 1.})),
+                                        Row.of(
+                                                4,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {2, 3, 5},
+                                                        new double[] {1., 1., 1.})),
+                                        Row.of(
+                                                5,
+                                                Vectors.sparse(
+                                                        6,
+                                                        new int[] {1, 2, 4},
+                                                        new double[] {1., 1., 1.}))),
+                                Types.ROW_NAMED(
+                                        new String[] {"id", "vec"},
+                                        Types.INT,
+                                        TypeInformation.of(SparseVector.class))));
+
+        // Creates a MinHashLSH estimator object and initializes its parameters
+        MinHashLSH lsh =
+                new MinHashLSH()
+                        .setInputCol("vec")
+                        .setOutputCol("hashes")
+                        .setSeed(2022)
+                        .setNumHashTables(5);
+
+        // Trains the MinHashLSH model
+        MinHashLSHModel model = lsh.fit(data);
+
+        // Uses the MinHashLSH model for transformation
+        Table output = model.transform(data)[0];
+
+        // Extracts and displays the results
+        List<String> fieldNames = output.getResolvedSchema().getColumnNames();
+        for (Row result :
+                (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
+            Vector inputValue = result.getFieldAs(fieldNames.indexOf(lsh.getInputCol()));
+            DenseVector[] outputValue = result.getFieldAs(fieldNames.indexOf(lsh.getOutputCol()));
+            System.out.printf(
+                    "Vector: %s \tHash values: %s\n", inputValue, Arrays.toString(outputValue));
+        }
+
+        // Finds approximate nearest neighbors of the key
+        Vector key = Vectors.sparse(6, new int[] {1, 3}, new double[] {1., 1.});
+        output = model.approxNearestNeighbors(data, key, 2).select($("id"), $("distCol"));
+        for (Row result :
+                (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
+            int idValue = result.getFieldAs(fieldNames.indexOf("id"));
+            double distValue = result.getFieldAs(result.getArity() - 1);
+            System.out.printf("ID: %d \tDistance: %f\n", idValue, distValue);
+        }
+
+        // Approximately finds pairs from two datasets with distances smaller than the threshold
+        output = model.approxSimilarityJoin(data, dataB, .6, "id");
+        for (Row result :
+                (List<Row>) IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect())) {
+            int idAValue = result.getFieldAs(0);
+            int idBValue = result.getFieldAs(1);
+            double distValue = result.getFieldAs(2);
+            System.out.printf(
+                    "ID from left: %d \tID from right: %d \t Distance: %f\n",
+                    idAValue, idAValue, distValue);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSH.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSH.java
@@ -40,7 +40,7 @@ import java.util.Map;
  * metrics (e.g., Jaccard distance).
  *
  * <p>The basic idea of LSH is to use to a set of hash functions to map input vectors into different
- * buckets, where closer vectors are expected to be in same bucket with higher probabilities. In
+ * buckets, where closer vectors are expected to be in the same bucket with higher probabilities. In
  * detail, each input vector is hashed by all functions. To decide whether two input vectors are
  * mapped into the same bucket, two mechanisms for assigning buckets are proposed as follows.
  *

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSH.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSH.java
@@ -39,7 +39,7 @@ import java.util.Map;
  * Base class for estimators that support LSH (Locality-sensitive hashing) algorithm for different
  * metrics (e.g., Jaccard distance).
  *
- * <p>The basic idea of LSH is to use to a set of hash functions to map input vectors into different
+ * <p>The basic idea of LSH is to use a set of hash functions to map input vectors into different
  * buckets, where closer vectors are expected to be in the same bucket with higher probabilities. In
  * detail, each input vector is hashed by all functions. To decide whether two input vectors are
  * mapped into the same bucket, two mechanisms for assigning buckets are proposed as follows.

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSH.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSH.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.lsh;
+
+import org.apache.flink.ml.api.Estimator;
+import org.apache.flink.ml.common.datastream.DataStreamUtils;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base class for estimators that support LSH (Locality-sensitive hashing) algorithm for different
+ * metrics (e.g., Jaccard distance).
+ *
+ * <p>The basic idea of LSH is to use to a set of hash functions to map input vectors into different
+ * buckets, where closer vectors are expected to be in same bucket with higher probabilities. In
+ * detail, each input vector is hashed by all functions. To decide whether two input vectors are
+ * mapped into the same bucket, two mechanisms for assigning buckets are proposed as follows.
+ *
+ * <ul>
+ *   <li>AND-amplification: The two input vectors are defined to be in the same bucket as long as
+ *       ALL of the hash value matches.
+ *   <li>OR-amplification: The two input vectors are defined to be in the same bucket as long as ANY
+ *       of the hash value matches.
+ * </ul>
+ *
+ * <p>See: <a
+ * href="https://en.wikipedia.org/wiki/Locality-sensitive_hashing">Locality-sensitive_hashing</a>.
+ *
+ * @param <E> class type of the Estimator implementation.
+ * @param <M> class type of the Model this Estimator produces.
+ */
+abstract class LSH<E extends Estimator<E, M>, M extends LSHModel<M>>
+        implements Estimator<E, M>, LSHParams<E> {
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public LSH() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public M fit(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<Integer> inputDim = getVectorSize(tEnv.toDataStream(inputs[0]), getInputCol());
+        return createModel(inputDim, tEnv);
+    }
+
+    protected abstract M createModel(DataStream<Integer> inputDim, StreamTableEnvironment tEnv);
+
+    private static DataStream<Integer> getVectorSize(DataStream<Row> input, String vectorCol) {
+        DataStream<Integer> vectorSizes =
+                input.map(
+                        d -> {
+                            Vector vec = d.getFieldAs(vectorCol);
+                            return vec.size();
+                        });
+        return DataStreamUtils.reduce(
+                vectorSizes,
+                (s0, s1) -> {
+                    Preconditions.checkState(
+                            s0.equals(s1), "Vector sizes are not the same: %d %d.", s0, s1);
+                    return s0;
+                });
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModel.java
@@ -123,7 +123,7 @@ abstract class LSHModel<T extends LSHModel<T>> implements Model<T>, LSHModelPara
 
     /**
      * Approximately finds at most k items from a dataset which have the closest distance to a given
-     * item . If the `outputCol` is missing in the given dataset, this method transforms the dataset
+     * item. If the `outputCol` is missing in the given dataset, this method transforms the dataset
      * with the model at first.
      *
      * @param dataset The dataset in which to to search for nearest neighbors.

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModel.java
@@ -398,7 +398,7 @@ abstract class LSHModel<T extends LSHModel<T>> implements Model<T>, LSHModelPara
         public PriorityQueue<Row> merge(PriorityQueue<Row> a, PriorityQueue<Row> b) {
             PriorityQueue<Row> merged = new PriorityQueue<>(a);
             for (Row row : b) {
-                merged = add(row, merged);
+                add(row, merged);
             }
             return merged;
         }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModel.java
@@ -1,0 +1,457 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.lsh;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.api.Model;
+import org.apache.flink.ml.common.broadcast.BroadcastUtils;
+import org.apache.flink.ml.common.datastream.DataStreamUtils;
+import org.apache.flink.ml.common.datastream.EndOfStreamWindows;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+/**
+ * Base class for LSH model.
+ *
+ * <p>In addition to transforming input feature vectors to multiple hash values, it also supports
+ * approximate nearest neighbors search within a dataset regarding a key vector and approximate
+ * similarity join between two datasets.
+ *
+ * @param <T> class type of the LSHModel implementation itself.
+ */
+abstract class LSHModel<T extends LSHModel<T>> implements Model<T>, LSHModelParams<T> {
+    private static final String MODEL_DATA_BC_KEY = "modelData";
+
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    /** Stores the corresponding model data class of T. */
+    private final Class<? extends LSHModelData> modelDataClass;
+
+    protected Table modelDataTable;
+
+    public LSHModel(Class<? extends LSHModelData> modelDataClass) {
+        this.modelDataClass = modelDataClass;
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public T setModelData(Table... inputs) {
+        modelDataTable = inputs[0];
+        return (T) this;
+    }
+
+    @Override
+    public Table[] getModelData() {
+        return new Table[] {modelDataTable};
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    @Override
+    public Table[] transform(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<? extends LSHModelData> modelData =
+                tEnv.toDataStream(modelDataTable, modelDataClass);
+
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+        TypeInformation<?> outputType = TypeInformation.of(DenseVector[].class);
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(inputTypeInfo.getFieldTypes(), outputType),
+                        ArrayUtils.addAll(inputTypeInfo.getFieldNames(), getOutputCol()));
+
+        DataStream<Row> output =
+                BroadcastUtils.withBroadcastStream(
+                        Collections.singletonList(tEnv.toDataStream(inputs[0])),
+                        Collections.singletonMap(MODEL_DATA_BC_KEY, modelData),
+                        inputList -> {
+                            //noinspection unchecked
+                            DataStream<Row> data = (DataStream<Row>) inputList.get(0);
+                            return data.map(new PredictFunction(getInputCol()), outputTypeInfo);
+                        });
+        return new Table[] {tEnv.fromDataStream(output)};
+    }
+
+    /**
+     * Approximately finds at most k items from a dataset which have the closest distance to a given
+     * item . If the `outputCol` is missing in the given dataset, this method transforms the dataset
+     * with the model at first.
+     *
+     * @param dataset The dataset in which to to search for nearest neighbors.
+     * @param key The item to search for.
+     * @param k The maximum number of nearest neighbors.
+     * @param distCol The output column storing the distance between each neighbor and the key.
+     * @return A dataset containing at most k items closest to the key with a column named `distCol`
+     *     appended.
+     */
+    public Table approxNearestNeighbors(Table dataset, Vector key, int k, String distCol) {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) dataset).getTableEnvironment();
+        Table transformedTable =
+                (dataset.getResolvedSchema().getColumnNames().contains(getOutputCol()))
+                        ? dataset
+                        : transform(dataset)[0];
+
+        DataStream<? extends LSHModelData> modelData =
+                tEnv.toDataStream(modelDataTable, modelDataClass);
+
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(transformedTable.getResolvedSchema());
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(inputTypeInfo.getFieldTypes(), Types.DOUBLE),
+                        ArrayUtils.addAll(inputTypeInfo.getFieldNames(), distCol));
+
+        // Fetch items in the same bucket with key's, and calculate their distances to key.
+        DataStream<Row> filteredData =
+                BroadcastUtils.withBroadcastStream(
+                        Collections.singletonList(tEnv.toDataStream(transformedTable)),
+                        Collections.singletonMap(MODEL_DATA_BC_KEY, modelData),
+                        inputList -> {
+                            //noinspection unchecked
+                            DataStream<Row> data = (DataStream<Row>) inputList.get(0);
+                            return data.flatMap(
+                                    new FilterByBucketFunction(getInputCol(), getOutputCol(), key),
+                                    outputTypeInfo);
+                        });
+        DataStream<List<Row>> topKList =
+                DataStreamUtils.aggregate(filteredData, new TopKFunction(distCol, k));
+        DataStream<Row> topKData =
+                topKList.flatMap(
+                        (value, out) -> {
+                            for (Row row : value) {
+                                out.collect(row);
+                            }
+                        });
+        topKData.getTransformation().setOutputType(outputTypeInfo);
+        return tEnv.fromDataStream(topKData);
+    }
+
+    /**
+     * An overloaded version of `approxNearestNeighbors` with "distCol" as default value of
+     * `distCol`.
+     */
+    public Table approxNearestNeighbors(Table dataset, Vector key, int k) {
+        return approxNearestNeighbors(dataset, key, k, "distCol");
+    }
+
+    /**
+     * Joins two datasets to approximately find all pairs of rows whose distance are smaller than or
+     * equal to the threshold. If the `outputCol` is missing in either dataset, this method
+     * transforms the dataset at first.
+     *
+     * @param datasetA One dataset.
+     * @param datasetB The other dataset.
+     * @param threshold The distance threshold.
+     * @param idCol A column in the two datasets to identify each row.
+     * @param distCol The output column storing the distance between each pair of rows.
+     * @return A joined dataset containing pairs of rows. The original rows are in columns
+     *     "datasetA" and "datasetB", and a column "distCol" is added to show the distance between
+     *     each pair.
+     */
+    public Table approxSimilarityJoin(
+            Table datasetA, Table datasetB, double threshold, String idCol, String distCol) {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) datasetA).getTableEnvironment();
+
+        DataStream<Row> explodedA = preprocessData(datasetA, idCol);
+        DataStream<Row> explodedB = preprocessData(datasetB, idCol);
+
+        DataStream<? extends LSHModelData> modelData =
+                tEnv.toDataStream(modelDataTable, modelDataClass);
+        DataStream<Row> sameBucketPairs =
+                explodedA
+                        .join(explodedB)
+                        .where(new IndexHashValueKeySelector())
+                        .equalTo(new IndexHashValueKeySelector())
+                        .window(EndOfStreamWindows.get())
+                        .apply(
+                                (r0, r1) ->
+                                        Row.of(
+                                                r0.getField(0),
+                                                r1.getField(0),
+                                                r0.getField(1),
+                                                r1.getField(1)));
+        DataStream<Row> distinctSameBucketPairs =
+                DataStreamUtils.reduce(
+                        sameBucketPairs.keyBy(
+                                new KeySelector<Row, Tuple2<Integer, Integer>>() {
+                                    @Override
+                                    public Tuple2<Integer, Integer> getKey(Row r) {
+                                        return Tuple2.of(r.getFieldAs(0), r.getFieldAs(1));
+                                    }
+                                }),
+                        (r0, r1) -> r0);
+
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(datasetA.getResolvedSchema());
+        TypeInformation<?> idColType = inputTypeInfo.getTypeAt(idCol);
+        DataStream<Row> pairsWithDists =
+                BroadcastUtils.withBroadcastStream(
+                        Collections.singletonList(distinctSameBucketPairs),
+                        Collections.singletonMap(MODEL_DATA_BC_KEY, modelData),
+                        inputList -> {
+                            DataStream<Row> data = (DataStream<Row>) inputList.get(0);
+                            return data.flatMap(
+                                    new FilterByDistanceFunction(threshold),
+                                    new RowTypeInfo(
+                                            new TypeInformation[] {
+                                                idColType, idColType, Types.DOUBLE
+                                            },
+                                            new String[] {"datasetA.id", "datasetB.id", distCol}));
+                        });
+        return tEnv.fromDataStream(pairsWithDists);
+    }
+
+    /**
+     * An overloaded version of `approxNearestNeighbors` with "distCol" as default value of
+     * `distCol`.
+     */
+    public Table approxSimilarityJoin(
+            Table datasetA, Table datasetB, double threshold, String idCol) {
+        return approxSimilarityJoin(datasetA, datasetB, threshold, idCol, "distCol");
+    }
+
+    private DataStream<Row> preprocessData(Table dataTable, String idCol) {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) dataTable).getTableEnvironment();
+
+        dataTable =
+                (dataTable.getResolvedSchema().getColumnNames().contains(getOutputCol()))
+                        ? dataTable
+                        : transform(dataTable)[0];
+
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(dataTable.getResolvedSchema());
+        TypeInformation<?> idColType = inputTypeInfo.getTypeAt(idCol);
+        final String indexCol = "index";
+        final String hashValueCol = "hashValue";
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        new TypeInformation[] {
+                            idColType,
+                            TypeInformation.of(Vector.class),
+                            Types.INT,
+                            TypeInformation.of(DenseVector.class)
+                        },
+                        new String[] {idCol, getInputCol(), indexCol, hashValueCol});
+
+        return tEnv.toDataStream(dataTable)
+                .flatMap(
+                        new ExplodeHashValuesFunction(idCol, getInputCol(), getOutputCol()),
+                        outputTypeInfo);
+    }
+
+    private static class PredictFunction extends RichMapFunction<Row, Row> {
+        private final String inputCol;
+
+        private LSHModelData modelData;
+
+        public PredictFunction(String inputCol) {
+            this.inputCol = inputCol;
+        }
+
+        @Override
+        public Row map(Row value) throws Exception {
+            if (null == modelData) {
+                modelData =
+                        (LSHModelData)
+                                getRuntimeContext().getBroadcastVariable(MODEL_DATA_BC_KEY).get(0);
+            }
+            Vector[] hashValues = modelData.hashFunction(value.getFieldAs(inputCol));
+            return Row.join(value, Row.of((Object) hashValues));
+        }
+    }
+
+    private static class FilterByBucketFunction extends RichFlatMapFunction<Row, Row> {
+        private final String inputCol;
+        private final String outputCol;
+        private final Vector key;
+        private LSHModelData modelData;
+        private DenseVector[] keyHashes;
+
+        public FilterByBucketFunction(String inputCol, String outputCol, Vector key) {
+            this.inputCol = inputCol;
+            this.outputCol = outputCol;
+            this.key = key;
+        }
+
+        @Override
+        public void flatMap(Row value, Collector<Row> out) throws Exception {
+            if (null == modelData) {
+                modelData =
+                        (LSHModelData)
+                                getRuntimeContext().getBroadcastVariable(MODEL_DATA_BC_KEY).get(0);
+                keyHashes = modelData.hashFunction(key);
+            }
+            DenseVector[] hashes = value.getFieldAs(outputCol);
+            boolean sameBucket = false;
+            for (int i = 0; i < keyHashes.length; i += 1) {
+                if (keyHashes[i].equals(hashes[i])) {
+                    sameBucket = true;
+                    break;
+                }
+            }
+            if (!sameBucket) {
+                return;
+            }
+            Vector vec = value.getFieldAs(inputCol);
+            double dist = modelData.keyDistance(key, vec);
+            out.collect(Row.join(value, Row.of(dist)));
+        }
+    }
+
+    private static class TopKFunction
+            implements AggregateFunction<Row, PriorityQueue<Row>, List<Row>> {
+        private final int numNearestNeighbors;
+        private final String distCol;
+
+        private static class DistColComparator implements Comparator<Row> {
+
+            private final String distCol;
+
+            private DistColComparator(String distCol) {
+                this.distCol = distCol;
+            }
+
+            @Override
+            public int compare(Row o1, Row o2) {
+                return Double.compare(o1.getFieldAs(distCol), o2.getFieldAs(distCol));
+            }
+        }
+
+        public TopKFunction(String distCol, int numNearestNeighbors) {
+            this.distCol = distCol;
+            this.numNearestNeighbors = numNearestNeighbors;
+        }
+
+        @Override
+        public PriorityQueue<Row> createAccumulator() {
+            return new PriorityQueue<>(numNearestNeighbors, new DistColComparator(distCol));
+        }
+
+        @Override
+        public PriorityQueue<Row> add(Row value, PriorityQueue<Row> accumulator) {
+            if (accumulator.size() == numNearestNeighbors) {
+                Row peek = accumulator.peek();
+                if (accumulator.comparator().compare(value, peek) < 0) {
+                    accumulator.poll();
+                }
+            }
+            accumulator.add(value);
+            return accumulator;
+        }
+
+        @Override
+        public List<Row> getResult(PriorityQueue<Row> accumulator) {
+            return new ArrayList<>(accumulator);
+        }
+
+        @Override
+        public PriorityQueue<Row> merge(PriorityQueue<Row> a, PriorityQueue<Row> b) {
+            PriorityQueue<Row> merged = new PriorityQueue<>(a);
+            for (Row row : b) {
+                merged = add(row, merged);
+            }
+            return merged;
+        }
+    }
+
+    private static class ExplodeHashValuesFunction implements FlatMapFunction<Row, Row> {
+        private final String idCol;
+        private final String inputCol;
+        private final String outputCol;
+
+        public ExplodeHashValuesFunction(String idCol, String inputCol, String outputCol) {
+            this.idCol = idCol;
+            this.inputCol = inputCol;
+            this.outputCol = outputCol;
+        }
+
+        @Override
+        public void flatMap(Row value, Collector<Row> out) throws Exception {
+            Row kept = Row.of(value.getField(idCol), value.getField(inputCol));
+            DenseVector[] hashValues = value.getFieldAs(outputCol);
+            for (int i = 0; i < hashValues.length; i += 1) {
+                out.collect(Row.join(kept, Row.of(i, hashValues[i])));
+            }
+        }
+    }
+
+    private static class IndexHashValueKeySelector
+            implements KeySelector<Row, Tuple2<Integer, DenseVector>> {
+
+        @Override
+        public Tuple2<Integer, DenseVector> getKey(Row value) throws Exception {
+            return Tuple2.of(value.getFieldAs(2), value.getFieldAs(3));
+        }
+    }
+
+    private static class FilterByDistanceFunction extends RichFlatMapFunction<Row, Row> {
+        private final double threshold;
+        private LSHModelData modelData;
+
+        public FilterByDistanceFunction(double threshold) {
+            this.threshold = threshold;
+        }
+
+        @Override
+        public void flatMap(Row value, Collector<Row> out) throws Exception {
+            if (null == modelData) {
+                modelData =
+                        (LSHModelData)
+                                getRuntimeContext().getBroadcastVariable(MODEL_DATA_BC_KEY).get(0);
+            }
+            double dist = modelData.keyDistance(value.getFieldAs(2), value.getFieldAs(3));
+            if (dist <= threshold) {
+                out.collect(Row.of(value.getFieldAs(0), value.getFieldAs(1), dist));
+            }
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModel.java
@@ -151,7 +151,7 @@ abstract class LSHModel<T extends LSHModel<T>> implements Model<T>, LSHModelPara
                         ArrayUtils.addAll(inputTypeInfo.getFieldTypes(), Types.DOUBLE),
                         ArrayUtils.addAll(inputTypeInfo.getFieldNames(), distCol));
 
-        // Fetch items in the same bucket with key's, and calculate their distances to key.
+        // Fetches items in the same bucket with key's, and calculates their distances to key.
         DataStream<Row> filteredData =
                 BroadcastUtils.withBroadcastStream(
                         Collections.singletonList(tEnv.toDataStream(transformedTable)),

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModel.java
@@ -80,6 +80,7 @@ abstract class LSHModel<T extends LSHModel<T>> implements Model<T>, LSHModelPara
 
     @Override
     public T setModelData(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
         modelDataTable = inputs[0];
         return (T) this;
     }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModelData.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.lsh;
+
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vector;
+
+/**
+ * Base class for LSH model data. A concrete class extending this base class should implement how to
+ * map a feature vector to multiple hash vectors, and how to calculate corresponding distance
+ * between two feature vectors.
+ */
+abstract class LSHModelData {
+    /**
+     * Maps an input feature vector to multiple hash vectors.
+     *
+     * @param vec input vector.
+     * @return the mapping of LSH functions.
+     */
+    public abstract DenseVector[] hashFunction(Vector vec);
+
+    /**
+     * Calculates the distance between two different feature vectors using the corresponding
+     * distance metric.
+     *
+     * @param x One input vector in the metric space.
+     * @param y One input vector in the metric space.
+     * @return The distance between x and y.
+     */
+    public abstract double keyDistance(Vector x, Vector y);
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModelParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHModelParams.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.lsh;
+
+import org.apache.flink.ml.common.param.HasInputCol;
+import org.apache.flink.ml.common.param.HasOutputCol;
+
+/**
+ * Params for {@link LSHModel}.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface LSHModelParams<T> extends HasInputCol<T>, HasOutputCol<T> {}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHParams.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.ml.feature.lsh;
 
-import org.apache.flink.ml.common.param.HasInputCol;
-import org.apache.flink.ml.common.param.HasOutputCol;
-import org.apache.flink.ml.common.param.HasSeed;
 import org.apache.flink.ml.param.IntParam;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.param.ParamValidators;
@@ -30,7 +27,7 @@ import org.apache.flink.ml.param.ParamValidators;
  *
  * @param <T> The class type of this instance.
  */
-public interface LSHParams<T> extends HasInputCol<T>, HasOutputCol<T>, HasSeed<T> {
+public interface LSHParams<T> extends LSHModelParams<T> {
 
     /**
      * Param for the number of hash tables used in LSH OR-amplification.

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHParams.java
@@ -37,7 +37,7 @@ public interface LSHParams<T> extends LSHModelParams<T> {
      * complexity.
      */
     Param<Integer> NUM_HASH_TABLES =
-            new IntParam("numHashTables", "Number of hash tables.", 1, ParamValidators.gtEq(1.));
+            new IntParam("numHashTables", "Number of hash tables.", 1, ParamValidators.gtEq(1));
 
     default int getNumHashTables() {
         return get(NUM_HASH_TABLES);
@@ -59,7 +59,7 @@ public interface LSHParams<T> extends LSHModelParams<T> {
                     "numHashFunctionsPerTable",
                     "Number of hash functions per table.",
                     1,
-                    ParamValidators.gtEq(1.));
+                    ParamValidators.gtEq(1));
 
     default int getNumHashFunctionsPerTable() {
         return get(NUM_HASH_FUNCTIONS_PER_TABLE);

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHParams.java
@@ -39,14 +39,6 @@ public interface LSHParams<T> extends LSHModelParams<T> {
     Param<Integer> NUM_HASH_TABLES =
             new IntParam("numHashTables", "Number of hash tables.", 1, ParamValidators.gtEq(1));
 
-    default int getNumHashTables() {
-        return get(NUM_HASH_TABLES);
-    }
-
-    default T setNumHashTables(Integer value) {
-        return set(NUM_HASH_TABLES, value);
-    }
-
     /**
      * Param for the number of hash functions per hash table used in LSH AND-amplification.
      *
@@ -60,6 +52,14 @@ public interface LSHParams<T> extends LSHModelParams<T> {
                     "Number of hash functions per table.",
                     1,
                     ParamValidators.gtEq(1));
+
+    default int getNumHashTables() {
+        return get(NUM_HASH_TABLES);
+    }
+
+    default T setNumHashTables(Integer value) {
+        return set(NUM_HASH_TABLES, value);
+    }
 
     default int getNumHashFunctionsPerTable() {
         return get(NUM_HASH_FUNCTIONS_PER_TABLE);

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/LSHParams.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.lsh;
+
+import org.apache.flink.ml.common.param.HasInputCol;
+import org.apache.flink.ml.common.param.HasOutputCol;
+import org.apache.flink.ml.common.param.HasSeed;
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+
+/**
+ * Params for {@link LSH}.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface LSHParams<T> extends HasInputCol<T>, HasOutputCol<T>, HasSeed<T> {
+
+    /**
+     * Param for the number of hash tables used in LSH OR-amplification.
+     *
+     * <p>OR-amplification can be used to reduce the false negative rate. Higher values of this
+     * param lead to a reduced false negative rate, at the expense of added computational
+     * complexity.
+     */
+    Param<Integer> NUM_HASH_TABLES =
+            new IntParam("numHashTables", "Number of hash tables.", 1, ParamValidators.gtEq(1.));
+
+    default int getNumHashTables() {
+        return get(NUM_HASH_TABLES);
+    }
+
+    default T setNumHashTables(Integer value) {
+        return set(NUM_HASH_TABLES, value);
+    }
+
+    /**
+     * Param for the number of hash functions per hash table used in LSH AND-amplification.
+     *
+     * <p>AND-amplification can be used to reduce the false positive rate. Higher values of this
+     * param lead to a reduced false positive rate, at the expense of added computational
+     * complexity.
+     */
+    Param<Integer> NUM_HASH_FUNCTIONS_PER_TABLE =
+            new IntParam(
+                    "numHashFunctionsPerTable",
+                    "Number of hash functions per table.",
+                    1,
+                    ParamValidators.gtEq(1.));
+
+    default int getNumHashFunctionsPerTable() {
+        return get(NUM_HASH_FUNCTIONS_PER_TABLE);
+    }
+
+    default T setNumHashFunctionsPerTable(Integer value) {
+        return set(NUM_HASH_FUNCTIONS_PER_TABLE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSH.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSH.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  *
  * <p>The input could be dense or sparse vectors. Each input vector must have at least one non-zero
  * index and all non-zero values are treated as binary "1" values. The sizes of input vectors should
- * be same and not too large (not larger than a large prime 2038074743).
+ * be same and not larger than a predefined prime (i.e., 2038074743).
  *
  * <p>See: <a href="https://en.wikipedia.org/wiki/MinHash">MinHash</a>.
  */

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSH.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSH.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.ml.feature.lsh;
 
+import org.apache.flink.ml.common.param.HasSeed;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -33,7 +34,7 @@ import java.io.IOException;
  *
  * <p>See: <a href="https://en.wikipedia.org/wiki/MinHash">MinHash</a>.
  */
-public class MinHashLSH extends LSH<MinHashLSH, MinHashLSHModel> {
+public class MinHashLSH extends LSH<MinHashLSH, MinHashLSHModel> implements HasSeed<MinHashLSH> {
 
     @Override
     protected MinHashLSHModel createModel(

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSH.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSH.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * An Estimator that implements the MinHash LSH algorithm, which supports LSH for Jaccard distance.
  *
- * <p>The input could be dense or sparse vectors. Each input vector must hava at least one non-zero
+ * <p>The input could be dense or sparse vectors. Each input vector must have at least one non-zero
  * index and all non-zero values are treated as binary "1" values. The sizes of input vectors should
  * be same and not too large (not larger than a large prime 2038074743).
  *

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSH.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSH.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.ml.feature.lsh;
 
-import org.apache.flink.ml.common.param.HasSeed;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -34,7 +33,8 @@ import java.io.IOException;
  *
  * <p>See: <a href="https://en.wikipedia.org/wiki/MinHash">MinHash</a>.
  */
-public class MinHashLSH extends LSH<MinHashLSH, MinHashLSHModel> implements HasSeed<MinHashLSH> {
+public class MinHashLSH extends LSH<MinHashLSH, MinHashLSHModel>
+        implements MinHashLSHParams<MinHashLSH> {
 
     @Override
     protected MinHashLSHModel createModel(

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSH.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSH.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.lsh;
+
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+import java.io.IOException;
+
+/**
+ * An Estimator that implements the MinHash LSH algorithm, which supports LSH for Jaccard distance.
+ *
+ * <p>The input could be dense or sparse vectors. Each input vector must hava at least one non-zero
+ * index and all non-zero values are treated as binary "1" values. The sizes of input vectors should
+ * be same and not too large (not larger than a large prime 2038074743).
+ *
+ * <p>See: <a href="https://en.wikipedia.org/wiki/MinHash">MinHash</a>.
+ */
+public class MinHashLSH extends LSH<MinHashLSH, MinHashLSHModel> {
+
+    @Override
+    protected MinHashLSHModel createModel(
+            DataStream<Integer> inputDim, StreamTableEnvironment tEnv) {
+        DataStream<MinHashLSHModelData> modelData =
+                inputDim.map(
+                        dim ->
+                                MinHashLSHModelData.generateModelData(
+                                        getNumHashTables(),
+                                        getNumHashFunctionsPerTable(),
+                                        dim,
+                                        getSeed()));
+        MinHashLSHModel model = new MinHashLSHModel().setModelData(tEnv.fromDataStream(modelData));
+        ReadWriteUtils.updateExistingParams(model, getParamMap());
+        return model;
+    }
+
+    public static MinHashLSH load(StreamTableEnvironment tEnv, String path) throws IOException {
+        return ReadWriteUtils.loadStageParam(path);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSHModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSHModel.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.lsh;
+
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+
+import java.io.IOException;
+
+/** A Model which generates hash values using the model data computed by {@link MinHashLSH}. */
+public class MinHashLSHModel extends LSHModel<MinHashLSHModel> {
+
+    public MinHashLSHModel() {
+        super(MinHashLSHModelData.class);
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) modelDataTable).getTableEnvironment();
+
+        ReadWriteUtils.saveModelData(
+                tEnv.toDataStream(modelDataTable, MinHashLSHModelData.class),
+                path,
+                new MinHashLSHModelData.ModelDataEncoder());
+    }
+
+    /**
+     * Loads model data from path.
+     *
+     * @param tEnv A StreamTableEnvironment instance.
+     * @param path Model path.
+     * @return LSH model.
+     */
+    public static MinHashLSHModel load(StreamTableEnvironment tEnv, String path)
+            throws IOException {
+        MinHashLSHModel model = ReadWriteUtils.loadStageParam(path);
+        Table modelDataTable =
+                ReadWriteUtils.loadModelData(
+                        tEnv, path, new MinHashLSHModelData.ModelDataDecoder());
+        model.setModelData(modelDataTable);
+        return model;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSHModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSHModelData.java
@@ -45,7 +45,7 @@ import java.util.Random;
  */
 public class MinHashLSHModelData extends LSHModelData {
 
-    // A large prime smaller than sqrt(2^63 − 1)
+    // A large prime smaller than sqrt(2^63 − 1).
     private static final int HASH_PRIME = 2038074743;
 
     public int numHashTables;
@@ -128,8 +128,8 @@ public class MinHashLSHModelData extends LSHModelData {
         double[][] hashValues = new double[numHashTables][numHashFunctionsPerTable];
         for (int i = 0; i < numHashTables; i += 1) {
             for (int j = 0; j < numHashFunctionsPerTable; j += 1) {
-                // for each hash function, the hash value is computed by
-                // min(((1 + index) * randCoefficientA + randCoefficientB) % HASH_PRIME)
+                // For each hash function, the hash value is computed by
+                // min(((1 + index) * randCoefficientA + randCoefficientB) % HASH_PRIME).
                 int coeffA = randCoefficientA[i * numHashFunctionsPerTable + j];
                 int coeffB = randCoefficientB[i * numHashFunctionsPerTable + j];
                 long minv = HASH_PRIME;

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSHModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSHModelData.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.lsh;
+
+import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.array.IntPrimitiveArraySerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.reader.SimpleStreamFormat;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.util.Preconditions;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * Model data of {@link MinHashLSHModel}.
+ *
+ * <p>This class also provides classes to save/load model data.
+ */
+public class MinHashLSHModelData extends LSHModelData {
+
+    // A large prime smaller than sqrt(2^63 − 1)
+    private static final int HASH_PRIME = 2038074743;
+
+    public int numHashTables;
+    public int numHashFunctionsPerTable;
+    public int[] randCoefficientA;
+    public int[] randCoefficientB;
+
+    public MinHashLSHModelData() {}
+
+    public MinHashLSHModelData(
+            int numHashTables,
+            int numHashFunctionsPerTable,
+            int[] randCoefficientA,
+            int[] randCoefficientB) {
+        this.numHashTables = numHashTables;
+        this.numHashFunctionsPerTable = numHashFunctionsPerTable;
+        this.randCoefficientA = randCoefficientA;
+        this.randCoefficientB = randCoefficientB;
+    }
+
+    public static MinHashLSHModelData generateModelData(
+            int numHashTables, int numHashFunctionsPerTable, int dim, long seed) {
+        Preconditions.checkArgument(
+                dim <= HASH_PRIME,
+                "The input vector dimension %d exceeds the threshold %s.",
+                dim,
+                HASH_PRIME);
+
+        Random random = new Random(seed);
+        int numHashFunctions = numHashTables * numHashFunctionsPerTable;
+        int[] randCoeffA = new int[numHashFunctions];
+        int[] randCoeffB = new int[numHashFunctions];
+        for (int i = 0; i < numHashFunctions; i += 1) {
+            randCoeffA[i] = 1 + random.nextInt(HASH_PRIME - 1);
+            randCoeffB[i] = random.nextInt(HASH_PRIME - 1);
+        }
+        return new MinHashLSHModelData(
+                numHashTables, numHashFunctionsPerTable, randCoeffA, randCoeffB);
+    }
+
+    static class ModelDataDecoder extends SimpleStreamFormat<MinHashLSHModelData> {
+        @Override
+        public Reader<MinHashLSHModelData> createReader(
+                Configuration configuration, FSDataInputStream fsDataInputStream)
+                throws IOException {
+            return new Reader<MinHashLSHModelData>() {
+                @Override
+                public MinHashLSHModelData read() throws IOException {
+                    try {
+                        DataInputViewStreamWrapper source =
+                                new DataInputViewStreamWrapper(fsDataInputStream);
+                        int numHashTables = IntSerializer.INSTANCE.deserialize(source);
+                        int numHashFunctionsPerTable = IntSerializer.INSTANCE.deserialize(source);
+                        int[] randCoeffA = IntPrimitiveArraySerializer.INSTANCE.deserialize(source);
+                        int[] randCoeffB = IntPrimitiveArraySerializer.INSTANCE.deserialize(source);
+                        return new MinHashLSHModelData(
+                                numHashTables, numHashFunctionsPerTable, randCoeffA, randCoeffB);
+                    } catch (EOFException e) {
+                        return null;
+                    }
+                }
+
+                @Override
+                public void close() throws IOException {
+                    fsDataInputStream.close();
+                }
+            };
+        }
+
+        @Override
+        public TypeInformation<MinHashLSHModelData> getProducedType() {
+            return TypeInformation.of(MinHashLSHModelData.class);
+        }
+    }
+
+    @Override
+    public DenseVector[] hashFunction(Vector vec) {
+        int[] indices = vec.toSparse().indices;
+        Preconditions.checkArgument(indices.length > 0, "Must have at least 1 non zero entry.");
+        double[][] hashValues = new double[numHashTables][numHashFunctionsPerTable];
+        for (int i = 0; i < numHashTables; i += 1) {
+            for (int j = 0; j < numHashFunctionsPerTable; j += 1) {
+                // for each hash function, the hash value is computed by
+                // min(((1 + index) * randCoefficientA + randCoefficientB) % HASH_PRIME)
+                int coeffA = randCoefficientA[i * numHashFunctionsPerTable + j];
+                int coeffB = randCoefficientB[i * numHashFunctionsPerTable + j];
+                long minv = HASH_PRIME;
+                for (int index : indices) {
+                    minv = Math.min(minv, ((1L + index) * coeffA + coeffB) % HASH_PRIME);
+                }
+                hashValues[i][j] = minv;
+            }
+        }
+        return Arrays.stream(hashValues).map(DenseVector::new).toArray(DenseVector[]::new);
+    }
+
+    @Override
+    public double keyDistance(Vector x, Vector y) {
+        int[] xIndices = x.toSparse().indices;
+        int[] yIndices = y.toSparse().indices;
+        Preconditions.checkArgument(
+                xIndices.length + yIndices.length > 0,
+                "The union of two input sets must have at least 1 elements");
+        int px = 0, py = 0;
+        int intersectionSize = 0;
+        while (px < xIndices.length && py < yIndices.length) {
+            if (xIndices[px] == yIndices[py]) {
+                intersectionSize += 1;
+                px += 1;
+                py += 1;
+            } else if (xIndices[px] < yIndices[py]) {
+                px += 1;
+            } else {
+                py += 1;
+            }
+        }
+        int unionSize = xIndices.length + yIndices.length - intersectionSize;
+        return 1. - 1. * intersectionSize / unionSize;
+    }
+
+    /** Encoder for {@link MinHashLSHModelData}. */
+    public static class ModelDataEncoder implements Encoder<MinHashLSHModelData> {
+
+        @Override
+        public void encode(MinHashLSHModelData modelData, OutputStream outputStream)
+                throws IOException {
+            DataOutputView dataOutputView = new DataOutputViewStreamWrapper(outputStream);
+            IntSerializer.INSTANCE.serialize(modelData.numHashTables, dataOutputView);
+            IntSerializer.INSTANCE.serialize(modelData.numHashFunctionsPerTable, dataOutputView);
+            IntPrimitiveArraySerializer.INSTANCE.serialize(
+                    modelData.randCoefficientA, dataOutputView);
+            IntPrimitiveArraySerializer.INSTANCE.serialize(
+                    modelData.randCoefficientB, dataOutputView);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSHParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/lsh/MinHashLSHParams.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature.lsh;
+
+import org.apache.flink.ml.common.param.HasSeed;
+
+/**
+ * Params for {@link MinHashLSH}.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface MinHashLSHParams<T> extends LSHParams<T>, HasSeed<T> {}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/MinHashLSHTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/MinHashLSHTest.java
@@ -1,0 +1,440 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.feature;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.feature.lsh.MinHashLSH;
+import org.apache.flink.ml.feature.lsh.MinHashLSHModel;
+import org.apache.flink.ml.feature.lsh.MinHashLSHModelData;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.SparseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.TestUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Tests {@link MinHashLSH} and {@link MinHashLSHModel}. */
+public class MinHashLSHTest extends AbstractTestBase {
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+    private StreamExecutionEnvironment env;
+    private StreamTableEnvironment tEnv;
+
+    /**
+     * Default case for most tests.
+     *
+     * @return a tuple including the estimator, input data table, and output rows.
+     */
+    private Tuple3<MinHashLSH, Table, List<Row>> getDefaultCase() {
+        MinHashLSH lsh =
+                new MinHashLSH()
+                        .setInputCol("vec")
+                        .setOutputCol("hashes")
+                        .setSeed(2022L)
+                        .setNumHashTables(5)
+                        .setNumHashFunctionsPerTable(3);
+
+        List<Row> inputRows =
+                Arrays.asList(
+                        Row.of(
+                                0,
+                                Vectors.sparse(6, new int[] {0, 1, 2}, new double[] {1., 1., 1.})),
+                        Row.of(
+                                1,
+                                Vectors.sparse(6, new int[] {2, 3, 4}, new double[] {1., 1., 1.})),
+                        Row.of(
+                                2,
+                                Vectors.sparse(6, new int[] {0, 2, 4}, new double[] {1., 1., 1.})));
+
+        Schema schema =
+                Schema.newBuilder()
+                        .column("f0", DataTypes.INT())
+                        .column("f1", DataTypes.of(SparseVector.class))
+                        .build();
+        DataStream<Row> dataStream = env.fromCollection(inputRows);
+        Table inputTable = tEnv.fromDataStream(dataStream, schema).as("id", "vec");
+
+        List<Row> outputRows =
+                convertToOutputFormat(
+                        Arrays.asList(
+                                new double[][] {
+                                    {1.73046954E8, 1.57275425E8, 6.90717571E8},
+                                    {5.02301169E8, 7.967141E8, 4.06089319E8},
+                                    {2.83652171E8, 1.97714719E8, 6.04731316E8},
+                                    {5.2181506E8, 6.36933726E8, 6.13894128E8},
+                                    {3.04301769E8, 1.113672955E9, 6.1388711E8}
+                                },
+                                new double[][] {
+                                    {1.73046954E8, 1.57275425E8, 6.7798584E7},
+                                    {6.38582806E8, 1.78703694E8, 4.06089319E8},
+                                    {6.232638E8, 9.28867E7, 9.92010642E8},
+                                    {2.461064E8, 1.12787481E8, 1.92180297E8},
+                                    {2.38162496E8, 1.552933319E9, 2.77995137E8}
+                                },
+                                new double[][] {
+                                    {1.73046954E8, 1.57275425E8, 6.90717571E8},
+                                    {1.453197722E9, 7.967141E8, 4.06089319E8},
+                                    {6.232638E8, 1.97714719E8, 6.04731316E8},
+                                    {2.461064E8, 1.12787481E8, 1.92180297E8},
+                                    {1.224130231E9, 1.113672955E9, 2.77995137E8}
+                                }));
+
+        return Tuple3.of(lsh, inputTable, outputRows);
+    }
+
+    @Before
+    public void before() {
+        Configuration config = new Configuration();
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.getConfig().enableObjectReuse();
+        env.setParallelism(4);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        tEnv = StreamTableEnvironment.create(env);
+    }
+
+    /**
+     * Convert a list of 2d double arrays to a list of rows with each of which containing a
+     * DenseVector array.
+     */
+    private static List<Row> convertToOutputFormat(List<double[][]> arrays) {
+        return arrays.stream()
+                .map(
+                        array -> {
+                            DenseVector[] denseVectors =
+                                    Arrays.stream(array)
+                                            .map(Vectors::dense)
+                                            .toArray(DenseVector[]::new);
+                            return Row.of((Object) denseVectors);
+                        })
+                .collect(Collectors.toList());
+    }
+
+    private static class DenseVectorArrayComparator implements Comparator<DenseVector[]> {
+        @Override
+        public int compare(DenseVector[] o1, DenseVector[] o2) {
+            if (o1.length != o2.length) {
+                return o1.length - o2.length;
+            }
+            for (int i = 0; i < o1.length; i += 1) {
+                int cmp = TestUtils.compare(o1[i], o2[i]);
+                if (0 != cmp) {
+                    return cmp;
+                }
+            }
+            return 0;
+        }
+    }
+
+    private static void verifyPredictionResult(Table output, List<Row> expected) throws Exception {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) output).getTableEnvironment();
+        List<Row> results = IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
+        compareResultCollections(
+                expected,
+                results,
+                (d0, d1) -> {
+                    DenseVectorArrayComparator denseVectorArrayComparator =
+                            new DenseVectorArrayComparator();
+                    return denseVectorArrayComparator.compare(d0.getFieldAs(0), d1.getFieldAs(0));
+                });
+    }
+
+    @Test
+    public void testHashFunction() {
+        MinHashLSHModelData lshModelData =
+                new MinHashLSHModelData(3, 1, new int[] {0, 1, 3}, new int[] {1, 2, 0});
+        Vector vec = Vectors.sparse(10, new int[] {2, 3, 5, 7}, new double[] {1., 1., 1., 1.});
+        DenseVector[] result = lshModelData.hashFunction(vec);
+        Assert.assertEquals(3, result.length);
+        Assert.assertEquals(Vectors.dense(1.), result[0]);
+        Assert.assertEquals(Vectors.dense(5.), result[1]);
+        Assert.assertEquals(Vectors.dense(9.), result[2]);
+    }
+
+    @Test
+    public void testHashFunctionEqualWithSparseDenseVector() {
+        // Use randomly generate coefficients, so that the hash values are not always from the least
+        // non-zero index.
+        MinHashLSHModelData lshModelData = MinHashLSHModelData.generateModelData(3, 1, 10, 2022L);
+        new MinHashLSHModelData(3, 1, new int[] {0, 1, 3}, new int[] {1, 2, 0});
+        Vector vec = Vectors.sparse(10, new int[] {2, 3, 5, 7}, new double[] {1., 1., 1., 1.});
+        DenseVector[] denseResults = lshModelData.hashFunction(vec.toDense());
+        DenseVector[] sparseResults = lshModelData.hashFunction(vec.toSparse());
+        Assert.assertArrayEquals(denseResults, sparseResults);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHashFunctionWithEmptyVector() {
+        MinHashLSHModelData lshModelData =
+                new MinHashLSHModelData(3, 1, new int[] {0, 1, 3}, new int[] {1, 2, 0});
+        Vector vec = Vectors.sparse(10, new int[] {}, new double[] {});
+        lshModelData.hashFunction(vec);
+    }
+
+    @Test
+    public void testParam() {
+        MinHashLSH lsh = new MinHashLSH();
+        Assert.assertEquals("input", lsh.getInputCol());
+        Assert.assertEquals("output", lsh.getOutputCol());
+        Assert.assertEquals(MinHashLSH.class.getName().hashCode(), lsh.getSeed());
+        Assert.assertEquals(1, lsh.getNumHashTables());
+        Assert.assertEquals(1, lsh.getNumHashFunctionsPerTable());
+        lsh.setInputCol("vec")
+                .setOutputCol("hashes")
+                .setSeed(2022L)
+                .setNumHashTables(3)
+                .setNumHashFunctionsPerTable(4);
+        Assert.assertEquals("vec", lsh.getInputCol());
+        Assert.assertEquals("hashes", lsh.getOutputCol());
+        Assert.assertEquals(2022L, lsh.getSeed());
+        Assert.assertEquals(3, lsh.getNumHashTables());
+        Assert.assertEquals(4, lsh.getNumHashFunctionsPerTable());
+    }
+
+    @Test
+    public void testOutputSchema() throws Exception {
+        Tuple3<MinHashLSH, Table, List<Row>> defaultCase = getDefaultCase();
+        MinHashLSH lsh = defaultCase.f0;
+        Table data = defaultCase.f1;
+        MinHashLSHModel model = lsh.fit(data);
+        Table output = model.transform(data)[0];
+        Assert.assertEquals(
+                Arrays.asList("id", "vec", "hashes"), output.getResolvedSchema().getColumnNames());
+    }
+
+    @Test
+    public void testFitAndPredict() throws Exception {
+        Tuple3<MinHashLSH, Table, List<Row>> defaultCase = getDefaultCase();
+        MinHashLSH lsh = defaultCase.f0;
+        Table data = defaultCase.f1;
+        List<Row> expected = defaultCase.f2;
+
+        MinHashLSHModel lshModel = lsh.fit(data);
+        Table output = lshModel.transform(data)[0].select($(lsh.getOutputCol()));
+        verifyPredictionResult(output, expected);
+    }
+
+    @Test
+    public void testFitAndPredictWithNumHashFunctionPerTableIsOne() throws Exception {
+        // when numHashFunctionPerTable = 1 and other parameters are same, the results should be the
+        // same with SparkML.
+        final List<Row> expected =
+                convertToOutputFormat(
+                        Arrays.asList(
+                                new double[][] {
+                                    {1.73046954E8},
+                                    {1.57275425E8},
+                                    {6.7798584E7},
+                                    {6.38582806E8},
+                                    {1.78703694E8}
+                                },
+                                new double[][] {
+                                    {1.73046954E8},
+                                    {1.57275425E8},
+                                    {6.90717571E8},
+                                    {5.02301169E8},
+                                    {7.967141E8}
+                                },
+                                new double[][] {
+                                    {1.73046954E8},
+                                    {1.57275425E8},
+                                    {6.90717571E8},
+                                    {1.453197722E9},
+                                    {7.967141E8}
+                                }));
+        // only use the input table
+        Table data = getDefaultCase().f1;
+        MinHashLSH lsh =
+                new MinHashLSH()
+                        .setInputCol("vec")
+                        .setOutputCol("hashes")
+                        .setSeed(2022L)
+                        .setNumHashTables(5);
+        MinHashLSHModel lshModel = lsh.fit(data);
+        Table output = lshModel.transform(data)[0].select($(lsh.getOutputCol()));
+        verifyPredictionResult(output, expected);
+    }
+
+    @Test
+    public void testEstimatorSaveLoadAndPredict() throws Exception {
+        Tuple3<MinHashLSH, Table, List<Row>> defaultCase = getDefaultCase();
+        MinHashLSH lsh = defaultCase.f0;
+        Table data = defaultCase.f1;
+        List<Row> expected = defaultCase.f2;
+
+        MinHashLSH loadedLsh =
+                TestUtils.saveAndReload(tEnv, lsh, tempFolder.newFolder().getAbsolutePath());
+        MinHashLSHModel lshModel = loadedLsh.fit(data);
+        Assert.assertEquals(
+                Arrays.asList(
+                        "numHashTables",
+                        "numHashFunctionsPerTable",
+                        "randCoefficientA",
+                        "randCoefficientB"),
+                lshModel.getModelData()[0].getResolvedSchema().getColumnNames());
+        Table output = lshModel.transform(data)[0].select($(lsh.getOutputCol()));
+        verifyPredictionResult(output, expected);
+    }
+
+    @Test
+    public void testModelSaveLoadAndPredict() throws Exception {
+        Tuple3<MinHashLSH, Table, List<Row>> defaultCase = getDefaultCase();
+        MinHashLSH lsh = defaultCase.f0;
+        Table data = defaultCase.f1;
+        List<Row> expected = defaultCase.f2;
+
+        MinHashLSHModel lshModel = lsh.fit(data);
+        MinHashLSHModel loadedModel =
+                TestUtils.saveAndReload(tEnv, lshModel, tempFolder.newFolder().getAbsolutePath());
+        Table output = loadedModel.transform(data)[0].select($(lsh.getOutputCol()));
+        verifyPredictionResult(output, expected);
+    }
+
+    @Test
+    public void testGetModelData() throws Exception {
+        Tuple3<MinHashLSH, Table, List<Row>> defaultCase = getDefaultCase();
+        MinHashLSH lsh = defaultCase.f0;
+        Table data = defaultCase.f1;
+
+        MinHashLSHModel lshModel = lsh.fit(data);
+        Table modelDataTable = lshModel.getModelData()[0];
+        List<String> modelDataColumnNames = modelDataTable.getResolvedSchema().getColumnNames();
+        DataStream<Row> output = tEnv.toDataStream(modelDataTable);
+        Assert.assertArrayEquals(
+                new String[] {
+                    "numHashTables",
+                    "numHashFunctionsPerTable",
+                    "randCoefficientA",
+                    "randCoefficientB"
+                },
+                modelDataColumnNames.toArray(new String[0]));
+
+        Row modelDataRow = (Row) IteratorUtils.toList(output.executeAndCollect()).get(0);
+        MinHashLSHModelData modelData =
+                new MinHashLSHModelData(
+                        modelDataRow.getFieldAs(0),
+                        modelDataRow.getFieldAs(1),
+                        modelDataRow.getFieldAs(2),
+                        modelDataRow.getFieldAs(3));
+        Assert.assertNotNull(modelData);
+        Assert.assertEquals(lsh.getNumHashTables(), modelData.numHashTables);
+        Assert.assertEquals(lsh.getNumHashFunctionsPerTable(), modelData.numHashFunctionsPerTable);
+        Assert.assertEquals(
+                lsh.getNumHashTables() * lsh.getNumHashFunctionsPerTable(),
+                modelData.randCoefficientA.length);
+        Assert.assertEquals(
+                lsh.getNumHashTables() * lsh.getNumHashFunctionsPerTable(),
+                modelData.randCoefficientB.length);
+    }
+
+    @Test
+    public void testSetModelData() throws Exception {
+        Tuple3<MinHashLSH, Table, List<Row>> defaultCase = getDefaultCase();
+        MinHashLSH lsh = defaultCase.f0;
+        Table data = defaultCase.f1;
+        List<Row> expected = defaultCase.f2;
+
+        MinHashLSHModel modelA = lsh.fit(data);
+        Table modelDataData = modelA.getModelData()[0];
+        MinHashLSHModel modelB = new MinHashLSHModel().setModelData(modelDataData);
+        ReadWriteUtils.updateExistingParams(modelB, modelA.getParamMap());
+        Table output = modelB.transform(data)[0].select($(lsh.getOutputCol()));
+        verifyPredictionResult(output, expected);
+    }
+
+    @Test
+    public void testApproxNearestNeighbors() {
+        Tuple3<MinHashLSH, Table, List<Row>> defaultCase = getDefaultCase();
+        MinHashLSH lsh = defaultCase.f0.setNumHashFunctionsPerTable(1);
+        Table data = defaultCase.f1;
+        MinHashLSHModel lshModel = lsh.fit(data);
+        List<Row> expected = Arrays.asList(Row.of(0, .75), Row.of(1, .75));
+
+        Vector key = Vectors.sparse(6, new int[] {1, 3}, new double[] {1.0, 1.0});
+        Table output = lshModel.approxNearestNeighbors(data, key, 2).select($("id"), $("distCol"));
+        List<Row> results = IteratorUtils.toList(output.execute().collect());
+        compareResultCollections(expected, results, Comparator.comparing(r -> r.getFieldAs(0)));
+    }
+
+    @Test
+    public void testApproxSimilarityJoin() {
+        Tuple3<MinHashLSH, Table, List<Row>> defaultCase = getDefaultCase();
+        MinHashLSH lsh = defaultCase.f0.setNumHashFunctionsPerTable(1);
+        Table dataA = defaultCase.f1;
+        MinHashLSHModel lshModel = lsh.fit(dataA);
+
+        List<Row> inputRowsB =
+                Arrays.asList(
+                        Row.of(
+                                3,
+                                Vectors.sparse(6, new int[] {1, 3, 5}, new double[] {1., 1., 1.})),
+                        Row.of(
+                                4,
+                                Vectors.sparse(6, new int[] {2, 3, 5}, new double[] {1., 1., 1.})),
+                        Row.of(
+                                5,
+                                Vectors.sparse(6, new int[] {1, 2, 4}, new double[] {1., 1., 1.})));
+        Schema schema =
+                Schema.newBuilder()
+                        .column("f0", DataTypes.INT())
+                        .column("f1", DataTypes.of(SparseVector.class))
+                        .build();
+        Table dataB = tEnv.fromDataStream(env.fromCollection(inputRowsB), schema).as("id", "vec");
+
+        List<Row> expected =
+                Arrays.asList(
+                        Row.of(1, 4, 0.5), Row.of(0, 5, 0.5), Row.of(1, 5, 0.5), Row.of(2, 5, 0.5));
+
+        Table output = lshModel.approxSimilarityJoin(dataA, dataB, .6, "id");
+        List<Row> results = IteratorUtils.toList(output.execute().collect());
+        compareResultCollections(
+                expected,
+                results,
+                Comparator.<Row>comparingInt(r -> r.getFieldAs(0))
+                        .thenComparingInt(r -> r.getFieldAs(1))
+                        .thenComparingDouble(r -> r.getFieldAs(2)));
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/MinHashLSHTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/MinHashLSHTest.java
@@ -163,8 +163,8 @@ public class MinHashLSHTest extends AbstractTestBase {
 
     @Test
     public void testHashFunctionEqualWithSparseDenseVector() {
-        // Use randomly generate coefficients, so that the hash values are not always from the least
-        // non-zero index.
+        // Uses randomly generate coefficients, so that the hash values are not always from the
+        // least non-zero index.
         MinHashLSHModelData lshModelData = MinHashLSHModelData.generateModelData(3, 1, 10, 2022L);
         new MinHashLSHModelData(3, 1, new int[] {0, 1, 3}, new int[] {1, 2, 0});
         Vector vec = Vectors.sparse(10, new int[] {2, 3, 5, 7}, new double[] {1., 1., 1., 1.});

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/MinHashLSHTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/MinHashLSHTest.java
@@ -86,7 +86,7 @@ public class MinHashLSHTest extends AbstractTestBase {
     private Table inputTable;
 
     /**
-     * Convert a list of 2d double arrays to a list of rows with each of which containing a
+     * Converts a list of 2d double arrays to a list of rows with each of which containing a
      * DenseVector array.
      */
     private static List<Row> convertToOutputFormat(List<double[][]> arrays) {
@@ -232,7 +232,7 @@ public class MinHashLSHTest extends AbstractTestBase {
 
     @Test
     public void testFitAndPredictWithNumHashFunctionPerTableIsOne() throws Exception {
-        // when numHashFunctionPerTable = 1 and other parameters are same, the results should be the
+        // When numHashFunctionPerTable = 1 and other parameters are same, the results should be the
         // same with SparkML.
         final List<Row> expected =
                 convertToOutputFormat(
@@ -258,7 +258,6 @@ public class MinHashLSHTest extends AbstractTestBase {
                                     {1.453197722E9},
                                     {7.967141E8}
                                 }));
-        // only use the input table
         MinHashLSH lsh =
                 new MinHashLSH()
                         .setInputCol("vec")

--- a/flink-ml-python/pyflink/examples/ml/feature/minhashlsh_example.py
+++ b/flink-ml-python/pyflink/examples/ml/feature/minhashlsh_example.py
@@ -1,0 +1,83 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Simple program that trains a MinHashLSH model and uses it for approximate nearest neighbors
+# and similarity join.
+
+
+from pyflink.common import Types
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.table import StreamTableEnvironment
+
+from pyflink.ml.core.linalg import Vectors, SparseVectorTypeInfo
+from pyflink.ml.lib.feature.lsh import MinHashLSH
+
+# Creates a new StreamExecutionEnvironment
+env = StreamExecutionEnvironment.get_execution_environment()
+
+# Creates a StreamTableEnvironment
+t_env = StreamTableEnvironment.create(env)
+
+# Generates two datasets
+data = t_env.from_data_stream(
+    env.from_collection([
+        (0, Vectors.sparse(6, [0, 1, 2], [1., 1., 1.])),
+        (1, Vectors.sparse(6, [2, 3, 4], [1., 1., 1.])),
+        (2, Vectors.sparse(6, [0, 2, 4], [1., 1., 1.])),
+    ], type_info=Types.ROW_NAMED(['id', 'vec'], [Types.INT(), SparseVectorTypeInfo()])))
+
+data_b = t_env.from_data_stream(
+    env.from_collection([
+        (3, Vectors.sparse(6, [1, 3, 5], [1., 1., 1.])),
+        (4, Vectors.sparse(6, [2, 3, 5], [1., 1., 1.])),
+        (5, Vectors.sparse(6, [1, 2, 4], [1., 1., 1.])),
+    ], type_info=Types.ROW_NAMED(['id', 'vec'], [Types.INT(), SparseVectorTypeInfo()])))
+
+# Creates a MinHashLSH estimator object and initializes its parameters
+lsh = MinHashLSH() \
+    .set_input_col('vec') \
+    .set_output_col('hashes') \
+    .set_seed(2022) \
+    .set_num_hash_tables(5)
+
+# Trains the MinHashLSH model
+model = lsh.fit(data)
+
+# Uses the MinHashLSH model for transformation
+output = model.transform(data)[0]
+
+# Extracts and displays the results
+field_names = output.get_schema().get_field_names()
+for result in t_env.to_data_stream(output).execute_and_collect():
+    input_value = result[field_names.index(lsh.get_input_col())]
+    output_value = result[field_names.index(lsh.get_output_col())]
+    print(f'Vector: {input_value} \tHash Values: {output_value}')
+
+# Finds approximate nearest neighbors of the key
+key = Vectors.sparse(6, [1, 3], [1., 1.])
+output = model.approx_nearest_neighbors(data, key, 2).select("id, distCol")
+for result in t_env.to_data_stream(output).execute_and_collect():
+    id_value = result[field_names.index("id")]
+    dist_value = result[-1]
+    print(f'ID: {id_value} \tDistance: {dist_value}')
+
+# Approximately finds pairs from two datasets with distances smaller than the threshold
+output = model.approx_similarity_join(data, data_b, .6, "id")
+for result in t_env.to_data_stream(output).execute_and_collect():
+    id_a_value, id_b_value, dist_value = result
+    print(f'ID from left: {id_a_value} \tID from right: {id_b_value} \t Distance: {dist_value}')

--- a/flink-ml-python/pyflink/examples/ml/feature/minhashlsh_example.py
+++ b/flink-ml-python/pyflink/examples/ml/feature/minhashlsh_example.py
@@ -34,7 +34,7 @@ env = StreamExecutionEnvironment.get_execution_environment()
 t_env = StreamTableEnvironment.create(env)
 
 # Generates two datasets
-data = t_env.from_data_stream(
+data_a = t_env.from_data_stream(
     env.from_collection([
         (0, Vectors.sparse(6, [0, 1, 2], [1., 1., 1.])),
         (1, Vectors.sparse(6, [2, 3, 4], [1., 1., 1.])),
@@ -56,10 +56,10 @@ lsh = MinHashLSH() \
     .set_num_hash_tables(5)
 
 # Trains the MinHashLSH model
-model = lsh.fit(data)
+model = lsh.fit(data_a)
 
 # Uses the MinHashLSH model for transformation
-output = model.transform(data)[0]
+output = model.transform(data_a)[0]
 
 # Extracts and displays the results
 field_names = output.get_schema().get_field_names()
@@ -70,14 +70,14 @@ for result in t_env.to_data_stream(output).execute_and_collect():
 
 # Finds approximate nearest neighbors of the key
 key = Vectors.sparse(6, [1, 3], [1., 1.])
-output = model.approx_nearest_neighbors(data, key, 2).select("id, distCol")
+output = model.approx_nearest_neighbors(data_a, key, 2).select("id, distCol")
 for result in t_env.to_data_stream(output).execute_and_collect():
     id_value = result[field_names.index("id")]
     dist_value = result[-1]
     print(f'ID: {id_value} \tDistance: {dist_value}')
 
 # Approximately finds pairs from two datasets with distances smaller than the threshold
-output = model.approx_similarity_join(data, data_b, .6, "id")
+output = model.approx_similarity_join(data_a, data_b, .6, "id")
 for result in t_env.to_data_stream(output).execute_and_collect():
     id_a_value, id_b_value, dist_value = result
     print(f'ID from left: {id_a_value} \tID from right: {id_b_value} \t Distance: {dist_value}')

--- a/flink-ml-python/pyflink/examples/ml/feature/minhashlsh_example.py
+++ b/flink-ml-python/pyflink/examples/ml/feature/minhashlsh_example.py
@@ -26,13 +26,13 @@ from pyflink.table import StreamTableEnvironment
 from pyflink.ml.core.linalg import Vectors, SparseVectorTypeInfo
 from pyflink.ml.lib.feature.lsh import MinHashLSH
 
-# Creates a new StreamExecutionEnvironment
+# Creates a new StreamExecutionEnvironment.
 env = StreamExecutionEnvironment.get_execution_environment()
 
-# Creates a StreamTableEnvironment
+# Creates a StreamTableEnvironment.
 t_env = StreamTableEnvironment.create(env)
 
-# Generates two datasets
+# Generates two datasets.
 data_a = t_env.from_data_stream(
     env.from_collection([
         (0, Vectors.sparse(6, [0, 1, 2], [1., 1., 1.])),
@@ -47,27 +47,27 @@ data_b = t_env.from_data_stream(
         (5, Vectors.sparse(6, [1, 2, 4], [1., 1., 1.])),
     ], type_info=Types.ROW_NAMED(['id', 'vec'], [Types.INT(), SparseVectorTypeInfo()])))
 
-# Creates a MinHashLSH estimator object and initializes its parameters
+# Creates a MinHashLSH estimator object and initializes its parameters.
 lsh = MinHashLSH() \
     .set_input_col('vec') \
     .set_output_col('hashes') \
     .set_seed(2022) \
     .set_num_hash_tables(5)
 
-# Trains the MinHashLSH model
+# Trains the MinHashLSH model.
 model = lsh.fit(data_a)
 
-# Uses the MinHashLSH model for transformation
+# Uses the MinHashLSH model for transformation.
 output = model.transform(data_a)[0]
 
-# Extracts and displays the results
+# Extracts and displays the results.
 field_names = output.get_schema().get_field_names()
 for result in t_env.to_data_stream(output).execute_and_collect():
     input_value = result[field_names.index(lsh.get_input_col())]
     output_value = result[field_names.index(lsh.get_output_col())]
     print(f'Vector: {input_value} \tHash Values: {output_value}')
 
-# Finds approximate nearest neighbors of the key
+# Finds approximate nearest neighbors of the key.
 key = Vectors.sparse(6, [1, 3], [1., 1.])
 output = model.approx_nearest_neighbors(data_a, key, 2).select("id, distCol")
 for result in t_env.to_data_stream(output).execute_and_collect():
@@ -75,7 +75,7 @@ for result in t_env.to_data_stream(output).execute_and_collect():
     dist_value = result[-1]
     print(f'ID: {id_value} \tDistance: {dist_value}')
 
-# Approximately finds pairs from two datasets with distances smaller than the threshold
+# Approximately finds pairs from two datasets with distances smaller than the threshold.
 output = model.approx_similarity_join(data_a, data_b, .6, "id")
 for result in t_env.to_data_stream(output).execute_and_collect():
     id_a_value, id_b_value, dist_value = result

--- a/flink-ml-python/pyflink/examples/ml/feature/minhashlsh_example.py
+++ b/flink-ml-python/pyflink/examples/ml/feature/minhashlsh_example.py
@@ -19,7 +19,6 @@
 # Simple program that trains a MinHashLSH model and uses it for approximate nearest neighbors
 # and similarity join.
 
-
 from pyflink.common import Types
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.table import StreamTableEnvironment

--- a/flink-ml-python/pyflink/ml/lib/feature/lsh.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/lsh.py
@@ -107,7 +107,7 @@ class _LSHModel(JavaFeatureModel, ABC):
     def approx_nearest_neighbors(self, dataset: Table, key: Vector, k: int,
                                  dist_col: str = 'distCol'):
         """
-        Given a dataset and an item, approximately find at most k items which have the closest
+        Given a dataset and an item, approximately finds at most k items that have the closest
         distance to the item. If the `outputCol` is missing in the given dataset, this method
         transforms the dataset with the model at first.
 

--- a/flink-ml-python/pyflink/ml/lib/feature/lsh.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/lsh.py
@@ -79,6 +79,11 @@ class _LSHParams(_LSHModelParams):
         return self.get_num_hash_functions_per_table()
 
 
+class _MinHashLSHParams(_LSHParams, HasSeed):
+    def __init__(self, java_params):
+        super(_MinHashLSHParams, self).__init__(java_params)
+
+
 class _LSH(JavaFeatureEstimator, ABC):
     """
     Base class for estimators which implement LSH (Locality-sensitive hashing) algorithms.
@@ -170,7 +175,7 @@ class MinHashLSHModel(_LSHModel, _LSHModelParams):
         return "MinHashLSHModel"
 
 
-class MinHashLSH(_LSH, _LSHParams, HasSeed):
+class MinHashLSH(_LSH, _MinHashLSHParams):
     """
     An Estimator which implements the MinHash LSH algorithm, with Jaccard distance as its distance
     metric.

--- a/flink-ml-python/pyflink/ml/lib/feature/lsh.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/lsh.py
@@ -139,7 +139,7 @@ class _LSHModel(JavaFeatureModel, ABC):
     def approx_similarity_join(self, dataset_a: Table, dataset_b: Table, threshold: float,
                                id_col: str, dist_col: str = 'distCol'):
         """
-        Join two datasets to approximately find all pairs of rows whose distance are smaller
+        Joins two datasets to approximately find all pairs of rows whose distances are smaller
         than or equal to the threshold. If the `outputCol` is missing in either dataset, this
         method transforms the dataset at first.
 

--- a/flink-ml-python/pyflink/ml/lib/feature/lsh.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/lsh.py
@@ -1,0 +1,191 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+import typing
+from abc import ABC
+from pyflink.java_gateway import get_gateway
+from pyflink.table import Table
+from pyflink.util.java_utils import to_jarray
+
+from pyflink.ml.core.linalg import Vector, DenseVector, SparseVector
+from pyflink.ml.core.param import Param, IntParam, ParamValidators
+from pyflink.ml.core.wrapper import JavaWithParams
+from pyflink.ml.lib.feature.common import JavaFeatureEstimator, JavaFeatureModel
+from pyflink.ml.lib.param import HasInputCol, HasOutputCol, HasSeed
+
+
+class _LSHParams(
+    JavaWithParams,
+    HasInputCol,
+    HasOutputCol,
+    HasSeed
+):
+    """
+    Params for :class:`LSH`
+    """
+
+    NUM_HASH_TABLES: Param[int] = IntParam(
+        "num_hash_tables", "Number of hash tables.", 1, ParamValidators.gt_eq(1)
+    )
+
+    NUM_HASH_FUNCTIONS_PER_TABLE: Param[int] = IntParam(
+        "num_hash_functions_per_table",
+        "Number of hash functions per table.",
+        1,
+        ParamValidators.gt_eq(1.))
+
+    def __init__(self, java_params):
+        super(_LSHParams, self).__init__(java_params)
+
+    def set_num_hash_tables(self, value: int):
+        return typing.cast(_LSHParams, self.set(self.NUM_HASH_TABLES, value))
+
+    def get_num_hash_tables(self):
+        return self.get(self.NUM_HASH_TABLES)
+
+    @property
+    def num_hash_tables(self):
+        return self.get_num_hash_tables()
+
+    def set_num_hash_functions_per_table(self, value: int):
+        return typing.cast(_LSHParams, self.set(self.NUM_HASH_FUNCTIONS_PER_TABLE, value))
+
+    def get_num_hash_functions_per_table(self):
+        return self.get(self.NUM_HASH_FUNCTIONS_PER_TABLE)
+
+    @property
+    def num_hash_functions_per_table(self):
+        return self.get_num_hash_functions_per_table()
+
+
+class _LSHModelParams(JavaWithParams,
+                      HasInputCol,
+                      HasOutputCol):
+    ...
+
+
+class _LSH(JavaFeatureEstimator, ABC):
+    """
+    Base class for estimators which implement LSH (Locality-sensitive hashing) algorithms.
+    """
+
+    def __init__(self):
+        super(_LSH, self).__init__()
+
+    @classmethod
+    def _java_estimator_package_name(cls) -> str:
+        return "lsh"
+
+
+class _LSHModel(JavaFeatureModel, ABC):
+    """
+    Base class for LSH model.
+    """
+
+    def __init__(self, java_model):
+        super(_LSHModel, self).__init__(java_model)
+
+    @classmethod
+    def _java_model_package_name(cls) -> str:
+        return "lsh"
+
+    def approx_nearest_neighbors(self, dataset: Table, key: Vector, k: int,
+                                 dist_col: str = 'distCol'):
+        """
+        Given a dataset and an item, approximately find at most k items which have the closest
+        distance to the item. If the `outputCol` is missing in the given dataset, this method
+        transforms the dataset with the model at first.
+
+        :param dataset: The dataset in which to to search for nearest neighbors.
+        :param key: The item to search for.
+        :param k: The maximum number of nearest neighbors.
+        :param dist_col: The output column storing the distance between each neighbor and the
+        key.
+        :return: A dataset containing at most k items closest to the key with a column named
+        `distCol` appended.
+        """
+        j_vectors = get_gateway().jvm.org.apache.flink.ml.linalg.Vectors
+        if isinstance(key, (DenseVector,)):
+            j_key = j_vectors.dense(to_jarray(get_gateway().jvm.double, key.values.tolist()))
+        elif isinstance(key, (SparseVector,)):
+            # noinspection PyProtectedMember
+            j_key = j_vectors.sparse(
+                key.size(),
+                to_jarray(get_gateway().jvm.int, key._indices.tolist()),
+                to_jarray(get_gateway().jvm.double, key._values.tolist())
+            )
+        else:
+            raise TypeError(f'Key {key} must be an instance of Vector.')
+
+        # noinspection PyProtectedMember
+        return Table(self._java_obj.approxNearestNeighbors(
+            dataset._j_table, j_key, k, dist_col), self._t_env)
+
+    def approx_similarity_join(self, dataset_a: Table, dataset_b: Table, threshold: float,
+                               id_col: str, dist_col: str = 'distCol'):
+        """
+        Join two datasets to approximately find all pairs of rows whose distance are smaller
+        than or equal to the threshold. If the `outputCol` is missing in either dataset, this
+        method transforms the dataset at first.
+
+        :param dataset_a: One dataset.
+        :param dataset_b: The other dataset.
+        :param threshold: The distance threshold.
+        :param id_col: A column in the two datasets to identify each row.
+        :param dist_col: The output column storing the distance between each pair of rows.
+        :return: A joined dataset containing pairs of rows. The original rows are in columns
+        "dataset_a" and "dataset_b", and a column "distCol" is added to show the distance
+        between each pair.
+        """
+        # noinspection PyProtectedMember
+        return Table(self._java_obj.approxSimilarityJoin(
+            dataset_a._j_table, dataset_b._j_table,
+            threshold, id_col, dist_col), self._t_env)
+
+
+class MinHashLSHModel(_LSHModel, _LSHModelParams):
+    """
+    A Model which generates hash values using the model data computed by :class:`MinHashLSH`.
+    """
+
+    def __init__(self, java_model=None):
+        super(MinHashLSHModel, self).__init__(java_model)
+
+    @classmethod
+    def _java_model_class_name(cls) -> str:
+        return "MinHashLSHModel"
+
+
+class MinHashLSH(_LSH, _LSHParams):
+    """
+    An Estimator which implements the MinHash LSH algorithm, with Jaccard distance as its distance
+    metric.
+
+    See: https://en.wikipedia.org/wiki/MinHash.
+    """
+
+    def __init__(self):
+        super(MinHashLSH, self).__init__()
+
+    @classmethod
+    def _create_model(cls, java_model) -> MinHashLSHModel:
+        return MinHashLSHModel(java_model)
+
+    @classmethod
+    def _java_estimator_class_name(cls) -> str:
+        return "MinHashLSH"

--- a/flink-ml-python/pyflink/ml/lib/feature/lsh.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/lsh.py
@@ -29,12 +29,18 @@ from pyflink.ml.lib.feature.common import JavaFeatureEstimator, JavaFeatureModel
 from pyflink.ml.lib.param import HasInputCol, HasOutputCol, HasSeed
 
 
-class _LSHParams(
-    JavaWithParams,
-    HasInputCol,
-    HasOutputCol,
-    HasSeed
-):
+class _LSHModelParams(JavaWithParams,
+                      HasInputCol,
+                      HasOutputCol):
+    """
+    Params for :class:`LSHModel`
+    """
+
+    def __init__(self, java_params):
+        super(_LSHModelParams, self).__init__(java_params)
+
+
+class _LSHParams(_LSHModelParams):
     """
     Params for :class:`LSH`
     """
@@ -71,12 +77,6 @@ class _LSHParams(
     @property
     def num_hash_functions_per_table(self):
         return self.get_num_hash_functions_per_table()
-
-
-class _LSHModelParams(JavaWithParams,
-                      HasInputCol,
-                      HasOutputCol):
-    ...
 
 
 class _LSH(JavaFeatureEstimator, ABC):
@@ -171,7 +171,7 @@ class MinHashLSHModel(_LSHModel, _LSHModelParams):
         return "MinHashLSHModel"
 
 
-class MinHashLSH(_LSH, _LSHParams):
+class MinHashLSH(_LSH, _LSHParams, HasSeed):
     """
     An Estimator which implements the MinHash LSH algorithm, with Jaccard distance as its distance
     metric.

--- a/flink-ml-python/pyflink/ml/lib/feature/lsh.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/lsh.py
@@ -53,7 +53,7 @@ class _LSHParams(_LSHModelParams):
         "num_hash_functions_per_table",
         "Number of hash functions per table.",
         1,
-        ParamValidators.gt_eq(1.))
+        ParamValidators.gt_eq(1))
 
     def __init__(self, java_params):
         super(_LSHParams, self).__init__(java_params)
@@ -114,10 +114,9 @@ class _LSHModel(JavaFeatureModel, ABC):
         :param dataset: The dataset in which to to search for nearest neighbors.
         :param key: The item to search for.
         :param k: The maximum number of nearest neighbors.
-        :param dist_col: The output column storing the distance between each neighbor and the
-        key.
+        :param dist_col: The output column storing the distance between each neighbor and the key.
         :return: A dataset containing at most k items closest to the key with a column named
-        `distCol` appended.
+                 `distCol` appended.
         """
         j_vectors = get_gateway().jvm.org.apache.flink.ml.linalg.Vectors
         if isinstance(key, (DenseVector,)):
@@ -149,8 +148,8 @@ class _LSHModel(JavaFeatureModel, ABC):
         :param id_col: A column in the two datasets to identify each row.
         :param dist_col: The output column storing the distance between each pair of rows.
         :return: A joined dataset containing pairs of rows. The original rows are in columns
-        "dataset_a" and "dataset_b", and a column "distCol" is added to show the distance
-        between each pair.
+                 "dataset_a" and "dataset_b", and a column "distCol" is added to show the distance
+                 between each pair.
         """
         # noinspection PyProtectedMember
         return Table(self._java_obj.approxSimilarityJoin(

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_minhashlsh.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_minhashlsh.py
@@ -1,0 +1,235 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import functools
+import os
+from typing import List, Tuple
+
+from pyflink.common import Row, Types
+from pyflink.java_gateway import get_gateway
+from pyflink.ml.core.linalg import Vectors, SparseVectorTypeInfo, DenseVector
+from pyflink.ml.core.wrapper import JavaWithParams
+from pyflink.ml.lib.feature.lsh import MinHashLSH, MinHashLSHModel
+from pyflink.ml.tests.test_utils import PyFlinkMLTestCase
+from pyflink.table import Table
+
+
+class MinHashLSHTest(PyFlinkMLTestCase):
+    def setUp(self):
+        super(MinHashLSHTest, self).setUp()
+
+    def _get_default_case(self) -> Tuple[MinHashLSH, Table, List[Row]]:
+        lsh = MinHashLSH() \
+            .set_input_col('vec') \
+            .set_output_col('hashes') \
+            .set_seed(2022) \
+            .set_num_hash_tables(5) \
+            .set_num_hash_functions_per_table(3)
+
+        data = self.t_env.from_data_stream(
+            self.env.from_collection([
+                (0, Vectors.sparse(6, [0, 1, 2], [1., 1., 1.])),
+                (1, Vectors.sparse(6, [2, 3, 4], [1., 1., 1.])),
+                (2, Vectors.sparse(6, [0, 2, 4], [1., 1., 1.])),
+            ],
+                type_info=Types.ROW_NAMED(
+                    ['id', 'vec'],
+                    [Types.INT(), SparseVectorTypeInfo()])))
+
+        expected = [
+            Row([
+                Vectors.dense(1.73046954E8, 1.57275425E8, 6.90717571E8),
+                Vectors.dense(5.02301169E8, 7.967141E8, 4.06089319E8),
+                Vectors.dense(2.83652171E8, 1.97714719E8, 6.04731316E8),
+                Vectors.dense(5.2181506E8, 6.36933726E8, 6.13894128E8),
+                Vectors.dense(3.04301769E8, 1.113672955E9, 6.1388711E8),
+            ]),
+            Row([
+                Vectors.dense(1.73046954E8, 1.57275425E8, 6.7798584E7),
+                Vectors.dense(6.38582806E8, 1.78703694E8, 4.06089319E8),
+                Vectors.dense(6.232638E8, 9.28867E7, 9.92010642E8),
+                Vectors.dense(2.461064E8, 1.12787481E8, 1.92180297E8),
+                Vectors.dense(2.38162496E8, 1.552933319E9, 2.77995137E8),
+            ]),
+            Row([
+                Vectors.dense(1.73046954E8, 1.57275425E8, 6.90717571E8),
+                Vectors.dense(1.453197722E9, 7.967141E8, 4.06089319E8),
+                Vectors.dense(6.232638E8, 1.97714719E8, 6.04731316E8),
+                Vectors.dense(2.461064E8, 1.12787481E8, 1.92180297E8),
+                Vectors.dense(1.224130231E9, 1.113672955E9, 2.77995137E8),
+            ])]
+        return lsh, data, expected
+
+    def test_param(self):
+        lsh = MinHashLSH()
+        self.assertEqual('input', lsh.get_input_col())
+        self.assertEqual('output', lsh.get_output_col())
+        self.assertEqual(-1229568175, lsh.get_seed())
+        self.assertEqual(1, lsh.get_num_hash_tables())
+        self.assertEqual(1, lsh.get_num_hash_functions_per_table())
+
+        lsh.set_input_col('test_input') \
+            .set_output_col('test_output') \
+            .set_seed(2022) \
+            .set_num_hash_tables(3) \
+            .set_num_hash_functions_per_table(4)
+
+        self.assertEqual('test_input', lsh.get_input_col())
+        self.assertEqual('test_output', lsh.get_output_col())
+        self.assertEqual(2022, lsh.get_seed())
+        self.assertEqual(3, lsh.get_num_hash_tables())
+        self.assertEqual(4, lsh.get_num_hash_functions_per_table())
+
+    def test_output_schema(self):
+        lsh, data, _ = self._get_default_case()
+        model = lsh.fit(data)
+        output = model.transform(data)[0]
+        self.assertEqual(['id', 'vec', 'hashes'], output.get_schema().get_field_names())
+
+    def test_fit_and_transform(self):
+        lsh, data, expected = self._get_default_case()
+        model = lsh.fit(data)
+        output = model.transform(data)[0].select("hashes")
+        self.verify_output_hashes(output, expected)
+
+    def test_estimator_save_load_transform(self):
+        path = os.path.join(self.temp_dir, 'test_estimator_save_load_transform_minhashlsh')
+        lsh, data, expected = self._get_default_case()
+        lsh.save(path)
+        lsh = MinHashLSH.load(self.t_env, path)
+        model = lsh.fit(data)
+        output = model.transform(data)[0].select(lsh.get_output_col())
+        self.verify_output_hashes(output, expected)
+
+    def test_model_save_load_transform(self):
+        path = os.path.join(self.temp_dir, 'test_model_save_load_transform_minhashlsh')
+        lsh, data, expected = self._get_default_case()
+        model = lsh.fit(data)
+        model.save(path)
+        self.env.execute('save_model')
+        model = MinHashLSHModel.load(self.t_env, path)
+        output = model.transform(data)[0].select(lsh.get_output_col())
+        self.verify_output_hashes(output, expected)
+
+    def test_get_model_data(self):
+        lsh, data, _ = self._get_default_case()
+        model = lsh.fit(data)
+        model_data_table: Table = model.get_model_data()[0]
+        self.assertEqual(
+            ['numHashTables', 'numHashFunctionsPerTable', 'randCoefficientA', 'randCoefficientB'],
+            model_data_table.get_schema().get_field_names())
+
+        model_data_row = list(self.t_env.to_data_stream(model_data_table).execute_and_collect())[0]
+        self.assertEqual(lsh.get_num_hash_tables(), model_data_row[0])
+        self.assertEqual(lsh.get_num_hash_functions_per_table(), model_data_row[1])
+        self.assertEqual(lsh.get_num_hash_tables() * lsh.get_num_hash_functions_per_table(),
+                         len(model_data_row[2]))
+        self.assertEqual(lsh.get_num_hash_tables() * lsh.get_num_hash_functions_per_table(),
+                         len(model_data_row[3]))
+
+    def test_set_model_data(self):
+        lsh, data, expected = self._get_default_case()
+        model_a = lsh.fit(data)
+        model_data_table = model_a.get_model_data()[0]
+        model_b: MinHashLSHModel = MinHashLSHModel().set_model_data(model_data_table)
+        self.update_existing_params(model_b, model_a)
+        output = model_b.transform(data)[0].select(lsh.get_output_col())
+        self.verify_output_hashes(output, expected)
+
+    def test_approx_nearest_neighbors(self):
+        lsh, data, _ = self._get_default_case()
+        expected = [
+            Row(0, 0.75),
+            Row(1, 0.75),
+        ]
+
+        model: MinHashLSHModel = lsh.set_num_hash_functions_per_table(1).fit(data)
+        key = Vectors.sparse(6, [1, 3], [1., 1.])
+        output = model.approx_nearest_neighbors(data, key, 2).select("id, distCol")
+        actual_result = [r for r in self.t_env.to_data_stream(output).execute_and_collect()]
+        actual_result.sort(key=lambda r: r[0])
+        self.assertEqual(expected, actual_result)
+
+    def test_approx_nearest_neighbors_dense_vector(self):
+        lsh, data, _ = self._get_default_case()
+        expected = [
+            Row(0, 0.75),
+            Row(1, 0.75),
+        ]
+
+        model: MinHashLSHModel = lsh.set_num_hash_functions_per_table(1).fit(data)
+        key = Vectors.dense([0., 1., 0., 1., 0., 0.])
+        output = model.approx_nearest_neighbors(data, key, 2).select("id, distCol")
+        actual_result = [r for r in self.t_env.to_data_stream(output).execute_and_collect()]
+        actual_result.sort(key=lambda r: r[0])
+        self.assertEqual(expected, actual_result)
+
+    def test_approx_similarity_join(self):
+        lsh, data_a, _ = self._get_default_case()
+        model: MinHashLSHModel = lsh.set_num_hash_functions_per_table(1).fit(data_a)
+        data_b = self.t_env.from_data_stream(
+            self.env.from_collection([
+                (3, Vectors.sparse(6, [1, 3, 5], [1., 1., 1.])),
+                (4, Vectors.sparse(6, [2, 3, 5], [1., 1., 1.])),
+                (5, Vectors.sparse(6, [1, 2, 4], [1., 1., 1.])),
+            ], type_info=Types.ROW_NAMED(['id', 'vec'], [Types.INT(), SparseVectorTypeInfo()])))
+        expected = [
+            Row(1, 4, .5),
+            Row(0, 5, .5),
+            Row(1, 5, .5),
+            Row(2, 5, .5)
+        ]
+        output = model.approx_similarity_join(data_a, data_b, .6, "id")
+        actual_result = [r for r in self.t_env.to_data_stream(output).execute_and_collect()]
+
+        expected.sort(key=lambda r: (r[0], r[1]))
+        actual_result.sort(key=lambda r: (r[0], r[1]))
+        self.assertEqual(expected, actual_result)
+
+    @classmethod
+    def update_existing_params(cls, target: JavaWithParams, source: JavaWithParams):
+        get_gateway().jvm.org.apache.flink.ml.util.ReadWriteUtils \
+            .updateExistingParams(target._java_obj, source._java_obj.getParamMap())
+
+    @classmethod
+    def dense_vector_comparator(cls, dv0: DenseVector, dv1: DenseVector):
+        if dv0.size() != dv1.size():
+            return dv0.size() - dv1.size()
+        for e0, e1 in zip(dv0.values, dv1.values):
+            if e0 != e1:
+                return 1 if e0 > e1 else -1
+        return 0
+
+    @classmethod
+    def dense_vector_array_comparator(cls, dvs0: List[DenseVector], dvs1: List[DenseVector]):
+        if len(dvs0) != len(dvs1):
+            return len(dvs0) - len(dvs1)
+        for dv0, dv1 in zip(dvs0, dvs1):
+            cmp = cls.dense_vector_comparator(dv0, dv1)
+            if cmp != 0:
+                return cmp
+        return 0
+
+    def verify_output_hashes(self, output: Table, expected_result: List[Row]):
+        actual_result = [r for r in
+                         self.t_env.to_data_stream(output).execute_and_collect()]
+        actual_result.sort(
+            key=lambda x: functools.cmp_to_key(self.dense_vector_array_comparator)(x[0]))
+        expected_result.sort(
+            key=lambda x: functools.cmp_to_key(self.dense_vector_array_comparator)(x[0]))
+        for r0, r1 in zip(actual_result, expected_result):
+            self.assertEqual(0, self.dense_vector_array_comparator(r0[0], r1[0]))

--- a/flink-ml-python/pyflink/ml/lib/feature/tests/test_minhashlsh.py
+++ b/flink-ml-python/pyflink/ml/lib/feature/tests/test_minhashlsh.py
@@ -66,11 +66,11 @@ class MinHashLSHTest(PyFlinkMLTestCase):
 
     def test_param(self):
         lsh = MinHashLSH()
-        self.assertEqual('input', lsh.get_input_col())
-        self.assertEqual('output', lsh.get_output_col())
-        self.assertEqual(-1229568175, lsh.get_seed())
-        self.assertEqual(1, lsh.get_num_hash_tables())
-        self.assertEqual(1, lsh.get_num_hash_functions_per_table())
+        self.assertEqual('input', lsh.input_col)
+        self.assertEqual('output', lsh.output_col)
+        self.assertEqual(-1229568175, lsh.seed)
+        self.assertEqual(1, lsh.num_hash_tables)
+        self.assertEqual(1, lsh.num_hash_functions_per_table)
 
         lsh.set_input_col('test_input') \
             .set_output_col('test_output') \
@@ -78,11 +78,11 @@ class MinHashLSHTest(PyFlinkMLTestCase):
             .set_num_hash_tables(3) \
             .set_num_hash_functions_per_table(4)
 
-        self.assertEqual('test_input', lsh.get_input_col())
-        self.assertEqual('test_output', lsh.get_output_col())
-        self.assertEqual(2022, lsh.get_seed())
-        self.assertEqual(3, lsh.get_num_hash_tables())
-        self.assertEqual(4, lsh.get_num_hash_functions_per_table())
+        self.assertEqual('test_input', lsh.input_col)
+        self.assertEqual('test_output', lsh.output_col)
+        self.assertEqual(2022, lsh.seed)
+        self.assertEqual(3, lsh.num_hash_tables)
+        self.assertEqual(4, lsh.num_hash_functions_per_table)
 
     def test_output_schema(self):
         lsh = MinHashLSH() \
@@ -117,7 +117,7 @@ class MinHashLSHTest(PyFlinkMLTestCase):
         lsh.save(path)
         lsh = MinHashLSH.load(self.t_env, path)
         model = lsh.fit(self.data)
-        output = model.transform(self.data)[0].select(lsh.get_output_col())
+        output = model.transform(self.data)[0].select(lsh.output_col)
         self.verify_output_hashes(output, self.expected)
 
     def test_model_save_load_transform(self):
@@ -132,7 +132,7 @@ class MinHashLSHTest(PyFlinkMLTestCase):
         model.save(path)
         self.env.execute('save_model')
         model = MinHashLSHModel.load(self.t_env, path)
-        output = model.transform(self.data)[0].select(lsh.get_output_col())
+        output = model.transform(self.data)[0].select(lsh.output_col)
         self.verify_output_hashes(output, self.expected)
 
     def test_get_model_data(self):
@@ -149,11 +149,11 @@ class MinHashLSHTest(PyFlinkMLTestCase):
             model_data_table.get_schema().get_field_names())
 
         model_data_row = list(self.t_env.to_data_stream(model_data_table).execute_and_collect())[0]
-        self.assertEqual(lsh.get_num_hash_tables(), model_data_row[0])
-        self.assertEqual(lsh.get_num_hash_functions_per_table(), model_data_row[1])
-        self.assertEqual(lsh.get_num_hash_tables() * lsh.get_num_hash_functions_per_table(),
+        self.assertEqual(lsh.num_hash_tables, model_data_row[0])
+        self.assertEqual(lsh.num_hash_functions_per_table, model_data_row[1])
+        self.assertEqual(lsh.num_hash_tables * lsh.num_hash_functions_per_table,
                          len(model_data_row[2]))
-        self.assertEqual(lsh.get_num_hash_tables() * lsh.get_num_hash_functions_per_table(),
+        self.assertEqual(lsh.num_hash_tables * lsh.num_hash_functions_per_table,
                          len(model_data_row[3]))
 
     def test_set_model_data(self):
@@ -167,7 +167,7 @@ class MinHashLSHTest(PyFlinkMLTestCase):
         model_data_table = model_a.get_model_data()[0]
         model_b: MinHashLSHModel = MinHashLSHModel().set_model_data(model_data_table)
         self.update_existing_params(model_b, model_a)
-        output = model_b.transform(self.data)[0].select(lsh.get_output_col())
+        output = model_b.transform(self.data)[0].select(lsh.output_col)
         self.verify_output_hashes(output, self.expected)
 
     def test_approx_nearest_neighbors(self):

--- a/flink-ml-python/pyflink/ml/lib/tests/test_ml_lib_completeness.py
+++ b/flink-ml-python/pyflink/ml/lib/tests/test_ml_lib_completeness.py
@@ -20,6 +20,7 @@ import importlib
 import os
 import pkgutil
 import unittest
+import inspect
 from abc import abstractmethod
 from typing import List
 
@@ -69,7 +70,8 @@ class MLLibTest(PyFlinkMLTestCase):
     @classmethod
     def _load_stages_from_module(cls, module):
         return [(name, obj) for name, obj in module.__dict__.items()
-                if hasattr(obj, '_java_stage_path') and name not in (
+                if hasattr(obj, '_java_stage_path') and not inspect.isabstract(obj)
+                and name not in (
                     'JavaClassificationEstimator', 'JavaClassificationModel',
                     'JavaClusteringEstimator', 'JavaClusteringModel',
                     'JavaClusteringAlgoOperator', 'JavaEvaluationAlgoOperator',


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds the implementation of MinHash LSH algorithm.

## Brief change log

  - Adds base Transformer and Estimator of LSH algorithms
  - Adds Transformer and Estimator implementation of MinHash LSH in Java and Python
  - Adds examples and documentations of MinHash LSH

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs / JavaDocs
