### PR TITLE
[FLINK-30939][draft] Add public APIs of GBTClassifier.

### DIFF
--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifier.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifier.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.classification.gbtclassifier;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.ml.api.Estimator;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** An Estimator which implements the gradient boosting trees classification algorithm. */
+public class GBTClassifier
+        implements Estimator<GBTClassifier, GBTClassifierModel>,
+                GBTClassifierParams<GBTClassifier> {
+
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public GBTClassifier() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    public static GBTClassifier load(StreamTableEnvironment tEnv, String path) throws IOException {
+        return ReadWriteUtils.loadStageParam(path);
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    @Override
+    public GBTClassifierModel fit(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        // TODO: add training part in next PRs.
+        DataStream<GBTModelData> modelData =
+                tEnv.toDataStream(tEnv.fromValues(0)).map(d -> new GBTModelData("CLASSIFICATION"));
+        GBTClassifierModel model = new GBTClassifierModel();
+        // TODO: change to GBTModelDataTypeInformation in next PRs.
+        model.setModelData(
+                tEnv.fromDataStream(
+                                modelData
+                                        .map(Row::of)
+                                        .returns(
+                                                Types.ROW_NAMED(
+                                                        new String[] {"f0"},
+                                                        TypeInformation.of(GBTModelData.class))))
+                        .renameColumns($("f0").as("modelData")));
+        ReadWriteUtils.updateExistingParams(model, getParamMap());
+        return model;
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifierModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifierModel.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.classification.gbtclassifier;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.common.broadcast.BroadcastUtils;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.common.gbt.BaseGBTModel;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.math3.analysis.function.Sigmoid;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/** A Model computed by {@link GBTClassifier}. */
+public class GBTClassifierModel extends BaseGBTModel<GBTClassifierModel>
+        implements GBTClassifierParams<GBTClassifierModel> {
+
+    /**
+     * Loads model data from path.
+     *
+     * @param tEnv A StreamTableEnvironment instance.
+     * @param path Model path.
+     * @return GBT classification model.
+     */
+    public static GBTClassifierModel load(StreamTableEnvironment tEnv, String path)
+            throws IOException {
+        GBTClassifierModel model = ReadWriteUtils.loadStageParam(path);
+        // TODO: load model data from path in next PRs.
+        Table modelDataTable = null;
+        return model.setModelData(modelDataTable);
+    }
+
+    @Override
+    public Table[] transform(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<Row> inputStream = tEnv.toDataStream(inputs[0]);
+        final String broadcastModelKey = "broadcastModelKey";
+        DataStream<GBTModelData> modelDataStream = GBTModelData.getModelDataStream(modelDataTable);
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(
+                                inputTypeInfo.getFieldTypes(),
+                                Types.DOUBLE,
+                                DenseVectorTypeInfo.INSTANCE,
+                                DenseVectorTypeInfo.INSTANCE),
+                        ArrayUtils.addAll(
+                                inputTypeInfo.getFieldNames(),
+                                getPredictionCol(),
+                                getRawPredictionCol(),
+                                getProbabilityCol()));
+        DataStream<Row> predictionResult =
+                BroadcastUtils.withBroadcastStream(
+                        Collections.singletonList(inputStream),
+                        Collections.singletonMap(broadcastModelKey, modelDataStream),
+                        inputList -> {
+                            //noinspection unchecked
+                            DataStream<Row> inputData = (DataStream<Row>) inputList.get(0);
+                            return inputData.map(
+                                    new PredictLabelFunction(
+                                            broadcastModelKey, getInputCols(), getFeaturesCol()),
+                                    outputTypeInfo);
+                        });
+        return new Table[] {tEnv.fromDataStream(predictionResult)};
+    }
+
+    private static class PredictLabelFunction extends RichMapFunction<Row, Row> {
+
+        private static final Sigmoid sigmoid = new Sigmoid();
+
+        private final String broadcastModelKey;
+        private final String[] inputCols;
+        private final String featuresCol;
+        private GBTModelData modelData;
+
+        public PredictLabelFunction(
+                String broadcastModelKey, String[] inputCols, String featuresCol) {
+            this.broadcastModelKey = broadcastModelKey;
+            this.inputCols = inputCols;
+            this.featuresCol = featuresCol;
+        }
+
+        @Override
+        public Row map(Row value) throws Exception {
+            if (null == modelData) {
+                modelData =
+                        (GBTModelData)
+                                getRuntimeContext().getBroadcastVariable(broadcastModelKey).get(0);
+            }
+            // TODO: add actual prediction computation in next PRs.
+            double logits = 0.;
+            double prob = sigmoid.value(logits);
+            return Row.join(
+                    value,
+                    Row.of(
+                            logits >= 0. ? 1. : 0.,
+                            Vectors.dense(-logits, logits),
+                            Vectors.dense(1 - prob, prob)));
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifierParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifierParams.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.classification.gbtclassifier;
+
+import org.apache.flink.ml.common.gbt.BaseGBTParams;
+import org.apache.flink.ml.common.param.HasProbabilityCol;
+import org.apache.flink.ml.common.param.HasRawPredictionCol;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+
+/**
+ * Parameters for {@link GBTClassifier}.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface GBTClassifierParams<T>
+        extends BaseGBTParams<T>, HasRawPredictionCol<T>, HasProbabilityCol<T> {
+
+    Param<String> LOSS_TYPE =
+            new StringParam(
+                    "lossType", "Loss type.", "logistic", ParamValidators.inArray("logistic"));
+
+    default String getLossType() {
+        return get(LOSS_TYPE);
+    }
+
+    default T setLossType(String value) {
+        return set(LOSS_TYPE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BaseGBTModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BaseGBTModel.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.ml.api.Model;
+import org.apache.flink.ml.classification.gbtclassifier.GBTClassifier;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.table.api.Table;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Base model computed by {@link GBTClassifier}. */
+public abstract class BaseGBTModel<T extends BaseGBTModel<T>>
+        implements Model<T>, GBTModelParams<T> {
+
+    protected final Map<Param<?>, Object> paramMap = new HashMap<>();
+    protected Table modelDataTable;
+
+    public BaseGBTModel() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public Table[] getModelData() {
+        return new Table[] {modelDataTable};
+    }
+
+    @Override
+    public T setModelData(Table... inputs) {
+        modelDataTable = inputs[0];
+        //noinspection unchecked
+        return (T) this;
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+        // TODO: add save model data in next PRs.
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BaseGBTParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BaseGBTParams.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.ml.common.param.HasFeatureSubsetStrategy;
+import org.apache.flink.ml.common.param.HasLeafCol;
+import org.apache.flink.ml.common.param.HasMaxBins;
+import org.apache.flink.ml.common.param.HasMaxDepth;
+import org.apache.flink.ml.common.param.HasMaxIter;
+import org.apache.flink.ml.common.param.HasMinInfoGain;
+import org.apache.flink.ml.common.param.HasMinInstancesPerNode;
+import org.apache.flink.ml.common.param.HasMinWeightFractionPerNode;
+import org.apache.flink.ml.common.param.HasSeed;
+import org.apache.flink.ml.common.param.HasStepSize;
+import org.apache.flink.ml.common.param.HasSubsamplingRate;
+import org.apache.flink.ml.common.param.HasValidationIndicatorCol;
+import org.apache.flink.ml.common.param.HasValidationTol;
+import org.apache.flink.ml.common.param.HasWeightCol;
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+
+/**
+ * Common parameters for GBT classifier and regressor.
+ *
+ * <p>TODO: support param thresholds, impurity (actually meaningless)
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface BaseGBTParams<T>
+        extends GBTModelParams<T>,
+                HasLeafCol<T>,
+                HasWeightCol<T>,
+                HasMaxDepth<T>,
+                HasMaxBins<T>,
+                HasMinInstancesPerNode<T>,
+                HasMinWeightFractionPerNode<T>,
+                HasMinInfoGain<T>,
+                HasMaxIter<T>,
+                HasStepSize<T>,
+                HasSeed<T>,
+                HasSubsamplingRate<T>,
+                HasFeatureSubsetStrategy<T>,
+                HasValidationIndicatorCol<T>,
+                HasValidationTol<T> {
+    Param<Double> REG_LAMBDA =
+            new DoubleParam(
+                    "regLambda",
+                    "Regularization term for the number of leaves.",
+                    0.,
+                    ParamValidators.gtEq(0.));
+    Param<Double> REG_GAMMA =
+            new DoubleParam(
+                    "regGamma",
+                    "L2 regularization term for the weights of leaves.",
+                    1.,
+                    ParamValidators.gtEq(0));
+
+    default double getRegLambda() {
+        return get(REG_LAMBDA);
+    }
+
+    default T setRegLambda(Double value) {
+        return set(REG_LAMBDA, value);
+    }
+
+    default double getRegGamma() {
+        return get(REG_GAMMA);
+    }
+
+    default T setRegGamma(Double value) {
+        return set(REG_GAMMA, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelData.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.ml.classification.gbtclassifier.GBTClassifierModel;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+
+/**
+ * Model data of {@link GBTClassifierModel}.
+ *
+ * <p>This class also provides methods to convert model data from Table to Datastream, and classes
+ * to save/load model data.
+ *
+ * <p>TODO: complete GBTModelData in next PRs.
+ */
+public class GBTModelData {
+
+    public String type;
+
+    public GBTModelData() {}
+
+    public GBTModelData(String type) {
+        this.type = type;
+    }
+
+    public static DataStream<GBTModelData> getModelDataStream(Table modelDataTable) {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) modelDataTable).getTableEnvironment();
+        return tEnv.toDataStream(modelDataTable).map(x -> x.getFieldAs(0));
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelParams.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.ml.classification.gbtclassifier.GBTClassifierModel;
+import org.apache.flink.ml.common.param.HasCategoricalCols;
+import org.apache.flink.ml.common.param.HasFeaturesCol;
+import org.apache.flink.ml.common.param.HasLabelCol;
+import org.apache.flink.ml.common.param.HasPredictionCol;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.StringArrayParam;
+
+/**
+ * Params of {@link GBTClassifierModel}.
+ *
+ * <p>If the input features come from 1 column of vector type, `featuresCol` should be used, and all
+ * features are treated as continuous features. Otherwise, `inputCols` should be used for multiple
+ * columns. Columns whose names specified in `categoricalCols` are treated as categorical features,
+ * while others are continuous features.
+ *
+ * <p>NOTE: `inputCols` and `featuresCol` are in conflict with each other, so they should not be set
+ * at the same time. In addition, `inputCols` has a higher precedence than `featuresCol`, that is,
+ * `featuresCol` is ignored when `inputCols` is not `null`.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface GBTModelParams<T>
+        extends HasFeaturesCol<T>, HasLabelCol<T>, HasCategoricalCols<T>, HasPredictionCol<T> {
+
+    Param<String[]> INPUT_COLS = new StringArrayParam("inputCols", "Input column names.", null);
+
+    default String[] getInputCols() {
+        return get(INPUT_COLS);
+    }
+
+    default T setInputCols(String... value) {
+        return set(INPUT_COLS, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/TaskType.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/TaskType.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+/** Indicates the type of task. */
+public enum TaskType {
+    CLASSIFICATION,
+    REGRESSION,
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasFeatureSubsetStrategy.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasFeatureSubsetStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param feature subset strategy. */
+public interface HasFeatureSubsetStrategy<T> extends WithParams<T> {
+    Param<String> FEATURE_SUBSET_STRATEGY =
+            new StringParam(
+                    "featureSubsetStrategy.",
+                    "Fraction of the training data used for learning one tree. Supports \"auto\", \"all\", \"onethird\", \"sqrt\", \"log2\", (0.0 - 1.0], and [1 - n].",
+                    "auto",
+                    ParamValidators.notNull());
+
+    default String getFeatureSubsetStrategy() {
+        return get(FEATURE_SUBSET_STRATEGY);
+    }
+
+    default T setFeatureSubsetStrategy(String value) {
+        return set(FEATURE_SUBSET_STRATEGY, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasLeafCol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasLeafCol.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param leaf column. */
+public interface HasLeafCol<T> extends WithParams<T> {
+    Param<String> LEAF_COL =
+            new StringParam("leafCol", "Predicted leaf index of each instance in each tree.", null);
+
+    default String getLeafCol() {
+        return get(LEAF_COL);
+    }
+
+    default T setLeafCol(String value) {
+        return set(LEAF_COL, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasLossType.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasLossType.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared maxBins param. */
+public interface HasLossType<T> extends WithParams<T> {
+
+    Param<String> LOSS_TYPE =
+            new StringParam(
+                    "lossType",
+                    "Loss type.",
+                    "squared",
+                    ParamValidators.inArray("squared", "absolute", "logistic"));
+
+    default String getLossType() {
+        return get(LOSS_TYPE);
+    }
+
+    default T setLossType(String value) {
+        set(LOSS_TYPE, value);
+        return (T) this;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMaxBins.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMaxBins.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared maxBins param. */
+public interface HasMaxBins<T> extends WithParams<T> {
+    Param<Integer> MAX_BINS =
+            new IntParam(
+                    "maxBins",
+                    "Maximum number of bins used for discretizing continuous features.",
+                    32,
+                    ParamValidators.gtEq(2));
+
+    default int getMaxBins() {
+        return get(MAX_BINS);
+    }
+
+    default T setMaxBins(int value) {
+        return set(MAX_BINS, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMaxDepth.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMaxDepth.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared maxDepth param. */
+public interface HasMaxDepth<T> extends WithParams<T> {
+    Param<Integer> MAX_DEPTH =
+            new IntParam("maxDepth", "Maximum depth of the tree.", 5, ParamValidators.gtEq(1));
+
+    default int getMaxDepth() {
+        return get(MAX_DEPTH);
+    }
+
+    default T setMaxDepth(int value) {
+        return set(MAX_DEPTH, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinInfoGain.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinInfoGain.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param minInfoGain. */
+public interface HasMinInfoGain<T> extends WithParams<T> {
+    Param<Double> MIN_INFO_GAIN =
+            new DoubleParam(
+                    "minInfoGain",
+                    "Minimum information gain for a split to be considered valid.",
+                    0.,
+                    ParamValidators.gtEq(0.));
+
+    default double getMinInfoGain() {
+        return get(MIN_INFO_GAIN);
+    }
+
+    default T setMinInfoGain(Double value) {
+        return set(MIN_INFO_GAIN, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinInstancesPerNode.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinInstancesPerNode.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared minInstancesPerNode param. */
+public interface HasMinInstancesPerNode<T> extends WithParams<T> {
+    Param<Integer> MIN_INSTANCES_PER_NODE =
+            new IntParam(
+                    "minInstancesPerNode",
+                    "Minimum number of instances each node must have. If a split causes the left or right child to have fewer instances than minInstancesPerNode, the split is invalid.",
+                    1,
+                    ParamValidators.gtEq(1));
+
+    default int getMinInstancesPerNode() {
+        return get(MIN_INSTANCES_PER_NODE);
+    }
+
+    default T setMinInstancesPerNode(int value) {
+        return set(MIN_INSTANCES_PER_NODE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinWeightFractionPerNode.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinWeightFractionPerNode.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param minWeightFractionPerNode. */
+public interface HasMinWeightFractionPerNode<T> extends WithParams<T> {
+    Param<Double> MIN_WEIGHT_FRACTION_PER_NODE =
+            new DoubleParam(
+                    "minWeightFractionPerNode",
+                    "Minimum fraction of the weighted sample count that each node must have. If a split causes the left or right child to have a smaller fraction of the total weight than minWeightFractionPerNode, the split is invalid.",
+                    0.,
+                    ParamValidators.gtEq(0.));
+
+    default double getMinWeightFractionPerNode() {
+        return get(MIN_WEIGHT_FRACTION_PER_NODE);
+    }
+
+    default T setMinWeightFractionPerNode(Double value) {
+        return set(MIN_WEIGHT_FRACTION_PER_NODE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasProbabilityCol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasProbabilityCol.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param probability column. */
+public interface HasProbabilityCol<T> extends WithParams<T> {
+    Param<String> PROBABILITY_COL =
+            new StringParam(
+                    "probabilityCol",
+                    "Column name for predicted class conditional probabilities.",
+                    "probability",
+                    ParamValidators.notNull());
+
+    default String getProbabilityCol() {
+        return get(PROBABILITY_COL);
+    }
+
+    default T setProbabilityCol(String value) {
+        return set(PROBABILITY_COL, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasStepSize.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasStepSize.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared step size param. */
+public interface HasStepSize<T> extends WithParams<T> {
+    Param<Double> STEP_SIZE =
+            new DoubleParam(
+                    "stepSize",
+                    "Step size for shrinking the contribution of each estimator.",
+                    0.1,
+                    ParamValidators.inRange(0., 1.));
+
+    default double getStepSize() {
+        return get(STEP_SIZE);
+    }
+
+    default T setStepSize(Double value) {
+        return set(STEP_SIZE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasSubsamplingRate.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasSubsamplingRate.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param subsampling rate. */
+public interface HasSubsamplingRate<T> extends WithParams<T> {
+    Param<Double> SUBSAMPLING_RATE =
+            new DoubleParam(
+                    "subsamplingRate",
+                    "Fraction of the training data used for learning one tree.",
+                    1.,
+                    ParamValidators.inRange(0., 1.));
+
+    default double getSubsamplingRate() {
+        return get(SUBSAMPLING_RATE);
+    }
+
+    default T setSubsamplingRate(Double value) {
+        return set(SUBSAMPLING_RATE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasValidationIndicatorCol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasValidationIndicatorCol.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared validation indicate column param. */
+public interface HasValidationIndicatorCol<T> extends WithParams<T> {
+    Param<String> VALIDATION_INDICATOR_COL =
+            new StringParam(
+                    "validationIndicatorCol",
+                    "The name of the column that indicates whether each row is for training or for validation.",
+                    null);
+
+    default String getValidationIndicatorCol() {
+        return get(VALIDATION_INDICATOR_COL);
+    }
+
+    default T setValidationIndicatorCol(String value) {
+        return set(VALIDATION_INDICATOR_COL, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasValidationTol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasValidationTol.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared tolerance param. */
+public interface HasValidationTol<T> extends WithParams<T> {
+
+    Param<Double> VALIDATION_TOL =
+            new DoubleParam(
+                    "validationTol",
+                    "Threshold for early stopping when fitting with validation is used.",
+                    .01,
+                    ParamValidators.gtEq(0));
+
+    default double getValidationTol() {
+        return get(VALIDATION_TOL);
+    }
+
+    default T setValidationTol(Double value) {
+        return set(VALIDATION_TOL, value);
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/GBTClassifierTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/GBTClassifierTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.classification;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.classification.gbtclassifier.GBTClassifier;
+import org.apache.flink.ml.classification.gbtclassifier.GBTClassifierModel;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+import org.apache.flink.ml.common.gbt.defs.TaskType;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Tests {@link GBTClassifier} and {@link GBTClassifierModel}. */
+public class GBTClassifierTest extends AbstractTestBase {
+    private static final List<Row> inputDataRows =
+            Arrays.asList(
+                    Row.of(1.2, 2, null, 40., 1., 0., Vectors.dense(1.2, 2, Double.NaN)),
+                    Row.of(2.3, 3, "b", 40., 2., 0., Vectors.dense(2.3, 3, 2.)),
+                    Row.of(3.4, 4, "c", 40., 3., 0., Vectors.dense(3.4, 4, 3.)),
+                    Row.of(4.5, 5, "a", 40., 4., 0., Vectors.dense(4.5, 5, 1.)),
+                    Row.of(5.6, 2, "b", 40., 5., 0., Vectors.dense(5.6, 2, 2.)),
+                    Row.of(null, 3, "c", 41., 1., 1., Vectors.dense(Double.NaN, 3, 3.)),
+                    Row.of(12.8, 4, "e", 41., 2., 1., Vectors.dense(12.8, 4, 5.)),
+                    Row.of(13.9, 2, "b", 41., 3., 1., Vectors.dense(13.9, 2, 2.)),
+                    Row.of(14.1, 4, "a", 41., 4., 1., Vectors.dense(14.1, 4, 1.)),
+                    Row.of(15.3, 1, "d", 41., 5., 1., Vectors.dense(15.3, 1, 4.)));
+
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+    private StreamTableEnvironment tEnv;
+    private Table inputTable;
+
+    @Before
+    public void before() {
+        Configuration config = new Configuration();
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.getConfig().enableObjectReuse();
+        env.setParallelism(4);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        tEnv = StreamTableEnvironment.create(env);
+
+        inputTable =
+                tEnv.fromDataStream(
+                        env.fromCollection(
+                                inputDataRows,
+                                new RowTypeInfo(
+                                        new TypeInformation[] {
+                                            Types.DOUBLE,
+                                            Types.INT,
+                                            Types.STRING,
+                                            Types.DOUBLE,
+                                            Types.DOUBLE,
+                                            Types.DOUBLE,
+                                            VectorTypeInfo.INSTANCE
+                                        },
+                                        new String[] {
+                                            "f0", "f1", "f2", "label", "weight", "cls_label", "vec"
+                                        })));
+    }
+
+    @Test
+    public void testParam() {
+        GBTClassifier gbtc = new GBTClassifier();
+        Assert.assertEquals("features", gbtc.getFeaturesCol());
+        Assert.assertNull(gbtc.getInputCols());
+        Assert.assertEquals("label", gbtc.getLabelCol());
+        Assert.assertArrayEquals(new String[] {}, gbtc.getCategoricalCols());
+        Assert.assertEquals("prediction", gbtc.getPredictionCol());
+
+        Assert.assertNull(gbtc.getLeafCol());
+        Assert.assertNull(gbtc.getWeightCol());
+        Assert.assertEquals(5, gbtc.getMaxDepth());
+        Assert.assertEquals(32, gbtc.getMaxBins());
+        Assert.assertEquals(1, gbtc.getMinInstancesPerNode());
+        Assert.assertEquals(0., gbtc.getMinWeightFractionPerNode(), 1e-12);
+        Assert.assertEquals(0., gbtc.getMinInfoGain(), 1e-12);
+        Assert.assertEquals(20, gbtc.getMaxIter());
+        Assert.assertEquals(.1, gbtc.getStepSize(), 1e-12);
+        Assert.assertEquals(GBTClassifier.class.getName().hashCode(), gbtc.getSeed());
+        Assert.assertEquals(1., gbtc.getSubsamplingRate(), 1e-12);
+        Assert.assertEquals("auto", gbtc.getFeatureSubsetStrategy());
+        Assert.assertNull(gbtc.getValidationIndicatorCol());
+        Assert.assertEquals(.01, gbtc.getValidationTol(), 1e-12);
+        Assert.assertEquals(0., gbtc.getRegLambda(), 1e-12);
+        Assert.assertEquals(1., gbtc.getRegGamma(), 1e-12);
+
+        Assert.assertEquals("logistic", gbtc.getLossType());
+        Assert.assertEquals("rawPrediction", gbtc.getRawPredictionCol());
+        Assert.assertEquals("probability", gbtc.getProbabilityCol());
+
+        gbtc.setFeaturesCol("vec")
+                .setInputCols("f0", "f1", "f2")
+                .setLabelCol("cls_label")
+                .setCategoricalCols("f0", "f1")
+                .setPredictionCol("pred")
+                .setLeafCol("leaf")
+                .setWeightCol("weight")
+                .setMaxDepth(6)
+                .setMaxBins(64)
+                .setMinInstancesPerNode(2)
+                .setMinWeightFractionPerNode(.1)
+                .setMinInfoGain(.1)
+                .setMaxIter(10)
+                .setStepSize(.2)
+                .setSeed(123)
+                .setSubsamplingRate(.8)
+                .setFeatureSubsetStrategy("0.5")
+                .setValidationIndicatorCol("val")
+                .setValidationTol(.1)
+                .setRegLambda(.1)
+                .setRegGamma(.1)
+                .setRawPredictionCol("raw_pred")
+                .setProbabilityCol("prob");
+
+        Assert.assertEquals("vec", gbtc.getFeaturesCol());
+        Assert.assertArrayEquals(new String[] {"f0", "f1", "f2"}, gbtc.getInputCols());
+        Assert.assertEquals("cls_label", gbtc.getLabelCol());
+        Assert.assertArrayEquals(new String[] {"f0", "f1"}, gbtc.getCategoricalCols());
+        Assert.assertEquals("pred", gbtc.getPredictionCol());
+
+        Assert.assertEquals("leaf", gbtc.getLeafCol());
+        Assert.assertEquals("weight", gbtc.getWeightCol());
+        Assert.assertEquals(6, gbtc.getMaxDepth());
+        Assert.assertEquals(64, gbtc.getMaxBins());
+        Assert.assertEquals(2, gbtc.getMinInstancesPerNode());
+        Assert.assertEquals(.1, gbtc.getMinWeightFractionPerNode(), 1e-12);
+        Assert.assertEquals(.1, gbtc.getMinInfoGain(), 1e-12);
+        Assert.assertEquals(10, gbtc.getMaxIter());
+        Assert.assertEquals(.2, gbtc.getStepSize(), 1e-12);
+        Assert.assertEquals(123, gbtc.getSeed());
+        Assert.assertEquals(.8, gbtc.getSubsamplingRate(), 1e-12);
+        Assert.assertEquals("0.5", gbtc.getFeatureSubsetStrategy());
+        Assert.assertEquals("val", gbtc.getValidationIndicatorCol());
+        Assert.assertEquals(.1, gbtc.getValidationTol(), 1e-12);
+        Assert.assertEquals(.1, gbtc.getRegLambda(), 1e-12);
+        Assert.assertEquals(.1, gbtc.getRegGamma(), 1e-12);
+
+        Assert.assertEquals("raw_pred", gbtc.getRawPredictionCol());
+        Assert.assertEquals("prob", gbtc.getProbabilityCol());
+    }
+
+    @Test
+    public void testOutputSchema() throws Exception {
+        GBTClassifier gbtc =
+                new GBTClassifier().setInputCols("f0", "f1", "f2").setCategoricalCols("f2");
+        GBTClassifierModel model = gbtc.fit(inputTable);
+        Table output = model.transform(inputTable)[0];
+        Assert.assertArrayEquals(
+                ArrayUtils.addAll(
+                        inputTable.getResolvedSchema().getColumnNames().toArray(new String[0]),
+                        gbtc.getPredictionCol(),
+                        gbtc.getRawPredictionCol(),
+                        gbtc.getProbabilityCol()),
+                output.getResolvedSchema().getColumnNames().toArray(new String[0]));
+    }
+
+    @Test
+    public void testModelSaveLoadAndPredict() {
+        // TODO: add test after complete model save/load methods in next PRs.
+    }
+
+    @Test
+    public void testGetModelData() throws Exception {
+        GBTClassifier gbtc =
+                new GBTClassifier()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("cls_label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTClassifierModel model = gbtc.fit(inputTable);
+        Table modelDataTable = model.getModelData()[0];
+        List<String> modelDataColumnNames = modelDataTable.getResolvedSchema().getColumnNames();
+        DataStream<Row> output = tEnv.toDataStream(modelDataTable);
+        Assert.assertArrayEquals(
+                new String[] {"modelData"}, modelDataColumnNames.toArray(new String[0]));
+
+        Row modelDataRow = (Row) IteratorUtils.toList(output.executeAndCollect()).get(0);
+        GBTModelData modelData = modelDataRow.getFieldAs(0);
+        Assert.assertNotNull(modelData);
+
+        Assert.assertEquals(TaskType.CLASSIFICATION, TaskType.valueOf(modelData.type));
+        // TODO: check more fields in next PRs.
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add public APIs of GBTClassifier.

## Brief change log

 - Adds GBTClassifier and GBTClassifierModel, and their parameters.
 - Adds GBTModelData to complete `fit` and `transform`. Note that actual `fit` and `transform` computations are not implemented in this PR.
 - Adds basic unit tests about parameters and inputs/outputs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
