### PR TITLE
[FLINK-30730][followup] Fix test failure in StringIndexerTest

### DIFF
--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/StringIndexerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/stringindexer/StringIndexerTest.java
@@ -242,15 +242,18 @@ public class StringIndexerTest extends AbstractTestBase {
             IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
             fail();
         } catch (Throwable e) {
-            List<String> expectedErrMsgs =
-                    Stream.of("f", "null")
+            List<String> expectedMessages =
+                    Stream.of("e", "f", "null")
                             .map(
                                     d ->
                                             String.format(
                                                     "The input contains unseen string: %s. See %s parameter for more options.",
                                                     d, HasHandleInvalid.HANDLE_INVALID))
                             .collect(Collectors.toList());
-            assertTrue(expectedErrMsgs.contains(ExceptionUtils.getRootCause(e).getMessage()));
+            String actualMessage = ExceptionUtils.getRootCause(e).getMessage();
+            assertTrue(
+                    "Actual message is: " + actualMessage,
+                    expectedMessages.contains(actualMessage));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fix a failed test in StringIndexerTest, which is encountered with certain probability.

To be specific, in the last assertion of StringIndexerTest#testHandleInvalid, one of multiple values could trigger the exception. All possible values should be considered when building the set of expected messages, yet existing code misses one value. This PR adds the missing value and improves the assertion message.

## Brief change log

 - Fixes the assertion in the failed test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
