### PR TITLE
[FLINK-30688][followup] Disable Kryo fallback for tests in flink-ml-lib

### DIFF
--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/Benchmark.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/Benchmark.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.ml.benchmark;
 
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -78,6 +79,8 @@ public class Benchmark {
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
+        env.getConfig().disableGenericTypes();
+        env.setRestartStrategy(RestartStrategies.noRestart());
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
         int index = 0;

--- a/flink-ml-benchmark/src/test/java/org/apache/flink/ml/benchmark/BenchmarkTest.java
+++ b/flink-ml-benchmark/src/test/java/org/apache/flink/ml/benchmark/BenchmarkTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.ml.benchmark;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator;
 import org.apache.flink.ml.clustering.kmeans.KMeans;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -48,8 +47,7 @@ public class BenchmarkTest extends AbstractTestBase {
 
     @Before
     public void before() {
-        Configuration config = new Configuration();
-        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
         tEnv = StreamTableEnvironment.create(env);
     }

--- a/flink-ml-benchmark/src/test/java/org/apache/flink/ml/benchmark/DataGeneratorTest.java
+++ b/flink-ml-benchmark/src/test/java/org/apache/flink/ml/benchmark/DataGeneratorTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.ml.benchmark;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorArrayGenerator;
 import org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator;
 import org.apache.flink.ml.benchmark.datagenerator.common.DoubleGenerator;
@@ -27,7 +26,6 @@ import org.apache.flink.ml.benchmark.datagenerator.common.LabeledPointWithWeight
 import org.apache.flink.ml.benchmark.datagenerator.common.RandomStringArrayGenerator;
 import org.apache.flink.ml.benchmark.datagenerator.common.RandomStringGenerator;
 import org.apache.flink.ml.linalg.DenseVector;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
@@ -49,9 +47,7 @@ public class DataGeneratorTest {
 
     @Before
     public void before() {
-        Configuration config = new Configuration();
-        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
         env.setParallelism(4);
         env.enableCheckpointing(100);

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/api/StageTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/api/StageTest.java
@@ -49,10 +49,12 @@ import org.apache.flink.ml.param.WindowsParam;
 import org.apache.flink.ml.param.WithParams;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.TestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -65,6 +67,8 @@ import static org.junit.Assert.assertEquals;
 
 /** Tests the behavior of Stage and WithParams. */
 public class StageTest {
+
+    private StreamTableEnvironment tEnv;
 
     // A WithParams subclass which has one parameter for each pre-defined parameter type.
     private interface MyParams<T> extends WithParams<T> {
@@ -246,6 +250,12 @@ public class StageTest {
         return loadedStage;
     }
 
+    @Before
+    public void before() {
+        StreamExecutionEnvironment env = TestUtils.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
+    }
+
     @Test
     public void testParamSetValueWithName() {
         MyStage stage = new MyStage();
@@ -392,8 +402,6 @@ public class StageTest {
 
     @Test
     public void testStageSaveLoad() throws IOException {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
         MyStage stage = new MyStage();
 
         stage.set(stage.paramWithNullDefault, 1);
@@ -457,8 +465,6 @@ public class StageTest {
 
     @Test
     public void testSaveLoadWithSpecialParams() throws IOException {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
         MyStage stage = new MyStage();
         stage.set(stage.paramWithNullDefault, 1);
 
@@ -487,8 +493,6 @@ public class StageTest {
 
     @Test
     public void testStageSaveLoadWithParamOverrides() throws IOException {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
         MyStage stage = new MyStage();
         stage.set(stage.paramWithNullDefault, 1);
         Stage<?> loadedStage =
@@ -499,8 +503,6 @@ public class StageTest {
 
     @Test
     public void testStageLoadWithoutLoadMethod() throws IOException {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
         MyStageWithoutLoad stage = new MyStageWithoutLoad();
         try {
             validateStageSaveLoad(tEnv, stage, Collections.emptyMap());
@@ -575,8 +577,6 @@ public class StageTest {
 
     @Test
     public void testSaveLoadWindowsParams() throws Exception {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
         MyStage stage = new MyStage();
 
         Windows[] testWindows =

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/common/datastream/TableUtilsTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/common/datastream/TableUtilsTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.ml.linalg.SparseVector;
 import org.apache.flink.ml.linalg.typeinfo.DenseMatrixTypeInfo;
 import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
 import org.apache.flink.ml.linalg.typeinfo.SparseVectorTypeInfo;
+import org.apache.flink.ml.util.TestUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
@@ -55,7 +56,7 @@ public class TableUtilsTest {
 
     @Before
     public void before() {
-        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env = TestUtils.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env);
     }
 

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/util/TestUtils.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/util/TestUtils.java
@@ -37,7 +37,6 @@ import org.apache.flink.ml.linalg.DenseVector;
 import org.apache.flink.ml.linalg.Vector;
 import org.apache.flink.ml.linalg.typeinfo.SparseVectorTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -62,12 +61,20 @@ public class TestUtils {
 
     /**
      * Gets a {@link StreamExecutionEnvironment} with the most common configurations of the Flink ML
+     * program as well as the given extra configuration.
+     */
+    public static StreamExecutionEnvironment getExecutionEnvironment(Configuration extraConfig) {
+        StreamExecutionEnvironment env = getExecutionEnvironment();
+        env.configure(extraConfig);
+        return env;
+    }
+
+    /**
+     * Gets a {@link StreamExecutionEnvironment} with the most common configurations of the Flink ML
      * program.
      */
     public static StreamExecutionEnvironment getExecutionEnvironment() {
-        Configuration config = new Configuration();
-        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
         env.getConfig().disableGenericTypes();
         env.setParallelism(4);

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/Iterations.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/Iterations.java
@@ -20,7 +20,7 @@ package org.apache.flink.iteration;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.iteration.compile.DraftExecutionEnvironment;
 import org.apache.flink.iteration.operator.HeadOperator;
 import org.apache.flink.iteration.operator.HeadOperatorFactory;
@@ -278,7 +278,7 @@ public class Iterations {
             tailsAndCriteriaTails.addAll(criteriaTails.getDataStreams());
         }
 
-        DataStream<Object> tailsUnion =
+        DataStream<Integer> tailsUnion =
                 unionAllTails(env, new DataStreamList(tailsAndCriteriaTails));
 
         return addOutputs(
@@ -405,14 +405,15 @@ public class Iterations {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private static DataStream<Object> unionAllTails(
+    private static DataStream<Integer> unionAllTails(
             StreamExecutionEnvironment env, DataStreamList tailsAndCriteriaTails) {
+
         return Iterations.<DataStream>map(
                         tailsAndCriteriaTails,
                         tail ->
                                 tail.filter(r -> false)
                                         .name("filter-tail")
-                                        .returns(new GenericTypeInfo(Object.class))
+                                        .returns((TypeInformation) Types.INT)
                                         .setParallelism(
                                                 tail.getParallelism() > 0
                                                         ? tail.getParallelism()

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/HeadOperator.java
@@ -226,7 +226,8 @@ public class HeadOperator extends AbstractStreamOperator<IterationRecord<?>>
                 context.getOperatorStateStore()
                         .getListState(
                                 new ListStateDescriptor<>(
-                                        "processorState", HeadOperatorState.class));
+                                        "processorState", HeadOperatorState.TYPE_INFO));
+
         OperatorStateUtils.getUniqueElement(processorState, "processorState")
                 .ifPresent(
                         headOperatorState ->

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorState.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/headprocessor/HeadOperatorState.java
@@ -18,11 +18,27 @@
 
 package org.apache.flink.iteration.operator.headprocessor;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /** The state entry for the head operator. */
 public class HeadOperatorState {
+
+    private static final Map<String, TypeInformation<?>> fields;
+
+    static {
+        fields = new HashMap<>();
+        fields.put("numFeedbackRecordsEachRound", Types.MAP(Types.INT, Types.LONG));
+        fields.put("latestRoundAligned", Types.INT);
+        fields.put("latestRoundGloballyAligned", Types.INT);
+    }
+
+    public static final TypeInformation<HeadOperatorState> TYPE_INFO =
+            Types.POJO(HeadOperatorState.class, fields);
 
     public static final HeadOperatorState FINISHED_STATE =
             new HeadOperatorState(Collections.emptyMap(), 0, 0);
@@ -32,6 +48,12 @@ public class HeadOperatorState {
     private int latestRoundAligned;
 
     private int latestRoundGloballyAligned;
+
+    public HeadOperatorState() {
+        numFeedbackRecordsEachRound = new HashMap<>();
+        latestRoundAligned = 0;
+        latestRoundGloballyAligned = 0;
+    }
 
     public HeadOperatorState(
             Map<Integer, Long> numFeedbackRecordsEachRound,

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/typeinfo/IterationRecordTypeInfo.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/typeinfo/IterationRecordTypeInfo.java
@@ -74,7 +74,7 @@ public class IterationRecordTypeInfo<T> extends TypeInformation<IterationRecord<
 
     @Override
     public String toString() {
-        return "IterationRecord Type";
+        return "IterationRecord<" + innerTypeInfo + ">";
     }
 
     @Override

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/OnlineLogisticRegression.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/OnlineLogisticRegression.java
@@ -23,7 +23,9 @@ import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.iteration.DataStreamList;
 import org.apache.flink.iteration.IterationBody;
 import org.apache.flink.iteration.IterationBodyResult;
@@ -31,6 +33,7 @@ import org.apache.flink.iteration.Iterations;
 import org.apache.flink.iteration.operator.OperatorStateUtils;
 import org.apache.flink.ml.api.Estimator;
 import org.apache.flink.ml.common.datastream.DataStreamUtils;
+import org.apache.flink.ml.common.datastream.TableUtils;
 import org.apache.flink.ml.linalg.BLAS;
 import org.apache.flink.ml.linalg.DenseVector;
 import org.apache.flink.ml.linalg.SparseVector;
@@ -88,11 +91,28 @@ public class OnlineLogisticRegression
         DataStream<LogisticRegressionModelData> modelDataStream =
                 LogisticRegressionModelData.getModelDataStream(initModelDataTable);
 
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+        TypeInformation pointTypeInfo;
+
+        if (getWeightCol() == null) {
+            pointTypeInfo =
+                    Types.ROW(
+                            inputTypeInfo.getTypeAt(getFeaturesCol()),
+                            inputTypeInfo.getTypeAt(getLabelCol()));
+        } else {
+            pointTypeInfo =
+                    Types.ROW(
+                            inputTypeInfo.getTypeAt(getFeaturesCol()),
+                            inputTypeInfo.getTypeAt(getLabelCol()),
+                            inputTypeInfo.getTypeAt(getWeightCol()));
+        }
+
         DataStream<Row> points =
                 tEnv.toDataStream(inputs[0])
                         .map(
                                 new FeaturesLabelExtractor(
-                                        getFeaturesCol(), getLabelCol(), getWeightCol()));
+                                        getFeaturesCol(), getLabelCol(), getWeightCol()),
+                                pointTypeInfo);
 
         DataStream<DenseVector> initModelData =
                 modelDataStream.map(

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/LinearSVCTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/LinearSVCTest.java
@@ -18,11 +18,9 @@
 
 package org.apache.flink.ml.classification;
 
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.ml.classification.linearsvc.LinearSVC;
 import org.apache.flink.ml.classification.linearsvc.LinearSVCModel;
 import org.apache.flink.ml.classification.linearsvc.LinearSVCModelData;
@@ -33,7 +31,6 @@ import org.apache.flink.ml.linalg.Vectors;
 import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.ml.util.TestUtils;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -87,13 +84,7 @@ public class LinearSVCTest extends AbstractTestBase {
 
     @Before
     public void before() {
-        Configuration config = new Configuration();
-        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
-        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
-        env.getConfig().enableObjectReuse();
-        env.setParallelism(4);
-        env.enableCheckpointing(100);
-        env.setRestartStrategy(RestartStrategies.noRestart());
+        env = TestUtils.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env);
         Collections.shuffle(trainData);
         trainDataTable =

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/LogisticRegressionTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/LogisticRegressionTest.java
@@ -18,11 +18,9 @@
 
 package org.apache.flink.ml.classification;
 
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.ml.classification.logisticregression.LogisticRegression;
 import org.apache.flink.ml.classification.logisticregression.LogisticRegressionModel;
 import org.apache.flink.ml.classification.logisticregression.LogisticRegressionModelData;
@@ -33,7 +31,6 @@ import org.apache.flink.ml.linalg.Vectors;
 import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.ml.util.TestUtils;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -104,13 +101,7 @@ public class LogisticRegressionTest extends AbstractTestBase {
 
     @Before
     public void before() {
-        Configuration config = new Configuration();
-        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
-        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
-        env.getConfig().enableObjectReuse();
-        env.setParallelism(4);
-        env.enableCheckpointing(100);
-        env.setRestartStrategy(RestartStrategies.noRestart());
+        env = TestUtils.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env);
         Collections.shuffle(binomialTrainData);
         binomialDataTable =

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/KMeansTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/KMeansTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.ml.clustering;
 
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.ml.clustering.kmeans.KMeans;
 import org.apache.flink.ml.clustering.kmeans.KMeansModel;
 import org.apache.flink.ml.clustering.kmeans.KMeansModelData;
@@ -31,7 +29,6 @@ import org.apache.flink.ml.linalg.Vectors;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.ml.util.TestUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -89,15 +86,8 @@ public class KMeansTest extends AbstractTestBase {
 
     @Before
     public void before() {
-        Configuration config = new Configuration();
-        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
-        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
-        env.getConfig().enableObjectReuse();
-        env.setParallelism(4);
-        env.enableCheckpointing(100);
-        env.setRestartStrategy(RestartStrategies.noRestart());
+        env = TestUtils.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env);
-
         dataTable = tEnv.fromDataStream(env.fromCollection(DATA)).as("features");
     }
 

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/OnlineKMeansTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/clustering/OnlineKMeansTest.java
@@ -20,9 +20,9 @@ package org.apache.flink.ml.clustering;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.ml.clustering.kmeans.KMeans;
@@ -43,7 +43,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.runtime.testutils.InMemoryReporter;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -152,7 +151,7 @@ public class OnlineKMeansTest extends TestLogger {
     public static void beforeClass() throws Exception {
         Configuration config = new Configuration();
         config.set(RestOptions.BIND_PORT, "18081-19091");
-        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        config.set(CoreOptions.DEFAULT_PARALLELISM, defaultParallelism);
         reporter = InMemoryReporter.create();
         reporter.addToConfiguration(config);
 
@@ -165,12 +164,7 @@ public class OnlineKMeansTest extends TestLogger {
                                 .build());
 
         miniCluster.start();
-
-        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
-        env.getConfig().enableObjectReuse();
-        env.setParallelism(defaultParallelism);
-        env.enableCheckpointing(100);
-        env.setRestartStrategy(RestartStrategies.noRestart());
+        env = TestUtils.getExecutionEnvironment(config);
         tEnv = StreamTableEnvironment.create(env);
     }
 

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/HashingTFTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/HashingTFTest.java
@@ -18,13 +18,11 @@
 
 package org.apache.flink.ml.feature;
 
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.ml.feature.hashingtf.HashingTF;
 import org.apache.flink.ml.linalg.Vectors;
 import org.apache.flink.ml.util.TestUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Expressions;
 import org.apache.flink.table.api.Table;
@@ -83,15 +81,9 @@ public class HashingTFTest extends AbstractTestBase {
 
     @Before
     public void before() {
-        Configuration config = new Configuration();
-        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
-        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
-        env.getConfig().enableObjectReuse();
-        env.setParallelism(4);
-        env.enableCheckpointing(100);
-        env.setRestartStrategy(RestartStrategies.noRestart());
+        env = TestUtils.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env);
-        DataStream<Row> dataStream = env.fromCollection(INPUT);
+        DataStream<Row> dataStream = env.fromCollection(INPUT, Types.ROW(Types.LIST(Types.STRING)));
         inputDataTable = tEnv.fromDataStream(dataStream).as("input");
     }
 

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/OnlineStandardScalerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/OnlineStandardScalerTest.java
@@ -21,12 +21,10 @@ package org.apache.flink.ml.feature;
 import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.MapFunction;
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.ml.common.window.CountTumblingWindows;
 import org.apache.flink.ml.common.window.EventTimeTumblingWindows;
 import org.apache.flink.ml.common.window.GlobalWindows;
@@ -41,7 +39,6 @@ import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.ml.util.TestUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
@@ -109,13 +106,7 @@ public class OnlineStandardScalerTest extends AbstractTestBase {
 
     @Before
     public void before() {
-        Configuration config = new Configuration();
-        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
-        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
-        env.getConfig().enableObjectReuse();
-        env.setParallelism(4);
-        env.enableCheckpointing(100);
-        env.setRestartStrategy(RestartStrategies.noRestart());
+        env = TestUtils.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env);
 
         DataStream<Row> inputStream = env.fromCollection(inputData);

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/regression/LinearRegressionTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/regression/LinearRegressionTest.java
@@ -18,11 +18,9 @@
 
 package org.apache.flink.ml.regression;
 
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.ml.linalg.SparseVector;
 import org.apache.flink.ml.linalg.Vectors;
 import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
@@ -31,7 +29,6 @@ import org.apache.flink.ml.regression.linearregression.LinearRegressionModel;
 import org.apache.flink.ml.regression.linearregression.LinearRegressionModelData;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.ml.util.TestUtils;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -87,13 +84,7 @@ public class LinearRegressionTest extends AbstractTestBase {
 
     @Before
     public void before() {
-        Configuration config = new Configuration();
-        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
-        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
-        env.getConfig().enableObjectReuse();
-        env.setParallelism(4);
-        env.enableCheckpointing(100);
-        env.setRestartStrategy(RestartStrategies.noRestart());
+        env = TestUtils.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env);
         Collections.shuffle(trainData);
         trainDataTable =

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundCheckpointITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundCheckpointITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.test.iteration;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.iteration.DataStreamList;
 import org.apache.flink.iteration.IterationBodyResult;
 import org.apache.flink.iteration.Iterations;
@@ -29,7 +28,6 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.test.iteration.operators.EpochRecord;
@@ -131,16 +129,7 @@ public class BoundedAllRoundCheckpointITCase extends TestLogger {
             int maxRound,
             int failoverCount,
             SinkFunction<OutputRecord<Integer>> sinkFunction) {
-        StreamExecutionEnvironment env =
-                StreamExecutionEnvironment.getExecutionEnvironment(
-                        new Configuration() {
-                            {
-                                this.set(
-                                        ExecutionCheckpointingOptions
-                                                .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
-                                        true);
-                            }
-                        });
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
         env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
         env.setParallelism(1);

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundCheckpointITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundCheckpointITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.test.iteration;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.iteration.DataStreamList;
 import org.apache.flink.iteration.IterationBody;
 import org.apache.flink.iteration.IterationBodyResult;
@@ -32,7 +31,6 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.test.iteration.operators.EpochRecord;
@@ -124,16 +122,7 @@ public class BoundedPerRoundCheckpointITCase extends TestLogger {
             int maxRound,
             int failoverCount,
             SinkFunction<OutputRecord<Integer>> sinkFunction) {
-        StreamExecutionEnvironment env =
-                StreamExecutionEnvironment.getExecutionEnvironment(
-                        new Configuration() {
-                            {
-                                this.set(
-                                        ExecutionCheckpointingOptions
-                                                .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
-                                        true);
-                            }
-                        });
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
         env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
         env.setParallelism(1);


### PR DESCRIPTION
## What is the purpose of the change

Disable Kryo fallback for all tests (except `OnlineLogisticRegressionTest`) in flink-ml-lib to ensure that all Flink ML algorithms can run without relying on Kryo for serialization and deserialization.

In addition, this PR also updates `Benchmark#executeBenchmarks` to disable Kryo fallback to make sure that our benchmarks (including data generators) do not reply on Kryo.

## Brief change log

Disabled Kryo fallback in the following classes and methods:
- OnlineStandardScalerTest
- LogisticRegressionTest
- KMeansTest
- OnlineKMeansTest
- LinearSVCTest
- LinearRegressionTest
- HashingTFTest
- Benchmark#executeBenchmarks
- TableUtilsTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable