### PR TITLE
[FLINK-30933] Fix missing max watermark when executing join in iteration body

### DIFF
--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperator.java
@@ -565,7 +565,7 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
 
         private MailboxExecutorWithYieldTimeout(MailboxExecutor mailboxExecutor) {
             this.mailboxExecutor = mailboxExecutor;
-            this.timer = new Timer();
+            this.timer = new Timer(true);
         }
 
         @Override

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/OutputOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/OutputOperator.java
@@ -19,9 +19,11 @@
 package org.apache.flink.iteration.operator;
 
 import org.apache.flink.iteration.IterationRecord;
+import org.apache.flink.iteration.IterationRecord.Type;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /**
@@ -48,6 +50,9 @@ public class OutputOperator<T> extends AbstractStreamOperator<T>
         if (streamRecord.getValue().getType() == IterationRecord.Type.RECORD) {
             reusable.replace(streamRecord.getValue().getValue(), streamRecord.getTimestamp());
             output.collect(reusable);
+        } else if (streamRecord.getValue().getType() == Type.EPOCH_WATERMARK
+                && streamRecord.getValue().getEpoch() == Integer.MAX_VALUE) {
+            output.emitWatermark(new Watermark(Long.MAX_VALUE));
         }
     }
 }

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundStreamIterationITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundStreamIterationITCase.java
@@ -18,18 +18,28 @@
 
 package org.apache.flink.test.iteration;
 
+import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.iteration.DataStreamList;
+import org.apache.flink.iteration.IterationBody;
 import org.apache.flink.iteration.IterationBodyResult;
 import org.apache.flink.iteration.IterationConfig;
 import org.apache.flink.iteration.Iterations;
 import org.apache.flink.iteration.ReplayableDataStreamList;
+import org.apache.flink.ml.common.datastream.EndOfStreamWindows;
+import org.apache.flink.ml.common.iteration.TerminateOnMaxIter;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.test.iteration.operators.CollectSink;
 import org.apache.flink.test.iteration.operators.EpochRecord;
 import org.apache.flink.test.iteration.operators.OutputRecord;
@@ -61,14 +71,16 @@ public class BoundedPerRoundStreamIterationITCase extends TestLogger {
 
     private MiniCluster miniCluster;
 
-    private SharedReference<BlockingQueue<OutputRecord<Integer>>> result;
+    private SharedReference<BlockingQueue<OutputRecord<Integer>>> collectedOutputRecord;
+    private SharedReference<BlockingQueue<Long>> collectedWatermarks;
 
     @Before
     public void setup() throws Exception {
         miniCluster = new MiniCluster(createMiniClusterConfiguration(2, 2));
         miniCluster.start();
 
-        result = sharedObjects.add(new LinkedBlockingQueue<>());
+        collectedOutputRecord = sharedObjects.add(new LinkedBlockingQueue<>());
+        collectedWatermarks = sharedObjects.add(new LinkedBlockingQueue<>());
     }
 
     @After
@@ -80,13 +92,48 @@ public class BoundedPerRoundStreamIterationITCase extends TestLogger {
 
     @Test
     public void testPerRoundIteration() throws Exception {
-        JobGraph jobGraph = createPerRoundJobGraph(4, 1000, 5, result);
+        JobGraph jobGraph = createPerRoundJobGraph(4, 1000, 5, collectedOutputRecord);
         miniCluster.executeJobBlocking(jobGraph);
 
-        assertEquals(5, result.get().size());
+        assertEquals(5, collectedOutputRecord.get().size());
         Map<Integer, Tuple2<Integer, Integer>> roundsStat =
-                computeRoundStat(result.get(), OutputRecord.Event.TERMINATED, 5);
+                computeRoundStat(collectedOutputRecord.get(), OutputRecord.Event.TERMINATED, 5);
         verifyResult(roundsStat, 5, 1, 4 * (0 + 999) * 1000 / 2);
+    }
+
+    @Test
+    public void testPerRoundIterationWithJoin() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(4);
+
+        DataStream<Tuple2<Long, Integer>> input1 = env.fromElements(Tuple2.of(1L, 1));
+
+        DataStream<Tuple2<Long, Long>> input2 = env.fromElements(Tuple2.of(1L, 2L));
+
+        DataStream<Tuple2<Long, Long>> iterationWithJoinResult =
+                Iterations.iterateBoundedStreamsUntilTermination(
+                                DataStreamList.of(input1),
+                                ReplayableDataStreamList.replay(input2),
+                                IterationConfig.newBuilder()
+                                        .setOperatorLifeCycle(
+                                                IterationConfig.OperatorLifeCycle.PER_ROUND)
+                                        .build(),
+                                new IterationBodyWithJoin())
+                        .get(0);
+        DataStream<Long> watermarks =
+                iterationWithJoinResult.transform(
+                        "CollectingWatermark", Types.LONG, new CollectingWatermark());
+
+        watermarks.addSink(new LongSink(collectedWatermarks));
+
+        JobGraph graph = env.getStreamGraph().getJobGraph();
+        miniCluster.executeJobBlocking(graph);
+
+        assertEquals(env.getParallelism(), collectedWatermarks.get().size());
+        collectedWatermarks
+                .get()
+                .iterator()
+                .forEachRemaining(x -> assertEquals(Long.MAX_VALUE, (long) x));
     }
 
     private static JobGraph createPerRoundJobGraph(
@@ -147,5 +194,63 @@ public class BoundedPerRoundStreamIterationITCase extends TestLogger {
         outputs.<OutputRecord<Integer>>get(0).addSink(new CollectSink(result));
 
         return env.getStreamGraph().getJobGraph();
+    }
+
+    private static class IterationBodyWithJoin implements IterationBody {
+        @Override
+        public IterationBodyResult process(
+                DataStreamList variableStreams, DataStreamList dataStreams) {
+            DataStream<Tuple2<Long, Integer>> input1 = variableStreams.get(0);
+            DataStream<Tuple2<Long, Long>> input2 = dataStreams.get(0);
+
+            DataStream<Long> terminationCriteria = input1.flatMap(new TerminateOnMaxIter(1));
+
+            DataStream<Tuple2<Long, Long>> res =
+                    input1.join(input2)
+                            .where(x -> x.f0)
+                            .equalTo(x -> x.f0)
+                            .window(EndOfStreamWindows.get())
+                            .apply(
+                                    new JoinFunction<
+                                            Tuple2<Long, Integer>,
+                                            Tuple2<Long, Long>,
+                                            Tuple2<Long, Long>>() {
+                                        @Override
+                                        public Tuple2<Long, Long> join(
+                                                Tuple2<Long, Integer> longIntegerTuple2,
+                                                Tuple2<Long, Long> longLongTuple2) {
+                                            return longLongTuple2;
+                                        }
+                                    });
+
+            return new IterationBodyResult(
+                    DataStreamList.of(input1), DataStreamList.of(res), terminationCriteria);
+        }
+    }
+
+    private static class LongSink implements SinkFunction<Long> {
+        private final SharedReference<BlockingQueue<Long>> collectedLong;
+
+        public LongSink(SharedReference<BlockingQueue<Long>> collectedLong) {
+            this.collectedLong = collectedLong;
+        }
+
+        @Override
+        public void invoke(Long value, Context context) {
+            collectedLong.get().add(value);
+        }
+    }
+
+    private static class CollectingWatermark extends AbstractStreamOperator<Long>
+            implements OneInputStreamOperator<Tuple2<Long, Long>, Long> {
+
+        @Override
+        public void processElement(StreamRecord<Tuple2<Long, Long>> streamRecord) {}
+
+        @Override
+        public void processWatermark(Watermark mark) throws Exception {
+            super.processWatermark(mark);
+            output.collect(new StreamRecord<>(mark.getTimestamp()));
+        }
     }
 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink ML - we are happy that you want to help us improve Flink ML. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to one [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] Title of the pull request`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, when executing join for bounded input streams in a perround iteration body, there exist two problems:
- The program may not exit even the result is collected using `datastream.executeAndCollect()`
- The max watermark of the output stream is losed.

This PR attempts to fix the above problems.

## Brief change log
- Set `Timer` thread as daemon in `HeadOperator`.
- Outputs maxwatermark when encountering max epoch watermark in `OutputOperator`.
- Added unit test for verify the change.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
