### PR TITLE
[FLINK-30523]  Fix the data generator for VectorAssembler benchmark

### DIFF
--- a/flink-ml-benchmark/src/main/resources/vectorassembler-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/vectorassembler-benchmark.json
@@ -17,7 +17,7 @@
   "version": 1,
   "vectorassembler1000000": {
     "inputData": {
-      "className": "org.apache.flink.ml.benchmark.datagenerator.common.ColsWithLabelGenerator",
+      "className": "org.apache.flink.ml.benchmark.datagenerator.common.DoubleGenerator",
       "paramMap": {
         "colNames": [
           [


### PR DESCRIPTION
##   Fix the data generator for VectorAssembler benchmark

## Brief change log
  - Change the data generator of VectorAssembler from `ColsWithLabelGenerator` to `DoubleGenerator`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
