### PR TITLE
[FLINK-31010] Add Transformer and Estimator for GBTClassifier and GBTRegressor

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/util/ReadWriteUtils.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/util/ReadWriteUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.ml.util;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.connector.file.src.FileSource;
@@ -464,6 +465,30 @@ public class ReadWriteUtils {
                 FileSource.forRecordStreamFormat(modelDecoder, new Path(getDataPath(path))).build();
         DataStream<T> modelDataStream =
                 env.fromSource(source, WatermarkStrategy.noWatermarks(), "modelData");
+        return tEnv.fromDataStream(modelDataStream);
+    }
+
+    /**
+     * Loads the model data from the given path using the model decoder. This overloaded version
+     * returns a table with only 1 column whose type is the class of the model data.
+     *
+     * @param tEnv A StreamTableEnvironment instance.
+     * @param path The parent directory of the model data file.
+     * @param modelDecoder The decoder used to decode the model data.
+     * @param typeInfo The type information of model data.
+     * @param <T> The class type of the model data.
+     * @return The loaded model data.
+     */
+    public static <T> Table loadModelData(
+            StreamTableEnvironment tEnv,
+            String path,
+            SimpleStreamFormat<T> modelDecoder,
+            TypeInformation<T> typeInfo) {
+        StreamExecutionEnvironment env = TableUtils.getExecutionEnvironment(tEnv);
+        Source<T, ?, ?> source =
+                FileSource.forRecordStreamFormat(modelDecoder, new Path(getDataPath(path))).build();
+        DataStream<T> modelDataStream =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "modelData", typeInfo);
         return tEnv.fromDataStream(modelDataStream);
     }
 }

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/util/TestUtils.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/util/TestUtils.java
@@ -47,6 +47,7 @@ import org.apache.flink.types.Row;
 
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Assert;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -267,5 +268,56 @@ public class TestUtils {
             }
         }
         return 0;
+    }
+
+    /**
+     * Compare two lists of elements with the given comparator. Different from {@link
+     * org.apache.flink.test.util.TestBaseUtils#compareResultCollections}, the comparator is also
+     * used when comparing elements.
+     */
+    public static <X> void compareResultCollectionsWithComparator(
+            List<X> expected, List<X> actual, Comparator<X> comparator) {
+        Assert.assertEquals(expected.size(), actual.size());
+        expected.sort(comparator);
+        actual.sort(comparator);
+        for (int i = 0; i < expected.size(); i++) {
+            Assert.assertEquals(0, comparator.compare(expected.get(i), actual.get(i)));
+        }
+    }
+
+    public static class DoubleComparatorWithDelta implements Comparator<Double> {
+        private final double delta;
+
+        public DoubleComparatorWithDelta(double delta) {
+            this.delta = delta;
+        }
+
+        @Override
+        public int compare(Double o1, Double o2) {
+            return Math.abs(o1 - o2) <= delta ? 0 : Double.compare(o1, o2);
+        }
+    }
+
+    public static class DenseVectorComparatorWithDelta implements Comparator<DenseVector> {
+        private final DoubleComparatorWithDelta doubleComparatorWithDelta;
+
+        public DenseVectorComparatorWithDelta(double delta) {
+            doubleComparatorWithDelta = new DoubleComparatorWithDelta(delta);
+        }
+
+        @Override
+        public int compare(DenseVector o1, DenseVector o2) {
+            if (o1.size() != o2.size()) {
+                return Integer.compare(o1.size(), o2.size());
+            } else {
+                for (int i = 0; i < o1.size(); i++) {
+                    int cmp = doubleComparatorWithDelta.compare(o1.get(i), o2.get(i));
+                    if (cmp != 0) {
+                        return cmp;
+                    }
+                }
+            }
+            return 0;
+        }
     }
 }

--- a/flink-ml-lib/pom.xml
+++ b/flink-ml-lib/pom.xml
@@ -110,6 +110,16 @@ under the License.
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.collections</groupId>
+      <artifactId>eclipse-collections-api</artifactId>
+      <version>11.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.collections</groupId>
+      <artifactId>eclipse-collections</artifactId>
+      <version>11.1.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifier.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifier.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.classification.gbtclassifier;
+
+import org.apache.flink.ml.api.Estimator;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+import org.apache.flink.ml.common.gbt.GBTRunner;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** An Estimator which implements the gradient boosting trees classification algorithm. */
+public class GBTClassifier
+        implements Estimator<GBTClassifier, GBTClassifierModel>,
+                GBTClassifierParams<GBTClassifier> {
+
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public GBTClassifier() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    public static GBTClassifier load(StreamTableEnvironment tEnv, String path) throws IOException {
+        return ReadWriteUtils.loadStageParam(path);
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    @Override
+    public GBTClassifierModel fit(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<GBTModelData> modelData = GBTRunner.trainClassifier(inputs[0], this);
+        GBTClassifierModel model = new GBTClassifierModel();
+        model.setModelData(tEnv.fromDataStream(modelData).renameColumns($("f0").as("modelData")));
+        ReadWriteUtils.updateExistingParams(model, getParamMap());
+        return model;
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifierModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifierModel.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.classification.gbtclassifier;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.common.broadcast.BroadcastUtils;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.common.gbt.BaseGBTModel;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.math3.analysis.function.Sigmoid;
+import org.eclipse.collections.impl.map.mutable.primitive.IntDoubleHashMap;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/** A Model computed by {@link GBTClassifier}. */
+public class GBTClassifierModel extends BaseGBTModel<GBTClassifierModel>
+        implements GBTClassifierParams<GBTClassifierModel> {
+
+    /**
+     * Loads model data from path.
+     *
+     * @param tEnv A StreamTableEnvironment instance.
+     * @param path Model path.
+     * @return GBT classification model.
+     */
+    public static GBTClassifierModel load(StreamTableEnvironment tEnv, String path)
+            throws IOException {
+        GBTClassifierModel model = ReadWriteUtils.loadStageParam(path);
+        Table modelDataTable =
+                ReadWriteUtils.loadModelData(tEnv, path, new GBTModelData.ModelDataDecoder());
+        return model.setModelData(modelDataTable);
+    }
+
+    @Override
+    public Table[] transform(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<Row> inputStream = tEnv.toDataStream(inputs[0]);
+        final String broadcastModelKey = "broadcastModelKey";
+        DataStream<GBTModelData> modelDataStream = GBTModelData.getModelDataStream(modelDataTable);
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(
+                                inputTypeInfo.getFieldTypes(),
+                                Types.DOUBLE,
+                                DenseVectorTypeInfo.INSTANCE,
+                                DenseVectorTypeInfo.INSTANCE),
+                        ArrayUtils.addAll(
+                                inputTypeInfo.getFieldNames(),
+                                getPredictionCol(),
+                                getRawPredictionCol(),
+                                getProbabilityCol()));
+        DataStream<Row> predictionResult =
+                BroadcastUtils.withBroadcastStream(
+                        Collections.singletonList(inputStream),
+                        Collections.singletonMap(broadcastModelKey, modelDataStream),
+                        inputList -> {
+                            //noinspection unchecked
+                            DataStream<Row> inputData = (DataStream<Row>) inputList.get(0);
+                            return inputData.map(
+                                    new PredictLabelFunction(
+                                            broadcastModelKey, getInputCols(), getFeaturesCol()),
+                                    outputTypeInfo);
+                        });
+        return new Table[] {tEnv.fromDataStream(predictionResult)};
+    }
+
+    private static class PredictLabelFunction extends RichMapFunction<Row, Row> {
+
+        private static final Sigmoid sigmoid = new Sigmoid();
+
+        private final String broadcastModelKey;
+        private final String[] inputCols;
+        private final String featuresCol;
+        private GBTModelData modelData;
+
+        public PredictLabelFunction(
+                String broadcastModelKey, String[] inputCols, String featuresCol) {
+            this.broadcastModelKey = broadcastModelKey;
+            this.inputCols = inputCols;
+            this.featuresCol = featuresCol;
+        }
+
+        @Override
+        public Row map(Row value) throws Exception {
+            if (null == modelData) {
+                modelData =
+                        (GBTModelData)
+                                getRuntimeContext().getBroadcastVariable(broadcastModelKey).get(0);
+            }
+            IntDoubleHashMap features = modelData.rowToFeatures(value, inputCols, featuresCol);
+            double logits = modelData.predictRaw(features);
+            double prob = sigmoid.value(logits);
+            return Row.join(
+                    value,
+                    Row.of(
+                            logits >= 0. ? 1. : 0.,
+                            Vectors.dense(-logits, logits),
+                            Vectors.dense(1 - prob, prob)));
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifierParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/gbtclassifier/GBTClassifierParams.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.classification.gbtclassifier;
+
+import org.apache.flink.ml.common.gbt.BaseGBTParams;
+import org.apache.flink.ml.common.param.HasProbabilityCol;
+import org.apache.flink.ml.common.param.HasRawPredictionCol;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+
+/**
+ * Parameters for {@link GBTClassifier}.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface GBTClassifierParams<T>
+        extends BaseGBTParams<T>, HasRawPredictionCol<T>, HasProbabilityCol<T> {
+
+    Param<String> LOSS_TYPE =
+            new StringParam(
+                    "lossType", "Loss type.", "logistic", ParamValidators.inArray("logistic"));
+
+    default String getLossType() {
+        return get(LOSS_TYPE);
+    }
+
+    default T setLossType(String value) {
+        return set(LOSS_TYPE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BaseGBTModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BaseGBTModel.java
@@ -21,6 +21,7 @@ package org.apache.flink.ml.common.gbt;
 import org.apache.flink.ml.api.Model;
 import org.apache.flink.ml.classification.gbtclassifier.GBTClassifier;
 import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.regression.gbtregressor.GBTRegressor;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
 import org.apache.flink.table.api.Table;
@@ -29,7 +30,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Base model computed by {@link GBTClassifier}. */
+/** Base model computed by {@link GBTClassifier} or {@link GBTRegressor}. */
 public abstract class BaseGBTModel<T extends BaseGBTModel<T>>
         implements Model<T>, GBTModelParams<T> {
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BaseGBTModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BaseGBTModel.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.ml.api.Model;
+import org.apache.flink.ml.classification.gbtclassifier.GBTClassifier;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.table.api.Table;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Base model computed by {@link GBTClassifier}. */
+public abstract class BaseGBTModel<T extends BaseGBTModel<T>>
+        implements Model<T>, GBTModelParams<T> {
+
+    protected final Map<Param<?>, Object> paramMap = new HashMap<>();
+    protected Table modelDataTable;
+
+    public BaseGBTModel() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    @Override
+    public Table[] getModelData() {
+        return new Table[] {modelDataTable};
+    }
+
+    @Override
+    public T setModelData(Table... inputs) {
+        modelDataTable = inputs[0];
+        //noinspection unchecked
+        return (T) this;
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+        ReadWriteUtils.saveModelData(
+                GBTModelData.getModelDataStream(modelDataTable),
+                path,
+                new GBTModelData.ModelDataEncoder());
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BaseGBTParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BaseGBTParams.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.ml.common.param.HasFeatureSubsetStrategy;
+import org.apache.flink.ml.common.param.HasLeafCol;
+import org.apache.flink.ml.common.param.HasMaxBins;
+import org.apache.flink.ml.common.param.HasMaxDepth;
+import org.apache.flink.ml.common.param.HasMaxIter;
+import org.apache.flink.ml.common.param.HasMinInfoGain;
+import org.apache.flink.ml.common.param.HasMinInstancesPerNode;
+import org.apache.flink.ml.common.param.HasMinWeightFractionPerNode;
+import org.apache.flink.ml.common.param.HasSeed;
+import org.apache.flink.ml.common.param.HasStepSize;
+import org.apache.flink.ml.common.param.HasSubsamplingRate;
+import org.apache.flink.ml.common.param.HasValidationIndicatorCol;
+import org.apache.flink.ml.common.param.HasValidationTol;
+import org.apache.flink.ml.common.param.HasWeightCol;
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+
+/**
+ * Common parameters for GBT classifier and regressor.
+ *
+ * <p>TODO: support param thresholds, impurity (actually meaningless)
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface BaseGBTParams<T>
+        extends GBTModelParams<T>,
+                HasLeafCol<T>,
+                HasWeightCol<T>,
+                HasMaxDepth<T>,
+                HasMaxBins<T>,
+                HasMinInstancesPerNode<T>,
+                HasMinWeightFractionPerNode<T>,
+                HasMinInfoGain<T>,
+                HasMaxIter<T>,
+                HasStepSize<T>,
+                HasSeed<T>,
+                HasSubsamplingRate<T>,
+                HasFeatureSubsetStrategy<T>,
+                HasValidationIndicatorCol<T>,
+                HasValidationTol<T> {
+    Param<Double> REG_LAMBDA =
+            new DoubleParam(
+                    "regLambda",
+                    "Regularization term for the number of leaves.",
+                    0.,
+                    ParamValidators.gtEq(0.));
+    Param<Double> REG_GAMMA =
+            new DoubleParam(
+                    "regGamma",
+                    "L2 regularization term for the weights of leaves.",
+                    1.,
+                    ParamValidators.gtEq(0));
+
+    default double getRegLambda() {
+        return get(REG_LAMBDA);
+    }
+
+    default T setRegLambda(Double value) {
+        return set(REG_LAMBDA, value);
+    }
+
+    default double getRegGamma() {
+        return get(REG_GAMMA);
+    }
+
+    default T setRegGamma(Double value) {
+        return set(REG_GAMMA, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BoostIterationBody.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/BoostIterationBody.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.iteration.DataStreamList;
+import org.apache.flink.iteration.IterationBody;
+import org.apache.flink.iteration.IterationBodyResult;
+import org.apache.flink.iteration.IterationID;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.common.gbt.defs.Histogram;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.Splits;
+import org.apache.flink.ml.common.gbt.operators.CacheDataCalcLocalHistsOperator;
+import org.apache.flink.ml.common.gbt.operators.CalcLocalSplitsOperator;
+import org.apache.flink.ml.common.gbt.operators.HistogramAggregateFunction;
+import org.apache.flink.ml.common.gbt.operators.PostSplitsOperator;
+import org.apache.flink.ml.common.gbt.operators.SplitsAggregateFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+/**
+ * Implements iteration body for boosting algorithms. This implementation uses horizontal partition
+ * of data and row-store storage of instances.
+ */
+class BoostIterationBody implements IterationBody {
+    private final IterationID iterationID;
+    private final GbtParams gbtParams;
+
+    public BoostIterationBody(IterationID iterationID, GbtParams gbtParams) {
+        this.iterationID = iterationID;
+        this.gbtParams = gbtParams;
+    }
+
+    @Override
+    public IterationBodyResult process(DataStreamList variableStreams, DataStreamList dataStreams) {
+        DataStream<Row> data = dataStreams.get(0);
+        DataStream<LocalState> localState = variableStreams.get(0);
+
+        final OutputTag<LocalState> stateOutputTag =
+                new OutputTag<>("state", TypeInformation.of(LocalState.class));
+
+        final OutputTag<LocalState> finalStateOutputTag =
+                new OutputTag<>("final_state", TypeInformation.of(LocalState.class));
+
+        /**
+         * In the iteration, some data needs to be shared between subtasks of different operators
+         * within one machine. We use {@link IterationSharedStorage} with co-location mechanism to
+         * achieve such purpose. The data is stored in JVM static region, and is accessed through
+         * string keys from different operator subtasks. Note the first operator to put the data is
+         * the owner of the data, and only the owner can update or delete the data.
+         *
+         * <p>To be specified, in gradient boosting trees algorithm, there three types of shared
+         * data:
+         *
+         * <ul>
+         *   <li>Instances (after binned) and their corresponding predictions, gradients, and
+         *       hessians are shared to avoid being stored multiple times or communication.
+         *   <li>When initializing every new tree, instances need to be shuffled and split to
+         *       bagging instances and non-bagging ones. To reduce the cost, we shuffle instance
+         *       indices other than instances. Therefore, the shuffle indices need to be shared to
+         *       access actual instances.
+         *   <li>After splitting nodes of each layer, instance indices need to be swapped to
+         *       maintain {@link LearningNode#slice} and {@link LearningNode#oob}. However, we
+         *       cannot directly update the data of shuffle indices above, as it already has an
+         *       owner. So we use another key to store instance indices after swapping.
+         * </ul>
+         */
+        final String sharedInstancesKey = "instances";
+        final String sharedPredGradHessKey = "preds_grads_hessians";
+        final String sharedShuffledIndicesKey = "shuffled_indices";
+        final String sharedSwappedIndicesKey = "swapped_indices";
+
+        final String coLocationKey = "boosting";
+
+        // In 1st round, cache all data. For all rounds calculate local histogram based on
+        // current tree layer.
+        SingleOutputStreamOperator<Histogram> localHists =
+                data.connect(localState)
+                        .transform(
+                                "CacheDataCalcLocalHists",
+                                TypeInformation.of(Histogram.class),
+                                new CacheDataCalcLocalHistsOperator(
+                                        gbtParams,
+                                        iterationID,
+                                        sharedInstancesKey,
+                                        sharedPredGradHessKey,
+                                        sharedShuffledIndicesKey,
+                                        sharedSwappedIndicesKey,
+                                        stateOutputTag));
+        localHists.getTransformation().setCoLocationGroupKey("coLocationKey");
+        DataStream<LocalState> modelData = localHists.getSideOutput(stateOutputTag);
+
+        DataStream<Histogram> globalHists = scatterReduceHistograms(localHists);
+
+        SingleOutputStreamOperator<Splits> localSplits =
+                modelData
+                        .connect(globalHists)
+                        .transform(
+                                "CalcLocalSplits",
+                                TypeInformation.of(Splits.class),
+                                new CalcLocalSplitsOperator(stateOutputTag));
+        localHists.getTransformation().setCoLocationGroupKey(coLocationKey);
+        DataStream<Splits> globalSplits =
+                localSplits.broadcast().flatMap(new SplitsAggregateFunction());
+
+        SingleOutputStreamOperator<LocalState> updatedModelData =
+                modelData
+                        .connect(globalSplits.broadcast())
+                        .transform(
+                                "PostSplits",
+                                TypeInformation.of(LocalState.class),
+                                new PostSplitsOperator(
+                                        iterationID,
+                                        sharedInstancesKey,
+                                        sharedPredGradHessKey,
+                                        sharedShuffledIndicesKey,
+                                        sharedSwappedIndicesKey,
+                                        finalStateOutputTag));
+        updatedModelData.getTransformation().setCoLocationGroupKey(coLocationKey);
+
+        DataStream<Integer> termination =
+                updatedModelData.flatMap(
+                        new FlatMapFunction<LocalState, Integer>() {
+                            @Override
+                            public void flatMap(LocalState value, Collector<Integer> out) {
+                                LocalState.Dynamics dynamics = value.dynamics;
+                                boolean terminated =
+                                        !dynamics.inWeakLearner
+                                                && dynamics.roots.size()
+                                                        == value.statics.params.maxIter;
+                                // TODO: add validation error rate
+                                if (!terminated) {
+                                    out.collect(0);
+                                }
+                            }
+                        });
+        termination.getTransformation().setCoLocationGroupKey(coLocationKey);
+
+        return new IterationBodyResult(
+                DataStreamList.of(updatedModelData),
+                DataStreamList.of(updatedModelData.getSideOutput(finalStateOutputTag)),
+                termination);
+    }
+
+    public DataStream<Histogram> scatterReduceHistograms(DataStream<Histogram> localHists) {
+        return localHists
+                .flatMap(
+                        (FlatMapFunction<Histogram, Tuple2<Integer, Histogram>>)
+                                (value, out) -> {
+                                    double[] hists = value.hists;
+                                    int[] recvcnts = value.recvcnts;
+                                    int p = 0;
+                                    for (int i = 0; i < recvcnts.length; i += 1) {
+                                        out.collect(
+                                                Tuple2.of(
+                                                        i,
+                                                        new Histogram(
+                                                                value.subtaskId,
+                                                                ArrayUtils.subarray(
+                                                                        hists, p, p + recvcnts[i]),
+                                                                recvcnts)));
+                                        p += recvcnts[i];
+                                    }
+                                })
+                .returns(new TypeHint<Tuple2<Integer, Histogram>>() {})
+                .partitionCustom(
+                        new Partitioner<Integer>() {
+                            @Override
+                            public int partition(Integer key, int numPartitions) {
+                                return key;
+                            }
+                        },
+                        new KeySelector<Tuple2<Integer, Histogram>, Integer>() {
+                            @Override
+                            public Integer getKey(Tuple2<Integer, Histogram> value)
+                                    throws Exception {
+                                return value.f0;
+                            }
+                        })
+                .map(d -> d.f1)
+                .flatMap(new HistogramAggregateFunction());
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/DataUtils.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/DataUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.ml.feature.kbinsdiscretizer.KBinsDiscretizerModel;
+
+import java.util.Arrays;
+
+/** Some data utilities. */
+public class DataUtils {
+    /** The mapping computation is from {@link KBinsDiscretizerModel}. */
+    public static int findBin(double[] binEdges, double v) {
+        int index = Arrays.binarySearch(binEdges, v);
+        if (index < 0) {
+            // Computes the index to insert.
+            index = -index - 1;
+            // Puts it in the left bin.
+            index--;
+        }
+        return Math.max(Math.min(index, (binEdges.length - 2)), 0);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/DataUtils.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/DataUtils.java
@@ -21,9 +21,39 @@ package org.apache.flink.ml.common.gbt;
 import org.apache.flink.ml.feature.kbinsdiscretizer.KBinsDiscretizerModel;
 
 import java.util.Arrays;
+import java.util.Random;
 
 /** Some data utilities. */
 public class DataUtils {
+
+    // Stores 4 values for one histogram bin, i.e., gradient, hessian, weight, and count.
+    public static final int BIN_SIZE = 4;
+
+    public static void shuffle(int[] array, Random random) {
+        int n = array.length;
+        for (int i = 0; i < n; i += 1) {
+            int index = i + random.nextInt(n - i);
+            int tmp = array[index];
+            array[index] = array[i];
+            array[i] = tmp;
+        }
+    }
+
+    public static int[] sample(int[] values, int numSamples, Random random) {
+        int n = values.length;
+        int[] sampled = new int[numSamples];
+
+        for (int i = 0; i < numSamples; i += 1) {
+            int index = i + random.nextInt(n - i);
+            sampled[i] = values[index];
+
+            int temp = values[i];
+            values[i] = values[index];
+            values[index] = temp;
+        }
+        return sampled;
+    }
+
     /** The mapping computation is from {@link KBinsDiscretizerModel}. */
     public static int findBin(double[] binEdges, double v) {
         int index = Arrays.binarySearch(binEdges, v);

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelData.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.Node;
+import org.apache.flink.ml.feature.stringindexer.StringIndexerModel;
+import org.apache.flink.ml.linalg.SparseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+
+import org.eclipse.collections.impl.map.mutable.primitive.IntDoubleHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectIntHashMap;
+
+import java.util.BitSet;
+import java.util.List;
+
+/**
+ * Model data of gradient boosting trees.
+ *
+ * <p>This class also provides methods to convert model data from Table to Datastream, and classes
+ * to save/load model data.
+ */
+public class GBTModelData {
+
+    public String type;
+    public boolean isInputVector;
+
+    public double prior;
+    public double stepSize;
+
+    public List<Node> roots;
+    public IntObjectHashMap<ObjectIntHashMap<String>> categoryToIdMaps;
+    public IntObjectHashMap<double[]> featureIdToBinEdges;
+    public BitSet isCategorical;
+
+    public GBTModelData() {}
+
+    public GBTModelData(
+            String type,
+            boolean isInputVector,
+            double prior,
+            double stepSize,
+            List<Node> roots,
+            IntObjectHashMap<ObjectIntHashMap<String>> categoryToIdMaps,
+            IntObjectHashMap<double[]> featureIdToBinEdges,
+            BitSet isCategorical) {
+        this.type = type;
+        this.isInputVector = isInputVector;
+        this.prior = prior;
+        this.stepSize = stepSize;
+        this.roots = roots;
+        this.categoryToIdMaps = categoryToIdMaps;
+        this.featureIdToBinEdges = featureIdToBinEdges;
+        this.isCategorical = isCategorical;
+    }
+
+    public static GBTModelData fromLocalState(LocalState state) {
+        IntObjectHashMap<ObjectIntHashMap<String>> categoryToIdMaps = new IntObjectHashMap<>();
+        IntObjectHashMap<double[]> featureIdToBinEdges = new IntObjectHashMap<>();
+        BitSet isCategorical = new BitSet();
+
+        FeatureMeta[] featureMetas = state.statics.featureMetas;
+        for (int k = 0; k < featureMetas.length; k += 1) {
+            FeatureMeta featureMeta = featureMetas[k];
+            if (featureMeta instanceof FeatureMeta.CategoricalFeatureMeta) {
+                String[] categories = ((FeatureMeta.CategoricalFeatureMeta) featureMeta).categories;
+                ObjectIntHashMap<String> categoryToId = new ObjectIntHashMap<>();
+                for (int i = 0; i < categories.length; i += 1) {
+                    categoryToId.put(categories[i], i);
+                }
+                categoryToIdMaps.put(k, categoryToId);
+                isCategorical.set(k);
+            } else if (featureMeta instanceof FeatureMeta.ContinuousFeatureMeta) {
+                featureIdToBinEdges.put(
+                        k, ((FeatureMeta.ContinuousFeatureMeta) featureMeta).binEdges);
+            }
+        }
+        return new GBTModelData(
+                state.statics.params.taskType.name(),
+                state.statics.params.isInputVector,
+                state.statics.prior,
+                state.statics.params.stepSize,
+                state.dynamics.roots,
+                categoryToIdMaps,
+                featureIdToBinEdges,
+                isCategorical);
+    }
+
+    public static DataStream<GBTModelData> getModelDataStream(Table modelDataTable) {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) modelDataTable).getTableEnvironment();
+        return tEnv.toDataStream(modelDataTable).map(x -> x.getFieldAs(0));
+    }
+
+    /** The mapping computation is from {@link StringIndexerModel}. */
+    private static int mapCategoricalFeature(ObjectIntHashMap<String> categoryToId, Object v) {
+        String s;
+        if (v instanceof String) {
+            s = (String) v;
+        } else if (v instanceof Number) {
+            s = String.valueOf(v);
+        } else if (null == v) {
+            s = null;
+        } else {
+            throw new RuntimeException("Categorical column only supports string and numeric type.");
+        }
+        return categoryToId.getIfAbsent(s, categoryToId.size());
+    }
+
+    public IntDoubleHashMap rowToFeatures(Row row, String[] featureCols, String vectorCol) {
+        IntDoubleHashMap features = new IntDoubleHashMap();
+        if (isInputVector) {
+            Vector vec = row.getFieldAs(vectorCol);
+            SparseVector sv = vec.toSparse();
+            for (int i = 0; i < sv.indices.length; i += 1) {
+                features.put(sv.indices[i], sv.values[i]);
+            }
+        } else {
+            for (int i = 0; i < featureCols.length; i += 1) {
+                Object obj = row.getField(featureCols[i]);
+                double v;
+                if (isCategorical.get(i)) {
+                    v = mapCategoricalFeature(categoryToIdMaps.get(i), obj);
+                } else {
+                    Number number = (Number) obj;
+                    v = (null == number) ? Double.NaN : number.doubleValue();
+                }
+                features.put(i, v);
+            }
+        }
+        return features;
+    }
+
+    public double predictRaw(IntDoubleHashMap rawFeatures) {
+        double v = prior;
+        for (Node root : roots) {
+            Node node = root;
+            while (!node.isLeaf) {
+                boolean goLeft = node.split.shouldGoLeft(rawFeatures);
+                node = goLeft ? node.left : node.right;
+            }
+            v += stepSize * node.split.prediction;
+        }
+        return v;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "GBTModelData{type=%s, prior=%s, roots=%s, categoryToIdMaps=%s, featureIdToBinEdges=%s, isCategorical=%s}",
+                type, prior, roots, categoryToIdMaps, featureIdToBinEdges, isCategorical);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelData.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelData.java
@@ -37,6 +37,7 @@ import org.apache.flink.ml.common.gbt.typeinfo.GBTModelDataTypeInfoFactory;
 import org.apache.flink.ml.feature.stringindexer.StringIndexerModel;
 import org.apache.flink.ml.linalg.SparseVector;
 import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.ml.regression.gbtregressor.GBTRegressorModel;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -53,7 +54,7 @@ import java.util.BitSet;
 import java.util.List;
 
 /**
- * Model data of gradient boosting trees.
+ * Model data of {@link GBTClassifierModel}.
  *
  * <p>This class also provides methods to convert model data from Table to Datastream, and classes
  * to save/load model data.

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelParams.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.ml.classification.gbtclassifier.GBTClassifierModel;
+import org.apache.flink.ml.common.param.HasCategoricalCols;
+import org.apache.flink.ml.common.param.HasFeaturesCol;
+import org.apache.flink.ml.common.param.HasLabelCol;
+import org.apache.flink.ml.common.param.HasPredictionCol;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.StringArrayParam;
+
+/**
+ * Params of {@link GBTClassifierModel}.
+ *
+ * <p>If the input features come from 1 column of vector type, `featuresCol` should be used, and all
+ * features are treated as continuous features. Otherwise, `inputCols` should be used for multiple
+ * columns. Columns whose names specified in `categoricalCols` are treated as categorical features,
+ * while others are continuous features.
+ *
+ * <p>NOTE: `inputCols` and `featuresCol` are in conflict with each other, so they should not be set
+ * at the same time. In addition, `inputCols` has a higher precedence than `featuresCol`, that is,
+ * `featuresCol` is ignored when `inputCols` is not `null`.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface GBTModelParams<T>
+        extends HasFeaturesCol<T>, HasLabelCol<T>, HasCategoricalCols<T>, HasPredictionCol<T> {
+
+    Param<String[]> INPUT_COLS = new StringArrayParam("inputCols", "Input column names.", null);
+
+    default String[] getInputCols() {
+        return get(INPUT_COLS);
+    }
+
+    default T setInputCols(String... value) {
+        return set(INPUT_COLS, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTModelParams.java
@@ -25,9 +25,10 @@ import org.apache.flink.ml.common.param.HasLabelCol;
 import org.apache.flink.ml.common.param.HasPredictionCol;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.param.StringArrayParam;
+import org.apache.flink.ml.regression.gbtregressor.GBTRegressorModel;
 
 /**
- * Params of {@link GBTClassifierModel}.
+ * Params of {@link GBTClassifierModel} and {@link GBTRegressorModel}.
  *
  * <p>If the input features come from 1 column of vector type, `featuresCol` should be used, and all
  * features are treated as continuous features. Otherwise, `inputCols` should be used for multiple

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTRunner.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTRunner.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.iteration.DataStreamList;
+import org.apache.flink.iteration.IterationConfig;
+import org.apache.flink.iteration.IterationID;
+import org.apache.flink.iteration.Iterations;
+import org.apache.flink.iteration.ReplayableDataStreamList;
+import org.apache.flink.ml.common.broadcast.BroadcastUtils;
+import org.apache.flink.ml.common.datastream.DataStreamUtils;
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Runs a gradient boosting trees implementation. */
+public class GBTRunner {
+
+    /** Trains a gradient boosting tree model with given data and parameters. */
+    static DataStream<GBTModelData> train(Table dataTable, GbtParams p) {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) dataTable).getTableEnvironment();
+        Tuple2<Table, DataStream<FeatureMeta>> preprocessResult =
+                p.isInputVector
+                        ? Preprocess.preprocessVecCol(dataTable, p)
+                        : Preprocess.preprocessCols(dataTable, p);
+        dataTable = preprocessResult.f0;
+        DataStream<FeatureMeta> featureMeta = preprocessResult.f1;
+
+        DataStream<Row> data = tEnv.toDataStream(dataTable);
+        DataStream<Tuple2<Double, Long>> labelSumCount =
+                DataStreamUtils.aggregate(data, new LabelSumCountFunction(p.labelCol));
+        return boost(dataTable, p, featureMeta, labelSumCount);
+    }
+
+    private static DataStream<GBTModelData> boost(
+            Table dataTable,
+            GbtParams p,
+            DataStream<FeatureMeta> featureMeta,
+            DataStream<Tuple2<Double, Long>> labelSumCount) {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) dataTable).getTableEnvironment();
+
+        final String featureMetaBcName = "featureMeta";
+        final String labelSumCountBcName = "labelSumCount";
+        Map<String, DataStream<?>> bcMap = new HashMap<>();
+        bcMap.put(featureMetaBcName, featureMeta);
+        bcMap.put(labelSumCountBcName, labelSumCount);
+
+        DataStream<LocalState> initStates =
+                BroadcastUtils.withBroadcastStream(
+                        Collections.singletonList(
+                                tEnv.toDataStream(tEnv.fromValues(0), Integer.class)),
+                        bcMap,
+                        (inputs) -> {
+                            //noinspection unchecked
+                            DataStream<Integer> input = (DataStream<Integer>) (inputs.get(0));
+                            return input.map(
+                                    new InitLocalStateFunction(
+                                            featureMetaBcName, labelSumCountBcName, p));
+                        });
+
+        DataStream<Row> data = tEnv.toDataStream(dataTable);
+        final IterationID iterationID = new IterationID();
+        DataStreamList dataStreamList =
+                Iterations.iterateBoundedStreamsUntilTermination(
+                        DataStreamList.of(initStates.broadcast()),
+                        ReplayableDataStreamList.notReplay(data, featureMeta),
+                        IterationConfig.newBuilder()
+                                .setOperatorLifeCycle(IterationConfig.OperatorLifeCycle.ALL_ROUND)
+                                .build(),
+                        new BoostIterationBody(iterationID, p));
+        DataStream<LocalState> state = dataStreamList.get(0);
+        return state.map(GBTModelData::fromLocalState);
+    }
+
+    private static class InitLocalStateFunction extends RichMapFunction<Integer, LocalState> {
+        private final String featureMetaBcName;
+        private final String labelSumCountBcName;
+        private final GbtParams p;
+
+        private InitLocalStateFunction(
+                String featureMetaBcName, String labelSumCountBcName, GbtParams p) {
+            this.featureMetaBcName = featureMetaBcName;
+            this.labelSumCountBcName = labelSumCountBcName;
+            this.p = p;
+        }
+
+        @Override
+        public LocalState map(Integer value) {
+            LocalState.Statics statics = new LocalState.Statics();
+            statics.params = p;
+            statics.featureMetas =
+                    getRuntimeContext()
+                            .<FeatureMeta>getBroadcastVariable(featureMetaBcName)
+                            .toArray(new FeatureMeta[0]);
+            if (!statics.params.isInputVector) {
+                Arrays.sort(
+                        statics.featureMetas,
+                        Comparator.comparing(d -> ArrayUtils.indexOf(p.featureCols, d.name)));
+            }
+            statics.numFeatures = statics.featureMetas.length;
+            statics.labelSumCount =
+                    getRuntimeContext()
+                            .<Tuple2<Double, Long>>getBroadcastVariable(labelSumCountBcName)
+                            .get(0);
+            return new LocalState(statics, new LocalState.Dynamics());
+        }
+    }
+
+    private static class LabelSumCountFunction
+            implements AggregateFunction<Row, Tuple2<Double, Long>, Tuple2<Double, Long>> {
+
+        private final String labelCol;
+
+        private LabelSumCountFunction(String labelCol) {
+            this.labelCol = labelCol;
+        }
+
+        @Override
+        public Tuple2<Double, Long> createAccumulator() {
+            return Tuple2.of(0., 0L);
+        }
+
+        @Override
+        public Tuple2<Double, Long> add(Row value, Tuple2<Double, Long> accumulator) {
+            double label = ((Number) value.getFieldAs(labelCol)).doubleValue();
+            return Tuple2.of(accumulator.f0 + label, accumulator.f1 + 1);
+        }
+
+        @Override
+        public Tuple2<Double, Long> getResult(Tuple2<Double, Long> accumulator) {
+            return accumulator;
+        }
+
+        @Override
+        public Tuple2<Double, Long> merge(Tuple2<Double, Long> a, Tuple2<Double, Long> b) {
+            return Tuple2.of(a.f0 + b.f0, a.f1 + b.f1);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTRunner.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/GBTRunner.java
@@ -34,6 +34,7 @@ import org.apache.flink.ml.common.gbt.defs.GbtParams;
 import org.apache.flink.ml.common.gbt.defs.LocalState;
 import org.apache.flink.ml.common.gbt.defs.TaskType;
 import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.regression.gbtregressor.GBTRegressorParams;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -173,8 +174,7 @@ public class GBTRunner {
         if (TaskType.CLASSIFICATION.equals(p.taskType)) {
             p.lossType = estimator.get(GBTClassifierParams.LOSS_TYPE);
         } else {
-            // TODO: add GBTRegressorParams.LOSS_TYPE in next PR.
-            p.lossType = estimator.get(GBTClassifierParams.LOSS_TYPE);
+            p.lossType = estimator.get(GBTRegressorParams.LOSS_TYPE);
         }
         p.maxNumLeaves = 1 << p.maxDepth - 1;
         p.useMissing = true;

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/Preprocess.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/Preprocess.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.feature.kbinsdiscretizer.KBinsDiscretizer;
+import org.apache.flink.ml.feature.kbinsdiscretizer.KBinsDiscretizerModel;
+import org.apache.flink.ml.feature.kbinsdiscretizer.KBinsDiscretizerModelData;
+import org.apache.flink.ml.feature.stringindexer.StringIndexer;
+import org.apache.flink.ml.feature.stringindexer.StringIndexerModel;
+import org.apache.flink.ml.feature.stringindexer.StringIndexerModelData;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.ApiExpression;
+import org.apache.flink.table.api.Expressions;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.Arrays;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/**
+ * Preprocesses input data table for gradient boosting trees algorithms.
+ *
+ * <p>Multiple non-vector columns or a single vector column can be specified for preprocessing.
+ * Values of these column(s) are mapped to integers inplace through discretizer or string indexer,
+ * and the meta information of column(s) are obtained.
+ */
+class Preprocess {
+
+    /**
+     * Maps continuous and categorical columns to integers inplace using quantile discretizer and
+     * string indexer respectively, and obtains meta information for all columns.
+     */
+    static Tuple2<Table, DataStream<FeatureMeta>> preprocessCols(Table dataTable, GbtParams p) {
+
+        final String[] relatedCols = ArrayUtils.add(p.featureCols, p.labelCol);
+        dataTable =
+                dataTable.select(
+                        Arrays.stream(relatedCols)
+                                .map(Expressions::$)
+                                .toArray(ApiExpression[]::new));
+
+        // Maps continuous columns to integers, and obtain corresponding discretizer model.
+        String[] continuousCols = ArrayUtils.removeElements(p.featureCols, p.categoricalCols);
+        Tuple2<Table, DataStream<KBinsDiscretizerModelData>> continuousMappedDataAndModelData =
+                discretizeContinuousCols(dataTable, continuousCols, p.maxBins);
+        dataTable = continuousMappedDataAndModelData.f0;
+        DataStream<FeatureMeta> continuousFeatureMeta =
+                buildContinuousFeatureMeta(continuousMappedDataAndModelData.f1, continuousCols);
+
+        // Maps categorical columns to integers, and obtain string indexer model.
+        DataStream<FeatureMeta> categoricalFeatureMeta;
+        if (p.categoricalCols.length > 0) {
+            String[] mappedCategoricalCols =
+                    Arrays.stream(p.categoricalCols).map(d -> d + "_output").toArray(String[]::new);
+            StringIndexer stringIndexer =
+                    new StringIndexer()
+                            .setInputCols(p.categoricalCols)
+                            .setOutputCols(mappedCategoricalCols)
+                            .setHandleInvalid("keep");
+            StringIndexerModel stringIndexerModel = stringIndexer.fit(dataTable);
+            dataTable = stringIndexerModel.transform(dataTable)[0];
+
+            categoricalFeatureMeta =
+                    buildCategoricalFeatureMeta(
+                            StringIndexerModelData.getModelDataStream(
+                                    stringIndexerModel.getModelData()[0]),
+                            p.categoricalCols);
+        } else {
+            categoricalFeatureMeta =
+                    continuousFeatureMeta
+                            .<FeatureMeta>flatMap((value, out) -> {})
+                            .returns(TypeInformation.of(FeatureMeta.class));
+        }
+
+        // Rename results columns.
+        ApiExpression[] dropColumnExprs =
+                Arrays.stream(p.categoricalCols).map(Expressions::$).toArray(ApiExpression[]::new);
+        ApiExpression[] renameColumnExprs =
+                Arrays.stream(p.categoricalCols)
+                        .map(d -> $(d + "_output").as(d))
+                        .toArray(ApiExpression[]::new);
+        dataTable = dataTable.dropColumns(dropColumnExprs).renameColumns(renameColumnExprs);
+
+        return Tuple2.of(dataTable, continuousFeatureMeta.union(categoricalFeatureMeta));
+    }
+
+    /**
+     * Maps features values in vectors to integers using quantile discretizer, and obtains meta
+     * information for all features.
+     */
+    static Tuple2<Table, DataStream<FeatureMeta>> preprocessVecCol(Table dataTable, GbtParams p) {
+        dataTable = dataTable.select($(p.vectorCol), $(p.labelCol));
+        Tuple2<Table, DataStream<KBinsDiscretizerModelData>> mappedDataAndModelData =
+                discretizeVectorCol(dataTable, p.vectorCol, p.maxBins);
+        dataTable = mappedDataAndModelData.f0;
+        DataStream<FeatureMeta> featureMeta =
+                buildContinuousFeatureMeta(mappedDataAndModelData.f1, null);
+        return Tuple2.of(dataTable, featureMeta);
+    }
+
+    /** Builds {@link FeatureMeta} from {@link StringIndexerModelData}. */
+    private static DataStream<FeatureMeta> buildCategoricalFeatureMeta(
+            DataStream<StringIndexerModelData> stringIndexerModelData, String[] cols) {
+        return stringIndexerModelData
+                .<FeatureMeta>flatMap(
+                        (d, out) -> {
+                            Preconditions.checkArgument(d.stringArrays.length == cols.length);
+                            for (int i = 0; i < cols.length; i += 1) {
+                                out.collect(
+                                        FeatureMeta.categorical(
+                                                cols[i],
+                                                d.stringArrays[i].length,
+                                                d.stringArrays[i]));
+                            }
+                        })
+                .returns(TypeInformation.of(FeatureMeta.class));
+    }
+
+    /** Builds {@link FeatureMeta} from {@link KBinsDiscretizerModelData}. */
+    private static DataStream<FeatureMeta> buildContinuousFeatureMeta(
+            DataStream<KBinsDiscretizerModelData> discretizerModelData, String[] cols) {
+        return discretizerModelData
+                .<FeatureMeta>flatMap(
+                        (d, out) -> {
+                            double[][] binEdges = d.binEdges;
+                            for (int i = 0; i < binEdges.length; i += 1) {
+                                String name = (null != cols) ? cols[i] : "_vec_f" + i;
+                                out.collect(
+                                        FeatureMeta.continuous(
+                                                name, binEdges[i].length - 1, binEdges[i]));
+                            }
+                        })
+                .returns(TypeInformation.of(FeatureMeta.class));
+    }
+
+    /** Discretizes continuous columns inplace, and obtains quantile discretizer model data. */
+    @SuppressWarnings("checkstyle:RegexpSingleline")
+    private static Tuple2<Table, DataStream<KBinsDiscretizerModelData>> discretizeContinuousCols(
+            Table dataTable, String[] continuousCols, int numBins) {
+        final StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) dataTable).getTableEnvironment();
+        final int nCols = continuousCols.length;
+
+        // Merges all continuous columns into a vector columns.
+        final String vectorCol = "_vec";
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(dataTable.getResolvedSchema());
+        DataStream<Row> data = tEnv.toDataStream(dataTable, Row.class);
+        DataStream<Row> dataWithVectors =
+                data.map(
+                        (row) -> {
+                            double[] values = new double[nCols];
+                            for (int i = 0; i < nCols; i += 1) {
+                                Number number = row.getFieldAs(continuousCols[i]);
+                                // Null values are represented using `Double.NaN` in `DenseVector`.
+                                values[i] = (null == number) ? Double.NaN : number.doubleValue();
+                            }
+                            return Row.join(row, Row.of(Vectors.dense(values)));
+                        },
+                        new RowTypeInfo(
+                                ArrayUtils.add(
+                                        inputTypeInfo.getFieldTypes(),
+                                        DenseVectorTypeInfo.INSTANCE),
+                                ArrayUtils.add(inputTypeInfo.getFieldNames(), vectorCol)));
+
+        Tuple2<Table, DataStream<KBinsDiscretizerModelData>> mappedDataAndModelData =
+                discretizeVectorCol(tEnv.fromDataStream(dataWithVectors), vectorCol, numBins);
+        DataStream<Row> discretized = tEnv.toDataStream(mappedDataAndModelData.f0);
+
+        // Maps the result vector back to multiple continuous columns.
+        final String[] otherCols =
+                ArrayUtils.removeElements(inputTypeInfo.getFieldNames(), continuousCols);
+        final TypeInformation<?>[] otherColTypes =
+                Arrays.stream(otherCols)
+                        .map(inputTypeInfo::getTypeAt)
+                        .toArray(TypeInformation[]::new);
+        final TypeInformation<?>[] mappedColTypes =
+                Arrays.stream(continuousCols).map(d -> Types.INT).toArray(TypeInformation[]::new);
+
+        DataStream<Row> mapped =
+                discretized.map(
+                        (row) -> {
+                            DenseVector vec = row.getFieldAs(vectorCol);
+                            Integer[] ints =
+                                    Arrays.stream(vec.values)
+                                            .mapToObj(d -> (Integer) ((int) d))
+                                            .toArray(Integer[]::new);
+                            Row result = Row.project(row, otherCols);
+                            for (int i = 0; i < ints.length; i += 1) {
+                                result.setField(continuousCols[i], ints[i]);
+                            }
+                            return result;
+                        },
+                        new RowTypeInfo(
+                                ArrayUtils.addAll(otherColTypes, mappedColTypes),
+                                ArrayUtils.addAll(otherCols, continuousCols)));
+
+        return Tuple2.of(tEnv.fromDataStream(mapped), mappedDataAndModelData.f1);
+    }
+
+    /**
+     * Discretize the vector column inplace using quantile discretizer, and obtains quantile
+     * discretizer model data..
+     */
+    private static Tuple2<Table, DataStream<KBinsDiscretizerModelData>> discretizeVectorCol(
+            Table dataTable, String vectorCol, int numBins) {
+        final String outputCol = "_output_col";
+        KBinsDiscretizer kBinsDiscretizer =
+                new KBinsDiscretizer()
+                        .setInputCol(vectorCol)
+                        .setOutputCol(outputCol)
+                        .setStrategy("quantile")
+                        .setNumBins(numBins);
+        KBinsDiscretizerModel model = kBinsDiscretizer.fit(dataTable);
+        Table discretizedDataTable = model.transform(dataTable)[0];
+        return Tuple2.of(
+                discretizedDataTable
+                        .dropColumns($(vectorCol))
+                        .renameColumns($(outputCol).as(vectorCol)),
+                KBinsDiscretizerModelData.getModelDataStream(model.getModelData()[0]));
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/datastorage/IterationSharedStorage.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/datastorage/IterationSharedStorage.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.datastorage;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.iteration.IterationID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** A shared storage across subtasks of different operators. */
+public class IterationSharedStorage {
+    private static final Map<Tuple3<IterationID, Integer, String>, Object> m =
+            new ConcurrentHashMap<>();
+
+    private static final Map<Tuple3<IterationID, Integer, String>, OperatorID> owners =
+            new ConcurrentHashMap<>();
+
+    /**
+     * Gets a {@link Reader} of shared data identified by (iterationId, subtaskId, key).
+     *
+     * @param iterationID The iteration ID.
+     * @param subtaskId The subtask ID.
+     * @param key The string key.
+     * @return A {@link Reader} of shared data.
+     * @param <T> The type of shared ata.
+     */
+    public static <T> Reader<T> getReader(IterationID iterationID, int subtaskId, String key) {
+        return new Reader<>(Tuple3.of(iterationID, subtaskId, key));
+    }
+
+    /**
+     * Gets a {@link Writer} of shared data identified by (iterationId, subtaskId, key).
+     *
+     * @param iterationID The iteration ID.
+     * @param subtaskId The subtask ID.
+     * @param key The string key.
+     * @param operatorID The owner operator.
+     * @param initVal Initialize value of the data.
+     * @return A {@link Writer} of shared data.
+     * @param <T> The type of shared ata.
+     */
+    public static <T> Writer<T> getWriter(
+            IterationID iterationID, int subtaskId, String key, OperatorID operatorID, T initVal) {
+        Tuple3<IterationID, Integer, String> t = Tuple3.of(iterationID, subtaskId, key);
+        OperatorID lastOwner = owners.putIfAbsent(t, operatorID);
+        if (null != lastOwner) {
+            throw new IllegalStateException(
+                    String.format(
+                            "The shared data (%s, %s, %s) already has a writer %s.",
+                            iterationID, subtaskId, key, operatorID));
+        }
+        Writer<T> writer = new Writer<>(t, operatorID);
+        writer.set(initVal);
+        return writer;
+    }
+
+    /**
+     * A reader of shared data identified by key (IterationID, subtaskID, key).
+     *
+     * @param <T> The type of shared ata.
+     */
+    public static class Reader<T> {
+        protected final Tuple3<IterationID, Integer, String> t;
+
+        public Reader(Tuple3<IterationID, Integer, String> t) {
+            this.t = t;
+        }
+
+        /**
+         * Get the value.
+         *
+         * @return The value.
+         */
+        public T get() {
+            //noinspection unchecked
+            return (T) m.get(t);
+        }
+    }
+
+    /**
+     * A writer of shared data identified by key (IterationID, subtaskID, key). A writer is
+     * responsible for the checkpointing of data.
+     *
+     * @param <T> The type of shared ata.
+     */
+    public static class Writer<T> extends Reader<T> {
+        private final OperatorID operatorID;
+
+        public Writer(Tuple3<IterationID, Integer, String> t, OperatorID operatorID) {
+            super(t);
+            this.operatorID = operatorID;
+        }
+
+        private void ensureOwner() {
+            // Double-checks the owner, because a writer may call this method after the key removed
+            // and re-added by other operators.
+            Preconditions.checkState(owners.get(t).equals(operatorID));
+        }
+
+        /**
+         * Set new value.
+         *
+         * @param value The new value.
+         */
+        public void set(T value) {
+            ensureOwner();
+            m.put(t, value);
+        }
+
+        /** Remove this data entry. */
+        public void remove() {
+            ensureOwner();
+            m.remove(t);
+            owners.remove(t);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/BinnedInstance.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/BinnedInstance.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+import org.apache.flink.ml.feature.kbinsdiscretizer.KBinsDiscretizer;
+import org.apache.flink.ml.feature.stringindexer.StringIndexer;
+import org.apache.flink.ml.linalg.SparseVector;
+
+import org.eclipse.collections.impl.map.mutable.primitive.IntIntHashMap;
+
+/**
+ * Represents an instance including binned values of all features, weight, and label.
+ *
+ * <p>Categorical and continuous features are mapped to integers by {@link StringIndexer} and {@link
+ * KBinsDiscretizer}, respectively. Null values (`null` or `Double.NaN`) are also mapped to certain
+ * integers.
+ *
+ * <p>NOTE: When the input features are sparse, i.e., from {@link SparseVector}s, unseen indices are
+ * not stored in `features`. They should be handled separately.
+ */
+public class BinnedInstance {
+
+    public IntIntHashMap features;
+    public double weight;
+    public double label;
+
+    public BinnedInstance() {}
+
+    public BinnedInstance(IntIntHashMap features, double weight, double label) {
+        this.weight = weight;
+        this.label = label;
+        this.features = features;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "BinnedInstance{features=%s, weight=%s, label=%s}", features, weight, label);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Distributor.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Distributor.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+import java.io.Serializable;
+
+/**
+ * A utility class which helps data partitioning.
+ *
+ * <p>Given an indexable linear structures, like an array, of n elements and m tasks, the goal is to
+ * partition the linear structure into m consecutive segments and assign them to tasks accordingly.
+ * This class calculates the segment assigned to each task, including the start position and element
+ * count of the segment.
+ */
+public abstract class Distributor implements Serializable {
+    protected final long numTasks;
+    protected final long total;
+
+    public Distributor(long total, long numTasks) {
+        this.numTasks = numTasks;
+        this.total = total;
+    }
+
+    /**
+     * Calculates the start position of the segment assigned to the task.
+     *
+     * @param taskId The task index.
+     * @return The start position.
+     */
+    public abstract long start(long taskId);
+
+    /**
+     * Calculates the count of elements of the segment assigned to the task.
+     *
+     * @param taskId The task index.
+     * @return The count of elements.
+     */
+    public abstract long count(long taskId);
+
+    /** An implementation of {@link Distributor} which evenly partitioned the elements. */
+    public static class EvenDistributor extends Distributor {
+
+        public EvenDistributor(long parallelism, long totalCnt) {
+            super(totalCnt, parallelism);
+        }
+
+        @Override
+        public long start(long taskId) {
+            long div = total / numTasks;
+            long mod = total % numTasks;
+            return taskId < mod ? div * taskId + taskId : div * taskId + mod;
+        }
+
+        @Override
+        public long count(long taskId) {
+            long div = total / numTasks;
+            long mod = total % numTasks;
+            return taskId < mod ? div + 1 : div;
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/FeatureMeta.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/FeatureMeta.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+import org.apache.flink.ml.common.gbt.DataUtils;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/** Stores meta information of a feature. */
+public abstract class FeatureMeta {
+
+    public String name;
+    public Type type;
+    // The bin index representing the missing values.
+    public int missingBin;
+
+    public FeatureMeta() {}
+
+    public FeatureMeta(String name, int missingBin, Type type) {
+        this.name = name;
+        this.missingBin = missingBin;
+        this.type = type;
+    }
+
+    public static CategoricalFeatureMeta categorical(
+            String name, int missingBin, String[] categories) {
+        return new CategoricalFeatureMeta(name, missingBin, categories);
+    }
+
+    public static ContinuousFeatureMeta continuous(String name, int missingBin, double[] binEdges) {
+        return new ContinuousFeatureMeta(name, missingBin, binEdges);
+    }
+
+    /**
+     * Calculate number of bins used for this feature.
+     *
+     * @param useMissing Whether to assign an addition bin for missing values.
+     * @return The number of bins.
+     */
+    public abstract int numBins(boolean useMissing);
+
+    @Override
+    public String toString() {
+        return String.format(
+                "FeatureMeta{name='%s', type=%s, missingBin=%d}", name, type, missingBin);
+    }
+
+    /** Indicates the feature type. */
+    public enum Type implements Serializable {
+        CATEGORICAL,
+        CONTINUOUS
+    }
+
+    /** Stores meta information for a categorical feature. */
+    public static class CategoricalFeatureMeta extends FeatureMeta {
+        // Stores ordered categorical values.
+        public String[] categories;
+
+        public CategoricalFeatureMeta() {}
+
+        public CategoricalFeatureMeta(String name, int missingBin, String[] categories) {
+            super(name, missingBin, Type.CATEGORICAL);
+            this.categories = categories;
+        }
+
+        @Override
+        public int numBins(boolean useMissing) {
+            return useMissing ? categories.length + 1 : categories.length;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            return obj instanceof CategoricalFeatureMeta
+                    && this.type.equals(((CategoricalFeatureMeta) obj).type)
+                    && (this.name.equals(((CategoricalFeatureMeta) obj).name))
+                    && (this.missingBin == ((CategoricalFeatureMeta) obj).missingBin)
+                    && (Arrays.equals(this.categories, ((CategoricalFeatureMeta) obj).categories));
+        }
+
+        @Override
+        public String toString() {
+            return String.format(
+                    "CategoricalFeatureMeta{categories=%s} %s",
+                    Arrays.toString(categories), super.toString());
+        }
+    }
+
+    /** Stores meta information for a continuous feature. */
+    public static class ContinuousFeatureMeta extends FeatureMeta {
+        // Stores the edges of bins.
+        public double[] binEdges;
+        // The bin index for value 0.
+        public int zeroBin;
+
+        public ContinuousFeatureMeta() {}
+
+        public ContinuousFeatureMeta(String name, int missingBin, double[] binEdges) {
+            super(name, missingBin, Type.CONTINUOUS);
+            this.binEdges = binEdges;
+            this.zeroBin = DataUtils.findBin(binEdges, 0.);
+        }
+
+        @Override
+        public int numBins(boolean useMissing) {
+            return useMissing ? binEdges.length : binEdges.length - 1;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            return obj instanceof ContinuousFeatureMeta
+                    && this.type.equals(((ContinuousFeatureMeta) obj).type)
+                    && (this.name.equals(((ContinuousFeatureMeta) obj).name))
+                    && (this.missingBin == ((ContinuousFeatureMeta) obj).missingBin)
+                    && (Arrays.equals(this.binEdges, ((ContinuousFeatureMeta) obj).binEdges))
+                    && (this.zeroBin == ((ContinuousFeatureMeta) obj).zeroBin);
+        }
+
+        @Override
+        public String toString() {
+            return String.format(
+                    "ContinuousFeatureMeta{binEdges=%s, zeroBin=%d} %s",
+                    Arrays.toString(binEdges), zeroBin, super.toString());
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/GbtParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/GbtParams.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+import java.io.Serializable;
+
+/** Internal parameters of a gradient boosting trees algorithm. */
+public class GbtParams implements Serializable {
+    public String[] featureCols;
+    public String vectorCol;
+    public String labelCol;
+    public String[] categoricalCols;
+    public int maxBins;
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/GbtParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/GbtParams.java
@@ -22,9 +22,34 @@ import java.io.Serializable;
 
 /** Internal parameters of a gradient boosting trees algorithm. */
 public class GbtParams implements Serializable {
+    public TaskType taskType;
+
+    // Parameters related with input data.
     public String[] featureCols;
     public String vectorCol;
+    public boolean isInputVector;
     public String labelCol;
+    public String weightCol;
     public String[] categoricalCols;
+
+    // Parameters related with algorithms.
+    public int maxDepth;
     public int maxBins;
+    public int minInstancesPerNode;
+    public double minWeightFractionPerNode;
+    public double minInfoGain;
+    public int maxIter;
+    public double stepSize;
+    public long seed;
+    public double subsamplingRate;
+    public String featureSubsetStrategy;
+    public double validationTol;
+    public double lambda;
+    public double gamma;
+
+    // Derived parameters.
+    public String lossType;
+    public int maxNumLeaves;
+    // useMissing is always true right now.
+    public boolean useMissing;
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/HessianImpurity.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/HessianImpurity.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+/**
+ * The impurity introduced in XGBoost.
+ *
+ * <p>See: <a href="https://xgboost.readthedocs.io/en/stable/tutorials/model.html">Introduction to
+ * Boosted Trees</a>.
+ */
+public class HessianImpurity extends Impurity {
+
+    // Regularization of the leaf number.
+    protected final double lambda;
+    // Regularization of leaf scores.
+    protected final double gamma;
+    // Total of instance gradients.
+    protected double totalGradients;
+    // Total of instance hessians.
+    protected double totalHessians;
+
+    public HessianImpurity(
+            double lambda,
+            double gamma,
+            int numInstances,
+            double totalWeights,
+            double totalGradients,
+            double totalHessians) {
+        super(numInstances, totalWeights);
+        this.lambda = lambda;
+        this.gamma = gamma;
+        this.totalGradients = totalGradients;
+        this.totalHessians = totalHessians;
+    }
+
+    @Override
+    public double prediction() {
+        return -totalGradients / (totalHessians + gamma);
+    }
+
+    @Override
+    public double impurity() {
+        if (totalHessians + lambda == 0) {
+            return 0.;
+        }
+        return totalGradients * totalGradients / (totalHessians + lambda);
+    }
+
+    @Override
+    public double gain(Impurity... others) {
+        double sum = 0.;
+        for (Impurity other : others) {
+            sum += other.impurity();
+        }
+        return .5 * (sum - impurity()) - gamma;
+    }
+
+    @Override
+    public HessianImpurity add(Impurity other) {
+        HessianImpurity impurity = (HessianImpurity) other;
+        this.numInstances += impurity.numInstances;
+        this.totalWeights += impurity.totalWeights;
+        this.totalGradients += impurity.totalGradients;
+        this.totalHessians += impurity.totalHessians;
+        return this;
+    }
+
+    @Override
+    public HessianImpurity subtract(Impurity other) {
+        HessianImpurity impurity = (HessianImpurity) other;
+        this.numInstances -= impurity.numInstances;
+        this.totalWeights -= impurity.totalWeights;
+        this.totalGradients -= impurity.totalGradients;
+        this.totalHessians -= impurity.totalHessians;
+        return this;
+    }
+
+    public void add(int numInstances, double weights, double gradients, double hessians) {
+        this.numInstances += numInstances;
+        this.totalWeights += weights;
+        this.totalGradients += gradients;
+        this.totalHessians += hessians;
+    }
+
+    public void subtract(int numInstances, double weights, double gradients, double hessians) {
+        this.numInstances -= numInstances;
+        this.totalWeights -= weights;
+        this.totalGradients -= gradients;
+        this.totalHessians -= hessians;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Histogram.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Histogram.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/**
+ * This class stores values of histogram bins, and necessary information of reducing and scattering.
+ */
+public class Histogram implements Serializable {
+
+    // Stores source subtask ID when reducing or target subtask ID when scattering.
+    public int subtaskId;
+    // Stores values of histogram bins.
+    public double[] hists;
+    // Stores the number of elements received by subtasks in scattering.
+    public int[] recvcnts;
+
+    public Histogram(int subtaskId, double[] hists, int[] recvcnts) {
+        this.subtaskId = subtaskId;
+        this.hists = hists;
+        this.recvcnts = recvcnts;
+    }
+
+    private Histogram accumulate(Histogram other) {
+        Preconditions.checkArgument(hists.length == other.hists.length);
+        for (int i = 0; i < hists.length; i += 1) {
+            hists[i] += other.hists[i];
+        }
+        return this;
+    }
+
+    /** Aggregator for Histogram. */
+    public static class Aggregator
+            implements AggregateFunction<Histogram, Histogram, Histogram>, Serializable {
+        @Override
+        public Histogram createAccumulator() {
+            return null;
+        }
+
+        @Override
+        public Histogram add(Histogram value, Histogram accumulator) {
+            if (null == accumulator) {
+                return value;
+            }
+            return accumulator.accumulate(value);
+        }
+
+        @Override
+        public Histogram getResult(Histogram accumulator) {
+            return accumulator;
+        }
+
+        @Override
+        public Histogram merge(Histogram a, Histogram b) {
+            return a.accumulate(b);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Impurity.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Impurity.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+import java.io.Serializable;
+
+/** The base class for calculating information gain from statistics. */
+public abstract class Impurity implements Cloneable, Serializable {
+
+    // Number of instances.
+    protected int numInstances;
+    // Total of instance weights.
+    protected double totalWeights;
+
+    public Impurity(int numInstances, double totalWeights) {
+        this.numInstances = numInstances;
+        this.totalWeights = totalWeights;
+    }
+
+    /**
+     * Calculates the prediction.
+     *
+     * @return The prediction.
+     */
+    public abstract double prediction();
+
+    /**
+     * Calculates the impurity.
+     *
+     * @return The impurity score.
+     */
+    public abstract double impurity();
+
+    /**
+     * Calculate the information gain over other impurity instances, usually coming from splitting
+     * nodes.
+     *
+     * @param others Other impurity instances.
+     * @return The value of information gain.
+     */
+    public abstract double gain(Impurity... others);
+
+    /**
+     * Add statistics from other impurity instance.
+     *
+     * @param other The other impurity instance.
+     * @return The result after adding.
+     */
+    public abstract Impurity add(Impurity other);
+
+    /**
+     * Subtract statistics from other impurity instance.
+     *
+     * @param other The other impurity instance.
+     * @return The result after subtracting.
+     */
+    public abstract Impurity subtract(Impurity other);
+
+    /**
+     * Get the total of instance weights.
+     *
+     * @return The total of instance weights.
+     */
+    public double getTotalWeights() {
+        return totalWeights;
+    }
+
+    /**
+     * Get the number of instances.
+     *
+     * @return The number of instances.
+     */
+    public int getNumInstances() {
+        return numInstances;
+    }
+
+    @Override
+    public Impurity clone() {
+        try {
+            return (Impurity) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new IllegalStateException("Can not clone the impurity instance.", e);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/LearningNode.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/LearningNode.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+/** A node used in learning procedure. */
+public class LearningNode {
+
+    // The corresponding tree node.
+    public Node node;
+    // Slice of indices of bagging instances.
+    public Slice slice;
+    // Slice of indices of non-bagging instances.
+    public Slice oob;
+    // Depth of corresponding tree node.
+    public int depth;
+
+    public LearningNode(Node node, Slice slice, Slice oob, int depth) {
+        this.node = node;
+        this.slice = slice;
+        this.oob = oob;
+        this.depth = depth;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "LearningNode{node=%s, slice=%s, oob=%s, depth=%d}", node, slice, oob, depth);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/LocalState.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/LocalState.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.ml.common.gbt.loss.Loss;
+
+import org.eclipse.collections.api.tuple.primitive.IntIntPair;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Stores training state, including static parts and dynamic parts. Static parts won't change across
+ * the iteration rounds (except initialization), while dynamic parts are updated on every round.
+ *
+ * <p>An instance of training states is bound to a subtask id, so the operators accepting training
+ * states should be co-located.
+ */
+public class LocalState implements Serializable {
+
+    public Statics statics;
+    public Dynamics dynamics;
+
+    public LocalState(Statics statics, Dynamics dynamics) {
+        this.statics = statics;
+        this.dynamics = dynamics;
+    }
+
+    /** Static part of local state. */
+    public static class Statics {
+
+        public int subtaskId;
+        public int numSubtasks;
+        public GbtParams params;
+
+        public int numInstances;
+        public int numBaggingInstances;
+        public Random instanceRandomizer;
+
+        public int numFeatures;
+        public int numBaggingFeatures;
+        public Random featureRandomizer;
+
+        public FeatureMeta[] featureMetas;
+        public int[] numFeatureBins;
+
+        public Tuple2<Double, Long> labelSumCount;
+        public double prior;
+        public Loss loss;
+    }
+
+    /** Dynamic part of local state. */
+    public static class Dynamics {
+        // Root nodes of every tree.
+        public List<Node> roots = new ArrayList<>();
+        // Initializes a new tree when false, otherwise splits nodes in current layer.
+        public boolean inWeakLearner;
+
+        // Nodes to be split in the current layer.
+        public List<LearningNode> layer = new ArrayList<>();
+        // Node ID and feature ID pairs to be considered in current layer.
+        public List<IntIntPair> nodeFeaturePairs = new ArrayList<>();
+        // Leaf nodes in the current tree.
+        public List<LearningNode> leaves = new ArrayList<>();
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Node.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Node.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+import java.io.Serializable;
+
+/** Tree node in the decision tree that will be serialized to json and deserialized from json. */
+public class Node implements Serializable {
+
+    public Split split;
+    public boolean isLeaf = false;
+    public Node left;
+    public Node right;
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/PredGradHess.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/PredGradHess.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+/** Stores prediction, gradient, and hessian of an instance. */
+public class PredGradHess {
+    public double pred;
+    public double gradient;
+    public double hessian;
+
+    public PredGradHess() {}
+
+    public PredGradHess(double pred, double gradient, double hessian) {
+        this.pred = pred;
+        this.gradient = gradient;
+        this.hessian = hessian;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "PredGradHess{pred=%s, gradient=%s, hessian=%s}", pred, gradient, hessian);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Slice.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Slice.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+/** Represents a slice of an indexable linear structure, like an array. */
+public final class Slice {
+
+    public int start;
+    public int end;
+
+    public Slice(int start, int end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public int size() {
+        return end - start;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Slice{start=%d, end=%d}", start, end);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Split.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Split.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+import org.eclipse.collections.impl.map.mutable.primitive.IntDoubleHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.IntIntHashMap;
+
+import java.util.BitSet;
+
+/** Stores a split on a feature. */
+public abstract class Split {
+    public static final double INVALID_GAIN = 0.0;
+
+    // Stores the feature index of this split.
+    public final int featureId;
+
+    // Stores impurity gain. A value of `INVALID_GAIN` indicates this split is invalid.
+    public final double gain;
+
+    // Bin index for missing values of this feature.
+    public final int missingBin;
+    // Whether the missing values should go left.
+    public final boolean missingGoLeft;
+
+    // The prediction value if this split is invalid.
+    public final double prediction;
+
+    public Split(
+            int featureId, double gain, int missingBin, boolean missingGoLeft, double prediction) {
+        this.featureId = featureId;
+        this.gain = gain;
+        this.missingBin = missingBin;
+        this.missingGoLeft = missingGoLeft;
+        this.prediction = prediction;
+    }
+
+    /**
+     * Test the binned instance should go to the left child or the right child.
+     *
+     * @param binnedInstance The instance after binned.
+     * @return True if the instance should go to the left child.
+     */
+    public abstract boolean shouldGoLeft(BinnedInstance binnedInstance);
+
+    /**
+     * Test the raw features should go to the left child or the right child. In the raw features,
+     * the categorical values are mapped to integers, while the continuous values are kept unmapped.
+     *
+     * @param rawFeatures The feature map from feature indices to values.
+     * @return True if the raw features should go to the left child.
+     */
+    public abstract boolean shouldGoLeft(IntDoubleHashMap rawFeatures);
+
+    public boolean isValid() {
+        return gain != INVALID_GAIN;
+    }
+
+    /** Stores a split on a continuous feature. */
+    public static class ContinuousSplit extends Split {
+
+        /**
+         * Stores the threshold that one continuous feature should go the left or right. Before
+         * splitting the node, the threshold is the bin index. After that, the threshold is replaced
+         * with the actual value of the bin edge.
+         */
+        public double threshold;
+
+        // True if treat unseen values as missing values, otherwise treat them as 0s.
+        public boolean isUnseenMissing;
+
+        // Bin index for 0 values.
+        public int zeroBin;
+
+        public ContinuousSplit(
+                int featureIndex,
+                double gain,
+                int missingBin,
+                boolean missingGoLeft,
+                double prediction,
+                double threshold,
+                boolean isUnseenMissing,
+                int zeroBin) {
+            super(featureIndex, gain, missingBin, missingGoLeft, prediction);
+            this.threshold = threshold;
+            this.isUnseenMissing = isUnseenMissing;
+            this.zeroBin = zeroBin;
+        }
+
+        public static ContinuousSplit invalid(double prediction) {
+            return new ContinuousSplit(0, INVALID_GAIN, 0, false, prediction, 0., false, 0);
+        }
+
+        @Override
+        public boolean shouldGoLeft(BinnedInstance binnedInstance) {
+            IntIntHashMap features = binnedInstance.features;
+            if (!features.containsKey(featureId) && isUnseenMissing) {
+                return missingGoLeft;
+            }
+            int binId = features.getIfAbsent(featureId, zeroBin);
+            return binId == missingBin ? missingGoLeft : binId <= threshold;
+        }
+
+        @Override
+        public boolean shouldGoLeft(IntDoubleHashMap rawFeatures) {
+            if (!rawFeatures.containsKey(featureId) && isUnseenMissing) {
+                return missingGoLeft;
+            }
+            double v = rawFeatures.getIfAbsent(featureId, 0.);
+            return Double.isNaN(v) ? missingGoLeft : v < threshold;
+        }
+    }
+
+    /** Stores a split on a categorical feature. */
+    public static class CategoricalSplit extends Split {
+        // Stores the indices of categorical values that should go to the left child.
+        public final BitSet categoriesGoLeft;
+
+        public CategoricalSplit(
+                int featureId,
+                double gain,
+                int missingBin,
+                boolean missingGoLeft,
+                double prediction,
+                BitSet categoriesGoLeft) {
+            super(featureId, gain, missingBin, missingGoLeft, prediction);
+            this.categoriesGoLeft = categoriesGoLeft;
+        }
+
+        public static CategoricalSplit invalid(double prediction) {
+            return new CategoricalSplit(0, INVALID_GAIN, 0, false, prediction, new BitSet());
+        }
+
+        @Override
+        public boolean shouldGoLeft(BinnedInstance binnedInstance) {
+            IntIntHashMap features = binnedInstance.features;
+            if (!features.containsKey(featureId)) {
+                return missingGoLeft;
+            }
+            int binId = features.get(featureId);
+            return binId == missingBin ? missingGoLeft : categoriesGoLeft.get(binId);
+        }
+
+        @Override
+        public boolean shouldGoLeft(IntDoubleHashMap rawFeatures) {
+            if (!rawFeatures.containsKey(featureId)) {
+                return missingGoLeft;
+            }
+            return categoriesGoLeft.get((int) rawFeatures.get(featureId));
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Splits.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/Splits.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+
+/**
+ * This class stores splits of nodes in the current layer, and necessary information of
+ * all-reducing..
+ */
+public class Splits {
+
+    // Stores source subtask ID when reducing or target subtask ID when scattering.
+    public int subtaskId;
+    // Stores splits of nodes in the current layer.
+    public Split[] splits;
+
+    public Splits(int subtaskId, Split[] splits) {
+        this.subtaskId = subtaskId;
+        this.splits = splits;
+    }
+
+    private Splits accumulate(Splits other) {
+        for (int i = 0; i < splits.length; ++i) {
+            if (splits[i] == null && other.splits[i] != null) {
+                splits[i] = other.splits[i];
+            } else if (splits[i] != null && other.splits[i] != null) {
+                if (splits[i].gain < other.splits[i].gain) {
+                    splits[i] = other.splits[i];
+                } else if (splits[i].gain == other.splits[i].gain) {
+                    if (splits[i].featureId < other.splits[i].featureId) {
+                        splits[i] = other.splits[i];
+                    }
+                }
+            }
+        }
+        return this;
+    }
+
+    /** Aggregator for Splits. */
+    public static class Aggregator implements AggregateFunction<Splits, Splits, Splits> {
+        @Override
+        public Splits createAccumulator() {
+            return null;
+        }
+
+        @Override
+        public Splits add(Splits value, Splits accumulator) {
+            if (null == accumulator) {
+                return value;
+            }
+            return accumulator.accumulate(value);
+        }
+
+        @Override
+        public Splits getResult(Splits accumulator) {
+            return accumulator;
+        }
+
+        @Override
+        public Splits merge(Splits a, Splits b) {
+            return a.accumulate(b);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/TaskType.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/defs/TaskType.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.defs;
+
+/** Indicates the type of task. */
+public enum TaskType {
+    CLASSIFICATION,
+    REGRESSION,
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/loss/AbsoluteError.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/loss/AbsoluteError.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.loss;
+
+/**
+ * Squared error loss function defined as |y - pred| where y and pred are label and predictions for
+ * the instance respectively.
+ */
+public class AbsoluteError implements Loss {
+
+    public static final AbsoluteError INSTANCE = new AbsoluteError();
+
+    private AbsoluteError() {}
+
+    @Override
+    public double loss(double pred, double y) {
+        double error = y - pred;
+        return Math.abs(error);
+    }
+
+    @Override
+    public double gradient(double pred, double y) {
+        return y > pred ? -1. : 1;
+    }
+
+    @Override
+    public double hessian(double pred, double y) {
+        return 0.;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/loss/LogLoss.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/loss/LogLoss.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.loss;
+
+import org.apache.commons.math3.analysis.function.Sigmoid;
+
+/**
+ * The loss function for binary log loss.
+ *
+ * <p>The binary log loss defined as -y * pred + log(1 + exp(pred)) where y is a label in {0, 1} and
+ * pred is the predicted logit for the sample point.
+ */
+public class LogLoss implements Loss {
+
+    public static final LogLoss INSTANCE = new LogLoss();
+    private final Sigmoid sigmoid = new Sigmoid();
+
+    private LogLoss() {}
+
+    @Override
+    public double loss(double pred, double y) {
+        return -y * pred + Math.log(1 + Math.exp(pred));
+    }
+
+    @Override
+    public double gradient(double pred, double y) {
+        return sigmoid.value(pred) - y;
+    }
+
+    @Override
+    public double hessian(double pred, double y) {
+        double sig = sigmoid.value(pred);
+        return sig * (1 - sig);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/loss/Loss.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/loss/Loss.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.loss;
+
+import java.io.Serializable;
+
+/** Loss functions for gradient boosting algorithms. */
+public interface Loss extends Serializable {
+
+    /**
+     * Calculates loss given pred and y.
+     *
+     * @param pred prediction value.
+     * @param y label value.
+     * @return loss value.
+     */
+    double loss(double pred, double y);
+
+    /**
+     * Calculates value of gradient given prediction and label.
+     *
+     * @param pred prediction value.
+     * @param y label value.
+     * @return the value of gradient.
+     */
+    double gradient(double pred, double y);
+
+    /**
+     * Calculates value of second derivative, i.e. hessian, given prediction and label.
+     *
+     * @param pred prediction value.
+     * @param y label value.
+     * @return the value of second derivative, i.e. hessian.
+     */
+    double hessian(double pred, double y);
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/loss/SquaredError.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/loss/SquaredError.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.loss;
+
+/**
+ * Squared error loss function defined as (y - pred)^2 where y and pred are label and predictions
+ * for the instance respectively.
+ */
+public class SquaredError implements Loss {
+
+    public static final SquaredError INSTANCE = new SquaredError();
+
+    private SquaredError() {}
+
+    @Override
+    public double loss(double pred, double y) {
+        double error = y - pred;
+        return error * error;
+    }
+
+    @Override
+    public double gradient(double pred, double y) {
+        return -2. * (y - pred);
+    }
+
+    @Override
+    public double hessian(double pred, double y) {
+        return 2.;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/CacheDataCalcLocalHistsOperator.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/CacheDataCalcLocalHistsOperator.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.iteration.IterationID;
+import org.apache.flink.iteration.IterationListener;
+import org.apache.flink.ml.common.gbt.datastorage.IterationSharedStorage;
+import org.apache.flink.ml.common.gbt.defs.BinnedInstance;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.common.gbt.defs.Histogram;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.PredGradHess;
+import org.apache.flink.ml.common.gbt.loss.Loss;
+import org.apache.flink.ml.linalg.SparseVector;
+import org.apache.flink.ml.linalg.Vector;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
+
+import org.eclipse.collections.impl.map.mutable.primitive.IntIntHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Calculates local histograms for local data partition. Specifically in the first round, this
+ * operator caches all data instances to JVM static region.
+ */
+public class CacheDataCalcLocalHistsOperator extends AbstractStreamOperator<Histogram>
+        implements TwoInputStreamOperator<Row, LocalState, Histogram>,
+                IterationListener<Histogram> {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(CacheDataCalcLocalHistsOperator.class);
+
+    private final GbtParams gbtParams;
+    private final IterationID iterationID;
+    private final String sharedInstancesKey;
+    private final String sharedPredGradHessKey;
+    private final String sharedShuffledIndicesKey;
+    private final String sharedSwappedIndicesKey;
+    private final OutputTag<LocalState> stateOutputTag;
+
+    // States of local data.
+    private transient List<BinnedInstance> instancesCollecting;
+    private transient LocalState localState;
+    private transient TreeInitializer treeInitializer;
+    private transient HistBuilder histBuilder;
+
+    // Readers/writers of shared data.
+    private transient IterationSharedStorage.Writer<BinnedInstance[]> instancesWriter;
+    private transient IterationSharedStorage.Reader<PredGradHess[]> pghReader;
+    private transient IterationSharedStorage.Writer<int[]> shuffledIndicesWriter;
+    private transient IterationSharedStorage.Reader<int[]> swappedIndicesReader;
+
+    public CacheDataCalcLocalHistsOperator(
+            GbtParams gbtParams,
+            IterationID iterationID,
+            String sharedInstancesKey,
+            String sharedPredGradHessKey,
+            String sharedShuffledIndicesKey,
+            String sharedSwappedIndicesKey,
+            OutputTag<LocalState> stateOutputTag) {
+        super();
+        this.gbtParams = gbtParams;
+        this.iterationID = iterationID;
+        this.sharedInstancesKey = sharedInstancesKey;
+        this.sharedPredGradHessKey = sharedPredGradHessKey;
+        this.sharedShuffledIndicesKey = sharedShuffledIndicesKey;
+        this.sharedSwappedIndicesKey = sharedSwappedIndicesKey;
+        this.stateOutputTag = stateOutputTag;
+    }
+
+    @Override
+    public void open() throws Exception {
+        instancesCollecting = new ArrayList<>();
+
+        int subtaskId = getRuntimeContext().getIndexOfThisSubtask();
+        instancesWriter =
+                IterationSharedStorage.getWriter(
+                        iterationID,
+                        subtaskId,
+                        sharedInstancesKey,
+                        getOperatorID(),
+                        new BinnedInstance[0]);
+
+        shuffledIndicesWriter =
+                IterationSharedStorage.getWriter(
+                        iterationID,
+                        subtaskId,
+                        sharedShuffledIndicesKey,
+                        getOperatorID(),
+                        new int[0]);
+
+        this.pghReader =
+                IterationSharedStorage.getReader(iterationID, subtaskId, sharedPredGradHessKey);
+        this.swappedIndicesReader =
+                IterationSharedStorage.getReader(iterationID, subtaskId, sharedSwappedIndicesKey);
+    }
+
+    @Override
+    public void processElement1(StreamRecord<Row> streamRecord) throws Exception {
+        Row row = streamRecord.getValue();
+        IntIntHashMap features = new IntIntHashMap();
+        if (gbtParams.isInputVector) {
+            Vector vec = row.getFieldAs(gbtParams.vectorCol);
+            SparseVector sv = vec.toSparse();
+            for (int i = 0; i < sv.indices.length; i += 1) {
+                features.put(sv.indices[i], (int) sv.values[i]);
+            }
+        } else {
+            for (int i = 0; i < gbtParams.featureCols.length; i += 1) {
+                // Values from StringIndexModel#transform are double.
+                features.put(i, ((Number) row.getFieldAs(gbtParams.featureCols[i])).intValue());
+            }
+        }
+        double label = row.getFieldAs(gbtParams.labelCol);
+        instancesCollecting.add(new BinnedInstance(features, 1., label));
+    }
+
+    @Override
+    public void processElement2(StreamRecord<LocalState> streamRecord) throws Exception {
+        localState = streamRecord.getValue();
+    }
+
+    @Override
+    public void onEpochWatermarkIncremented(
+            int epochWatermark, Context context, Collector<Histogram> out) throws Exception {
+        if (0 == epochWatermark) {
+            // Initializes local state in first round.
+            instancesWriter.set(instancesCollecting.toArray(new BinnedInstance[0]));
+            instancesCollecting.clear();
+            new LocalStateInitializer(gbtParams)
+                    .init(
+                            localState,
+                            getRuntimeContext().getIndexOfThisSubtask(),
+                            getRuntimeContext().getNumberOfParallelSubtasks(),
+                            instancesWriter.get());
+
+            treeInitializer = new TreeInitializer(localState.statics);
+            histBuilder = new HistBuilder(localState.statics);
+        }
+
+        BinnedInstance[] instances = instancesWriter.get();
+        Preconditions.checkArgument(
+                getRuntimeContext().getIndexOfThisSubtask() == localState.statics.subtaskId);
+        PredGradHess[] pgh = pghReader.get();
+
+        // In the first round, use prior as the predictions.
+        if (0 == pgh.length) {
+            pgh = new PredGradHess[instances.length];
+            double prior = localState.statics.prior;
+            Loss loss = localState.statics.loss;
+            for (int i = 0; i < instances.length; i += 1) {
+                double label = instances[i].label;
+                pgh[i] =
+                        new PredGradHess(
+                                prior, loss.gradient(prior, label), loss.hessian(prior, label));
+            }
+        }
+
+        int[] indices;
+        if (!localState.dynamics.inWeakLearner) {
+            // When last tree is finished, initializes a new tree, and shuffle instance indices.
+            treeInitializer.init(localState.dynamics, shuffledIndicesWriter::set);
+            localState.dynamics.inWeakLearner = true;
+            indices = shuffledIndicesWriter.get();
+        } else {
+            // Otherwise, uses the swapped instance indices.
+            shuffledIndicesWriter.set(new int[0]);
+            indices = swappedIndicesReader.get();
+        }
+
+        Histogram localHists =
+                histBuilder.build(
+                        localState.dynamics.layer,
+                        localState.dynamics.nodeFeaturePairs,
+                        indices,
+                        instances,
+                        pgh);
+        out.collect(localHists);
+        context.output(stateOutputTag, localState);
+    }
+
+    @Override
+    public void onIterationTerminated(Context context, Collector<Histogram> collector) {
+        instancesCollecting.clear();
+        instancesWriter.set(new BinnedInstance[0]);
+        shuffledIndicesWriter.set(new int[0]);
+    }
+
+    @Override
+    public void close() throws Exception {
+        instancesWriter.remove();
+        shuffledIndicesWriter.remove();
+        super.close();
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/CalcLocalSplitsOperator.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/CalcLocalSplitsOperator.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.iteration.IterationListener;
+import org.apache.flink.iteration.operator.OperatorStateUtils;
+import org.apache.flink.ml.common.gbt.defs.Histogram;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.Splits;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import java.util.Collections;
+
+/** Calculates local splits for assigned (nodeId, featureId) pairs. */
+public class CalcLocalSplitsOperator extends AbstractStreamOperator<Splits>
+        implements TwoInputStreamOperator<LocalState, Histogram, Splits>,
+                IterationListener<Splits> {
+
+    private static final String LOCAL_STATE_STATE_NAME = "local_state";
+    private static final String CALC_BEST_SPLIT_STATE_NAME = "split_finder";
+    private static final String HISTOGRAM_STATE_NAME = "histogram";
+
+    private final OutputTag<LocalState> stateOutputTag;
+
+    private transient ListState<LocalState> localState;
+    private transient ListState<SplitFinder> splitFinder;
+    private transient ListState<Histogram> histogram;
+
+    public CalcLocalSplitsOperator(OutputTag<LocalState> stateOutputTag) {
+        this.stateOutputTag = stateOutputTag;
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+        localState =
+                context.getOperatorStateStore()
+                        .getListState(
+                                new ListStateDescriptor<>(
+                                        LOCAL_STATE_STATE_NAME, LocalState.class));
+        splitFinder =
+                context.getOperatorStateStore()
+                        .getListState(
+                                new ListStateDescriptor<>(
+                                        CALC_BEST_SPLIT_STATE_NAME, SplitFinder.class));
+        histogram =
+                context.getOperatorStateStore()
+                        .getListState(
+                                new ListStateDescriptor<>(HISTOGRAM_STATE_NAME, Histogram.class));
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Override
+    public void onEpochWatermarkIncremented(
+            int epochWatermark, Context context, Collector<Splits> collector) throws Exception {
+        LocalState localStateValue =
+                OperatorStateUtils.getUniqueElement(localState, LOCAL_STATE_STATE_NAME).get();
+        if (0 == epochWatermark) {
+            splitFinder.update(Collections.singletonList(new SplitFinder(localStateValue.statics)));
+        }
+        Splits splits =
+                OperatorStateUtils.getUniqueElement(splitFinder, CALC_BEST_SPLIT_STATE_NAME)
+                        .get()
+                        .calc(
+                                localStateValue.dynamics.layer,
+                                localStateValue.dynamics.nodeFeaturePairs,
+                                localStateValue.dynamics.leaves,
+                                OperatorStateUtils.getUniqueElement(histogram, HISTOGRAM_STATE_NAME)
+                                        .get());
+        collector.collect(splits);
+        context.output(stateOutputTag, localStateValue);
+    }
+
+    @Override
+    public void onIterationTerminated(Context context, Collector<Splits> collector) {}
+
+    @Override
+    public void processElement1(StreamRecord<LocalState> element) throws Exception {
+        localState.update(Collections.singletonList(element.getValue()));
+    }
+
+    @Override
+    public void processElement2(StreamRecord<Histogram> element) throws Exception {
+        histogram.update(Collections.singletonList(element.getValue()));
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/HistBuilder.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/HistBuilder.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.ml.common.gbt.DataUtils;
+import org.apache.flink.ml.common.gbt.defs.BinnedInstance;
+import org.apache.flink.ml.common.gbt.defs.Distributor;
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.Histogram;
+import org.apache.flink.ml.common.gbt.defs.LearningNode;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.PredGradHess;
+
+import org.eclipse.collections.api.tuple.primitive.IntIntPair;
+import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+class HistBuilder {
+    private static final Logger LOG = LoggerFactory.getLogger(HistBuilder.class);
+
+    private final int subtaskId;
+    private final int numSubtasks;
+
+    private final int[] numFeatureBins;
+    private final FeatureMeta[] featureMetas;
+
+    private final int numBaggingFeatures;
+    private final Random featureRandomizer;
+    private final int[] featureIndicesPool;
+
+    private final boolean isInputVector;
+
+    private final double[] hists;
+
+    public HistBuilder(LocalState.Statics statics) {
+        subtaskId = statics.subtaskId;
+        numSubtasks = statics.numSubtasks;
+
+        numFeatureBins = statics.numFeatureBins;
+        featureMetas = statics.featureMetas;
+
+        numBaggingFeatures = statics.numBaggingFeatures;
+        featureRandomizer = statics.featureRandomizer;
+        featureIndicesPool = IntStream.range(0, statics.numFeatures).toArray();
+
+        isInputVector = statics.params.isInputVector;
+
+        int maxNumNodes =
+                Math.min(
+                        ((int) Math.pow(2, statics.params.maxDepth - 1)),
+                        statics.params.maxNumLeaves);
+
+        int maxFeatureBins = Arrays.stream(numFeatureBins).max().orElse(0);
+        int totalNumFeatureBins = Arrays.stream(numFeatureBins).sum();
+        int maxNumBins =
+                maxNumNodes * Math.min(maxFeatureBins * numBaggingFeatures, totalNumFeatureBins);
+        hists = new double[maxNumBins * DataUtils.BIN_SIZE];
+    }
+
+    /**
+     * Calculate histograms for all (nodeId, featureId) pairs. The results are written to `hists`,
+     * so `hists` must be large enough to store values.
+     */
+    private static void calcNodeFeaturePairHists(
+            List<LearningNode> layer,
+            List<IntIntPair> nodeFeaturePairs,
+            FeatureMeta[] featureMetas,
+            boolean isInputVector,
+            int[] numFeatureBins,
+            int[] indices,
+            BinnedInstance[] instances,
+            PredGradHess[] pgh,
+            double[] hists) {
+        Arrays.fill(hists, 0.);
+        int binOffset = 0;
+        for (IntIntPair nodeFeaturePair : nodeFeaturePairs) {
+            int nodeId = nodeFeaturePair.getOne();
+            int featureId = nodeFeaturePair.getTwo();
+            FeatureMeta featureMeta = featureMetas[featureId];
+
+            int defaultValue = featureMeta.missingBin;
+            // When isInputVector is true, values of unseen features are treated as 0s.
+            if (isInputVector && featureMeta instanceof FeatureMeta.ContinuousFeatureMeta) {
+                defaultValue = ((FeatureMeta.ContinuousFeatureMeta) featureMeta).zeroBin;
+            }
+
+            LearningNode node = layer.get(nodeId);
+            for (int i = node.slice.start; i < node.slice.end; i += 1) {
+                int instanceId = indices[i];
+                BinnedInstance binnedInstance = instances[instanceId];
+                double gradient = pgh[instanceId].gradient;
+                double hessian = pgh[instanceId].hessian;
+
+                int val = binnedInstance.features.getIfAbsent(featureId, defaultValue);
+                int startIndex = (binOffset + val) * DataUtils.BIN_SIZE;
+                hists[startIndex] += gradient;
+                hists[startIndex + 1] += hessian;
+                hists[startIndex + 2] += binnedInstance.weight;
+                hists[startIndex + 3] += 1.;
+            }
+            binOffset += numFeatureBins[featureId];
+        }
+    }
+
+    /**
+     * Calculates elements counts of histogram distributed to each downstream subtask. The elements
+     * counts is bin counts multiplied by STEP. The minimum unit to be distributed is (nodeId,
+     * featureId), i.e., all bins belonging to the same (nodeId, featureId) pair must go to one
+     * subtask.
+     */
+    private static int[] calcRecvCounts(
+            int numSubtasks, List<IntIntPair> nodeFeaturePairs, int[] numFeatureBins) {
+        int[] recvcnts = new int[numSubtasks];
+        Distributor.EvenDistributor distributor =
+                new Distributor.EvenDistributor(numSubtasks, nodeFeaturePairs.size());
+        for (int k = 0; k < numSubtasks; k += 1) {
+            int pairStart = (int) distributor.start(k);
+            int pairCnt = (int) distributor.count(k);
+            for (int i = pairStart; i < pairStart + pairCnt; i += 1) {
+                int featureId = nodeFeaturePairs.get(i).getTwo();
+                recvcnts[k] += numFeatureBins[featureId] * DataUtils.BIN_SIZE;
+            }
+        }
+        return recvcnts;
+    }
+
+    /** Calculate local histograms for nodes in current layer of tree. */
+    public Histogram build(
+            List<LearningNode> layer,
+            List<IntIntPair> nodeFeaturePairs,
+            int[] indices,
+            BinnedInstance[] instances,
+            PredGradHess[] pgh) {
+        LOG.info("subtaskId: {}, {} start", subtaskId, HistBuilder.class.getSimpleName());
+
+        // Generates (nodeId, featureId) pairs that are required to build histograms.
+        nodeFeaturePairs.clear();
+        for (int k = 0; k < layer.size(); k += 1) {
+            int[] sampledFeatures =
+                    DataUtils.sample(featureIndicesPool, numBaggingFeatures, featureRandomizer);
+            for (int featureId : sampledFeatures) {
+                nodeFeaturePairs.add(PrimitiveTuples.pair(k, featureId));
+            }
+        }
+
+        // Calculates histograms for (nodeId, featureId) pairs.
+        calcNodeFeaturePairHists(
+                layer,
+                nodeFeaturePairs,
+                featureMetas,
+                isInputVector,
+                numFeatureBins,
+                indices,
+                instances,
+                pgh,
+                hists);
+
+        // Calculates number of elements received by each downstream subtask.
+        int[] recvcnts = calcRecvCounts(numSubtasks, nodeFeaturePairs, numFeatureBins);
+
+        LOG.info("subtaskId: {}, {} end", this.subtaskId, HistBuilder.class.getSimpleName());
+        return new Histogram(this.subtaskId, hists, recvcnts);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/HistogramAggregateFunction.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/HistogramAggregateFunction.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.ml.common.gbt.defs.Histogram;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import java.util.BitSet;
+
+/** Aggregation function for merging histograms. */
+public class HistogramAggregateFunction extends RichFlatMapFunction<Histogram, Histogram> {
+
+    private final AggregateFunction<Histogram, Histogram, Histogram> aggregator =
+            new Histogram.Aggregator();
+    private int numSubtasks;
+    private BitSet accepted;
+    private Histogram acc = null;
+
+    @Override
+    public void flatMap(Histogram value, Collector<Histogram> out) throws Exception {
+        if (null == accepted) {
+            numSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
+            accepted = new BitSet(numSubtasks);
+        }
+        int receivedSubtaskId = value.subtaskId;
+        Preconditions.checkState(!accepted.get(receivedSubtaskId));
+        accepted.set(receivedSubtaskId);
+        acc = aggregator.add(value, acc);
+        if (numSubtasks == accepted.cardinality()) {
+            acc.subtaskId = getRuntimeContext().getIndexOfThisSubtask();
+            out.collect(acc);
+            accepted = null;
+            acc = null;
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/InstanceUpdater.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/InstanceUpdater.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.ml.common.gbt.defs.BinnedInstance;
+import org.apache.flink.ml.common.gbt.defs.LearningNode;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.PredGradHess;
+import org.apache.flink.ml.common.gbt.defs.Split;
+import org.apache.flink.ml.common.gbt.loss.Loss;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+class InstanceUpdater {
+    private static final Logger LOG = LoggerFactory.getLogger(InstanceUpdater.class);
+
+    private final int subtaskId;
+    private final Loss loss;
+    private final double stepSize;
+    private final PredGradHess[] pgh;
+    private final double prior;
+
+    private boolean initialized;
+
+    public InstanceUpdater(LocalState.Statics statics) {
+        subtaskId = statics.subtaskId;
+        loss = statics.loss;
+        stepSize = statics.params.stepSize;
+        prior = statics.prior;
+        pgh = new PredGradHess[statics.numInstances];
+        initialized = false;
+    }
+
+    public void update(
+            List<LearningNode> leaves,
+            int[] indices,
+            BinnedInstance[] instances,
+            Consumer<PredGradHess[]> pghSetter) {
+        LOG.info("subtaskId: {}, {} start", subtaskId, InstanceUpdater.class.getSimpleName());
+        if (!initialized) {
+            for (int i = 0; i < instances.length; i += 1) {
+                double label = instances[i].label;
+                pgh[i] =
+                        new PredGradHess(
+                                prior, loss.gradient(prior, label), loss.hessian(prior, label));
+            }
+            initialized = true;
+        }
+
+        for (LearningNode nodeInfo : leaves) {
+            Split split = nodeInfo.node.split;
+            double pred = split.prediction * stepSize;
+            for (int i = nodeInfo.slice.start; i < nodeInfo.slice.end; ++i) {
+                int instanceId = indices[i];
+                updatePgh(pred, instances[instanceId].label, pgh[instanceId]);
+            }
+            for (int i = nodeInfo.oob.start; i < nodeInfo.oob.end; ++i) {
+                int instanceId = indices[i];
+                updatePgh(pred, instances[instanceId].label, pgh[instanceId]);
+            }
+        }
+        pghSetter.accept(pgh);
+        LOG.info("subtaskId: {}, {} end", subtaskId, InstanceUpdater.class.getSimpleName());
+    }
+
+    private void updatePgh(double pred, double label, PredGradHess pgh) {
+        pgh.pred += pred;
+        pgh.gradient = loss.gradient(pgh.pred, label);
+        pgh.hessian = loss.hessian(pgh.pred, label);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/LocalStateInitializer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/LocalStateInitializer.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.ml.common.gbt.defs.BinnedInstance;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.TaskType;
+import org.apache.flink.ml.common.gbt.loss.AbsoluteError;
+import org.apache.flink.ml.common.gbt.loss.LogLoss;
+import org.apache.flink.ml.common.gbt.loss.Loss;
+import org.apache.flink.ml.common.gbt.loss.SquaredError;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Function;
+
+import static java.util.Arrays.stream;
+
+class LocalStateInitializer {
+    private static final Logger LOG = LoggerFactory.getLogger(LocalStateInitializer.class);
+    private final GbtParams params;
+
+    public LocalStateInitializer(GbtParams params) {
+        this.params = params;
+    }
+
+    /**
+     * Initializes local state.
+     *
+     * <p>Note that local state already has some properties set in advance, see GBTRunner#boost.
+     */
+    public LocalState init(
+            LocalState localState, int subtaskId, int numSubtasks, BinnedInstance[] instances) {
+        LOG.info("subtaskId: {}, {} start", subtaskId, LocalStateInitializer.class.getSimpleName());
+
+        LocalState.Statics statics = localState.statics;
+        statics.subtaskId = subtaskId;
+        statics.numSubtasks = numSubtasks;
+
+        int numInstances = instances.length;
+        int numFeatures = statics.featureMetas.length;
+
+        LOG.info(
+                "subtaskId: {}, #samples: {}, #features: {}", subtaskId, numInstances, numFeatures);
+
+        statics.params = params;
+        statics.numInstances = numInstances;
+        statics.numFeatures = numFeatures;
+
+        statics.numBaggingInstances = getNumBaggingSamples(numInstances);
+        statics.numBaggingFeatures = getNumBaggingFeatures(numFeatures);
+
+        statics.instanceRandomizer = new Random(subtaskId + params.seed);
+        statics.featureRandomizer = new Random(params.seed);
+
+        statics.loss = getLoss();
+        statics.prior = calcPrior(statics.labelSumCount);
+
+        statics.numFeatureBins =
+                stream(statics.featureMetas)
+                        .mapToInt(d -> d.numBins(statics.params.useMissing))
+                        .toArray();
+
+        LocalState.Dynamics dynamics = localState.dynamics;
+        dynamics.inWeakLearner = false;
+
+        LOG.info("subtaskId: {}, {} end", subtaskId, LocalStateInitializer.class.getSimpleName());
+        return new LocalState(statics, dynamics);
+    }
+
+    private int getNumBaggingSamples(int numSamples) {
+        return (int) Math.min(numSamples, Math.ceil(numSamples * params.subsamplingRate));
+    }
+
+    private int getNumBaggingFeatures(int numFeatures) {
+        final List<String> supported = Arrays.asList("auto", "all", "onethird", "sqrt", "log2");
+        final String errorMsg =
+                String.format(
+                        "Parameter `featureSubsetStrategy` supports %s, (0.0 - 1.0], [1 - n].",
+                        String.join(", ", supported));
+        final Function<Double, Integer> clamp =
+                d -> Math.max(1, Math.min(d.intValue(), numFeatures));
+        String strategy = params.featureSubsetStrategy;
+        try {
+            int numBaggingFeatures = Integer.parseInt(strategy);
+            Preconditions.checkArgument(
+                    numBaggingFeatures >= 1 && numBaggingFeatures <= numFeatures, errorMsg);
+        } catch (NumberFormatException ignored) {
+        }
+        try {
+            double baggingRatio = Double.parseDouble(strategy);
+            Preconditions.checkArgument(baggingRatio > 0. && baggingRatio <= 1., errorMsg);
+            return clamp.apply(baggingRatio * numFeatures);
+        } catch (NumberFormatException ignored) {
+        }
+
+        Preconditions.checkArgument(supported.contains(strategy), errorMsg);
+        switch (strategy) {
+            case "auto":
+                return TaskType.CLASSIFICATION.equals(params.taskType)
+                        ? clamp.apply(Math.sqrt(numFeatures))
+                        : clamp.apply(numFeatures / 3.);
+            case "all":
+                return numFeatures;
+            case "onethird":
+                return clamp.apply(numFeatures / 3.);
+            case "sqrt":
+                return clamp.apply(Math.sqrt(numFeatures));
+            case "log2":
+                return clamp.apply(Math.log(numFeatures) / Math.log(2));
+            default:
+                throw new IllegalArgumentException(errorMsg);
+        }
+    }
+
+    private Loss getLoss() {
+        String lossType = params.lossType;
+        switch (lossType) {
+            case "logistic":
+                return LogLoss.INSTANCE;
+            case "squared":
+                return SquaredError.INSTANCE;
+            case "absolute":
+                return AbsoluteError.INSTANCE;
+            default:
+                throw new UnsupportedOperationException("Unsupported loss.");
+        }
+    }
+
+    private double calcPrior(Tuple2<Double, Long> labelStat) {
+        String lossType = params.lossType;
+        switch (lossType) {
+            case "logistic":
+                return Math.log(labelStat.f0 / (labelStat.f1 - labelStat.f0));
+            case "squared":
+                return labelStat.f0 / labelStat.f1;
+            case "absolute":
+                throw new UnsupportedOperationException("absolute error is not supported yet.");
+            default:
+                throw new UnsupportedOperationException("Unsupported loss.");
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/NodeSplitter.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/NodeSplitter.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.ml.common.gbt.defs.BinnedInstance;
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.LearningNode;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.Node;
+import org.apache.flink.ml.common.gbt.defs.Slice;
+import org.apache.flink.ml.common.gbt.defs.Split;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class NodeSplitter {
+    private static final Logger LOG = LoggerFactory.getLogger(NodeSplitter.class);
+
+    private final int subtaskId;
+    private final FeatureMeta[] featureMetas;
+    private final int maxLeaves;
+    private final int maxDepth;
+
+    public NodeSplitter(LocalState.Statics statics) {
+        subtaskId = statics.subtaskId;
+        featureMetas = statics.featureMetas;
+        maxLeaves = statics.params.maxNumLeaves;
+        maxDepth = statics.params.maxDepth;
+    }
+
+    private int partitionInstances(
+            Split split, Slice slice, int[] indices, BinnedInstance[] instances) {
+        int lstart = slice.start;
+        int lend = slice.end - 1;
+        while (lstart <= lend) {
+            while (lstart <= lend && split.shouldGoLeft(instances[indices[lstart]])) {
+                lstart += 1;
+            }
+            while (lstart <= lend && !split.shouldGoLeft(instances[indices[lend]])) {
+                lend -= 1;
+            }
+            if (lstart < lend) {
+                int temp = indices[lstart];
+                indices[lstart] = indices[lend];
+                indices[lend] = temp;
+            }
+        }
+        return lstart;
+    }
+
+    private void splitNode(
+            LearningNode nodeInfo,
+            int[] indices,
+            BinnedInstance[] instances,
+            List<LearningNode> nextLayer) {
+        int mid = partitionInstances(nodeInfo.node.split, nodeInfo.slice, indices, instances);
+        int oobMid = partitionInstances(nodeInfo.node.split, nodeInfo.oob, indices, instances);
+        nodeInfo.node.left = new Node();
+        nodeInfo.node.right = new Node();
+        nextLayer.add(
+                new LearningNode(
+                        nodeInfo.node.left,
+                        new Slice(nodeInfo.slice.start, mid),
+                        new Slice(nodeInfo.oob.start, oobMid),
+                        nodeInfo.depth + 1));
+        nextLayer.add(
+                new LearningNode(
+                        nodeInfo.node.right,
+                        new Slice(mid, nodeInfo.slice.end),
+                        new Slice(oobMid, nodeInfo.oob.end),
+                        nodeInfo.depth + 1));
+    }
+
+    public void split(
+            List<LearningNode> layer,
+            List<LearningNode> leaves,
+            Split[] splits,
+            int[] indices,
+            BinnedInstance[] instances) {
+        LOG.info("subtaskId: {}, {} start", subtaskId, NodeSplitter.class.getSimpleName());
+        Preconditions.checkState(splits.length == layer.size());
+
+        List<LearningNode> nextLayer = new ArrayList<>();
+
+        // nodes in current layer or next layer are expected to generate at least 1 leaf.
+        int numQueued = layer.size();
+        for (int i = 0; i < layer.size(); i += 1) {
+            LearningNode node = layer.get(i);
+            Split split = splits[i];
+            numQueued -= 1;
+            node.node.split = split;
+            if (!split.isValid()
+                    || node.node.isLeaf
+                    || (leaves.size() + numQueued + 2) > maxLeaves
+                    || node.depth + 1 > maxDepth) {
+                node.node.isLeaf = true;
+                leaves.add(node);
+            } else {
+                splitNode(node, indices, instances, nextLayer);
+                // Converts splits point from bin id to real feature value after splitting node.
+                if (split instanceof Split.ContinuousSplit) {
+                    Split.ContinuousSplit cs = (Split.ContinuousSplit) split;
+                    FeatureMeta.ContinuousFeatureMeta featureMeta =
+                            (FeatureMeta.ContinuousFeatureMeta) featureMetas[cs.featureId];
+                    cs.threshold = featureMeta.binEdges[(int) cs.threshold + 1];
+                }
+                numQueued += 2;
+            }
+        }
+
+        layer.clear();
+        layer.addAll(nextLayer);
+
+        LOG.info("subtaskId: {}, {} end", subtaskId, NodeSplitter.class.getSimpleName());
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/PostSplitsOperator.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/PostSplitsOperator.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.iteration.IterationID;
+import org.apache.flink.iteration.IterationListener;
+import org.apache.flink.ml.common.gbt.datastorage.IterationSharedStorage;
+import org.apache.flink.ml.common.gbt.defs.BinnedInstance;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.PredGradHess;
+import org.apache.flink.ml.common.gbt.defs.Splits;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * Post-process after global splits obtained, including split instances to left or child nodes, and
+ * update instances scores after a tree is complete.
+ */
+public class PostSplitsOperator extends AbstractStreamOperator<LocalState>
+        implements TwoInputStreamOperator<LocalState, Splits, LocalState>,
+                IterationListener<LocalState> {
+
+    private final IterationID iterationID;
+    private final String sharedInstancesKey;
+    private final String sharedPredGradHessKey;
+    private final String sharedShuffledIndicesKey;
+    private final String sharedSwappedIndicesKey;
+    private final OutputTag<LocalState> finalStateOutputTag;
+
+    private IterationSharedStorage.Reader<BinnedInstance[]> instancesReader;
+    private IterationSharedStorage.Writer<PredGradHess[]> pghWriter;
+    private IterationSharedStorage.Reader<int[]> shuffledIndicesReader;
+    private IterationSharedStorage.Writer<int[]> swappedIndicesWriter;
+
+    private transient LocalState localState;
+    private transient Splits splits;
+    private transient NodeSplitter nodeSplitter;
+    private transient InstanceUpdater instanceUpdater;
+
+    public PostSplitsOperator(
+            IterationID iterationID,
+            String sharedInstancesKey,
+            String sharedPredGradHessKey,
+            String sharedShuffledIndicesKey,
+            String sharedSwappedIndicesKey,
+            OutputTag<LocalState> finalStateOutputTag) {
+        this.iterationID = iterationID;
+        this.sharedInstancesKey = sharedInstancesKey;
+        this.sharedPredGradHessKey = sharedPredGradHessKey;
+        this.sharedShuffledIndicesKey = sharedShuffledIndicesKey;
+        this.sharedSwappedIndicesKey = sharedSwappedIndicesKey;
+        this.finalStateOutputTag = finalStateOutputTag;
+    }
+
+    @Override
+    public void open() throws Exception {
+        int subtaskId = getRuntimeContext().getIndexOfThisSubtask();
+        pghWriter =
+                IterationSharedStorage.getWriter(
+                        iterationID,
+                        subtaskId,
+                        sharedPredGradHessKey,
+                        getOperatorID(),
+                        new PredGradHess[0]);
+        swappedIndicesWriter =
+                IterationSharedStorage.getWriter(
+                        iterationID,
+                        subtaskId,
+                        sharedSwappedIndicesKey,
+                        getOperatorID(),
+                        new int[0]);
+
+        this.instancesReader =
+                IterationSharedStorage.getReader(iterationID, subtaskId, sharedInstancesKey);
+        this.shuffledIndicesReader =
+                IterationSharedStorage.getReader(iterationID, subtaskId, sharedShuffledIndicesKey);
+    }
+
+    @Override
+    public void onEpochWatermarkIncremented(
+            int epochWatermark, Context context, Collector<LocalState> collector) throws Exception {
+        LocalState localStateValue = localState;
+        if (0 == epochWatermark) {
+            nodeSplitter = new NodeSplitter(localStateValue.statics);
+            instanceUpdater = new InstanceUpdater(localStateValue.statics);
+        }
+
+        int[] indices = swappedIndicesWriter.get();
+        if (0 == indices.length) {
+            indices = shuffledIndicesReader.get().clone();
+        }
+
+        BinnedInstance[] instances = instancesReader.get();
+        nodeSplitter.split(
+                localStateValue.dynamics.layer,
+                localStateValue.dynamics.leaves,
+                splits.splits,
+                indices,
+                instances);
+
+        if (localStateValue.dynamics.layer.isEmpty()) {
+            localStateValue.dynamics.inWeakLearner = false;
+            instanceUpdater.update(
+                    localStateValue.dynamics.leaves, indices, instances, pghWriter::set);
+            swappedIndicesWriter.set(new int[0]);
+        } else {
+            swappedIndicesWriter.set(indices);
+        }
+        collector.collect(localStateValue);
+    }
+
+    @Override
+    public void onIterationTerminated(Context context, Collector<LocalState> collector) {
+        pghWriter.set(new PredGradHess[0]);
+        swappedIndicesWriter.set(new int[0]);
+        if (0 == getRuntimeContext().getIndexOfThisSubtask()) {
+            context.output(finalStateOutputTag, localState);
+        }
+    }
+
+    @Override
+    public void processElement1(StreamRecord<LocalState> element) throws Exception {
+        localState = element.getValue();
+    }
+
+    @Override
+    public void processElement2(StreamRecord<Splits> element) throws Exception {
+        splits = element.getValue();
+    }
+
+    @Override
+    public void close() throws Exception {
+        pghWriter.remove();
+        swappedIndicesWriter.remove();
+        super.close();
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/SplitFinder.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/SplitFinder.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.ml.common.gbt.defs.Distributor;
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.Histogram;
+import org.apache.flink.ml.common.gbt.defs.LearningNode;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.Slice;
+import org.apache.flink.ml.common.gbt.defs.Split;
+import org.apache.flink.ml.common.gbt.defs.Splits;
+import org.apache.flink.ml.common.gbt.splitter.CategoricalFeatureSplitter;
+import org.apache.flink.ml.common.gbt.splitter.ContinuousFeatureSplitter;
+import org.apache.flink.ml.common.gbt.splitter.HistogramFeatureSplitter;
+import org.apache.flink.util.Preconditions;
+
+import org.eclipse.collections.api.tuple.primitive.IntIntPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+class SplitFinder {
+    private static final Logger LOG = LoggerFactory.getLogger(SplitFinder.class);
+
+    private final int subtaskId;
+    private final int numSubtasks;
+    private final int[] numFeatureBins;
+    private final HistogramFeatureSplitter[] splitters;
+    private final int maxDepth;
+    private final int maxNumLeaves;
+
+    public SplitFinder(LocalState.Statics statics) {
+        subtaskId = statics.subtaskId;
+        numSubtasks = statics.numSubtasks;
+
+        numFeatureBins = statics.numFeatureBins;
+        FeatureMeta[] featureMetas = statics.featureMetas;
+        splitters = new HistogramFeatureSplitter[statics.numFeatures];
+        for (int i = 0; i < statics.numFeatures; ++i) {
+            splitters[i] =
+                    FeatureMeta.Type.CATEGORICAL == featureMetas[i].type
+                            ? new CategoricalFeatureSplitter(i, featureMetas[i], statics.params)
+                            : new ContinuousFeatureSplitter(i, featureMetas[i], statics.params);
+        }
+        maxDepth = statics.params.maxDepth;
+        maxNumLeaves = statics.params.maxNumLeaves;
+    }
+
+    public Splits calc(
+            List<LearningNode> layer,
+            List<IntIntPair> nodeFeaturePairs,
+            List<LearningNode> leaves,
+            Histogram histogram) {
+        LOG.info("subtaskId: {}, {} start", subtaskId, SplitFinder.class.getSimpleName());
+
+        Distributor distributor =
+                new Distributor.EvenDistributor(numSubtasks, nodeFeaturePairs.size());
+        long start = distributor.start(subtaskId);
+        long cnt = distributor.count(subtaskId);
+
+        Split[] nodesBestSplits = new Split[layer.size()];
+        int binOffset = 0;
+        for (long i = start; i < start + cnt; i += 1) {
+            IntIntPair nodeFeaturePair = nodeFeaturePairs.get((int) i);
+            int nodeId = nodeFeaturePair.getOne();
+            int featureId = nodeFeaturePair.getTwo();
+            LearningNode node = layer.get(nodeId);
+
+            Preconditions.checkState(node.depth < maxDepth || leaves.size() + 2 <= maxNumLeaves);
+            splitters[featureId].reset(
+                    histogram.hists, new Slice(binOffset, binOffset + numFeatureBins[featureId]));
+            Split bestSplit = splitters[featureId].bestSplit();
+            if (null == nodesBestSplits[nodeId]
+                    || (bestSplit.gain > nodesBestSplits[nodeId].gain)) {
+                nodesBestSplits[nodeId] = bestSplit;
+            }
+            binOffset += numFeatureBins[featureId];
+        }
+
+        LOG.info("subtaskId: {}, {} end", subtaskId, SplitFinder.class.getSimpleName());
+        return new Splits(subtaskId, nodesBestSplits);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/SplitsAggregateFunction.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/SplitsAggregateFunction.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.ml.common.gbt.defs.Splits;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import java.util.BitSet;
+
+/** Aggregation function for merging splits. */
+public class SplitsAggregateFunction extends RichFlatMapFunction<Splits, Splits> {
+
+    private final AggregateFunction<Splits, Splits, Splits> aggregator = new Splits.Aggregator();
+    private int numSubtasks;
+    private BitSet accepted;
+    private Splits acc = null;
+
+    @Override
+    public void flatMap(Splits value, Collector<Splits> out) throws Exception {
+        if (null == accepted) {
+            numSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
+            accepted = new BitSet(numSubtasks);
+        }
+        int receivedSubtaskId = value.subtaskId;
+        Preconditions.checkState(!accepted.get(receivedSubtaskId));
+        accepted.set(receivedSubtaskId);
+        acc = aggregator.add(value, acc);
+        if (numSubtasks == accepted.cardinality()) {
+            acc.subtaskId = getRuntimeContext().getIndexOfThisSubtask();
+            out.collect(acc);
+            accepted = null;
+            acc = null;
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/TreeInitializer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/operators/TreeInitializer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.operators;
+
+import org.apache.flink.ml.common.gbt.DataUtils;
+import org.apache.flink.ml.common.gbt.defs.LearningNode;
+import org.apache.flink.ml.common.gbt.defs.LocalState;
+import org.apache.flink.ml.common.gbt.defs.Node;
+import org.apache.flink.ml.common.gbt.defs.Slice;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Random;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+class TreeInitializer {
+    private static final Logger LOG = LoggerFactory.getLogger(TreeInitializer.class);
+
+    private final int subtaskId;
+    private final int numInstances;
+    private final int numBaggingInstances;
+    private final int[] shuffledIndices;
+    private final Random instanceRandomizer;
+
+    public TreeInitializer(LocalState.Statics statics) {
+        subtaskId = statics.subtaskId;
+        numInstances = statics.numInstances;
+        numBaggingInstances = statics.numBaggingInstances;
+        instanceRandomizer = statics.instanceRandomizer;
+        shuffledIndices = IntStream.range(0, numInstances).toArray();
+    }
+
+    /** Calculate local histograms for nodes in current layer of tree. */
+    public void init(LocalState.Dynamics dynamics, Consumer<int[]> shuffledIndicesSetter) {
+        LOG.info("subtaskId: {}, {} start", subtaskId, TreeInitializer.class.getSimpleName());
+        Preconditions.checkState(!dynamics.inWeakLearner);
+        Preconditions.checkState(dynamics.layer.isEmpty());
+
+        // Initializes the root node of a new tree when last tree is finalized.
+        DataUtils.shuffle(shuffledIndices, instanceRandomizer);
+        Node root = new Node();
+        dynamics.layer.add(
+                new LearningNode(
+                        root,
+                        new Slice(0, numBaggingInstances),
+                        new Slice(numBaggingInstances, numInstances),
+                        1));
+        dynamics.roots.add(root);
+        dynamics.leaves.clear();
+        shuffledIndicesSetter.accept(shuffledIndices);
+
+        LOG.info("subtaskId: {}, {} end", this.subtaskId, TreeInitializer.class.getSimpleName());
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/splitter/CategoricalFeatureSplitter.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/splitter/CategoricalFeatureSplitter.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.splitter;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.common.gbt.defs.HessianImpurity;
+import org.apache.flink.ml.common.gbt.defs.Split;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Comparator;
+
+import static org.apache.flink.ml.common.gbt.DataUtils.BIN_SIZE;
+
+/** Splitter for a categorical feature using LightGBM many-vs-many split. */
+public class CategoricalFeatureSplitter extends HistogramFeatureSplitter {
+
+    public CategoricalFeatureSplitter(int featureId, FeatureMeta featureMeta, GbtParams params) {
+        super(featureId, featureMeta, params);
+    }
+
+    @Override
+    public Split.CategoricalSplit bestSplit() {
+        Tuple2<HessianImpurity, HessianImpurity> totalMissing = countTotalMissing();
+        HessianImpurity total = totalMissing.f0;
+        HessianImpurity missing = totalMissing.f1;
+
+        if (total.getNumInstances() <= minSamplesPerLeaf) {
+            return Split.CategoricalSplit.invalid(total.prediction());
+        }
+
+        int numBins = slice.size();
+        // Sorts categories based on grads / hessians, i.e., LightGBM many-vs-many approach.
+        Integer[] sortedCategories = new Integer[numBins];
+        {
+            double[] scores = new double[numBins];
+            for (int i = 0; i < numBins; ++i) {
+                sortedCategories[i] = i;
+                int startIndex = (slice.start + i) * BIN_SIZE;
+                scores[i] = hists[startIndex] / hists[startIndex + 1];
+            }
+            Arrays.sort(sortedCategories, Comparator.comparing(d -> scores[d]));
+        }
+
+        Tuple3<Double, Integer, Boolean> bestSplit =
+                findBestSplit(ArrayUtils.toPrimitive(sortedCategories), total, missing);
+        double bestGain = bestSplit.f0;
+        int bestSplitBinId = bestSplit.f1;
+        boolean missingGoLeft = bestSplit.f2;
+
+        if (bestGain <= Split.INVALID_GAIN || bestGain <= minInfoGain) {
+            return Split.CategoricalSplit.invalid(total.prediction());
+        }
+
+        // Indicates which bins should go left.
+        BitSet binsGoLeft = new BitSet(numBins);
+        if (useMissing) {
+            for (int i = 0; i < numBins; ++i) {
+                int binId = sortedCategories[i];
+                if (i <= bestSplitBinId) {
+                    if (binId < featureMeta.missingBin) {
+                        binsGoLeft.set(binId);
+                    } else if (binId > featureMeta.missingBin) {
+                        binsGoLeft.set(binId - 1);
+                    }
+                }
+            }
+        } else {
+            int numCategories =
+                    ((FeatureMeta.CategoricalFeatureMeta) featureMeta).categories.length;
+            for (int i = 0; i < numCategories; i += 1) {
+                int binId = sortedCategories[i];
+                if (i <= bestSplitBinId) {
+                    binsGoLeft.set(binId);
+                }
+            }
+        }
+        return new Split.CategoricalSplit(
+                featureId,
+                bestGain,
+                featureMeta.missingBin,
+                missingGoLeft,
+                total.prediction(),
+                binsGoLeft);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/splitter/ContinuousFeatureSplitter.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/splitter/ContinuousFeatureSplitter.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.splitter;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.common.gbt.defs.HessianImpurity;
+import org.apache.flink.ml.common.gbt.defs.Split;
+
+import java.util.stream.IntStream;
+
+/** Splitter for a continuous feature. */
+public final class ContinuousFeatureSplitter extends HistogramFeatureSplitter {
+
+    public ContinuousFeatureSplitter(int featureId, FeatureMeta featureMeta, GbtParams params) {
+        super(featureId, featureMeta, params);
+    }
+
+    @Override
+    public Split.ContinuousSplit bestSplit() {
+        Tuple2<HessianImpurity, HessianImpurity> totalMissing = countTotalMissing();
+        HessianImpurity total = totalMissing.f0;
+        HessianImpurity missing = totalMissing.f1;
+
+        if (total.getNumInstances() <= minSamplesPerLeaf) {
+            return Split.ContinuousSplit.invalid(total.prediction());
+        }
+
+        int[] sortedBinIds = IntStream.range(0, slice.size()).toArray();
+        Tuple3<Double, Integer, Boolean> bestSplit = findBestSplit(sortedBinIds, total, missing);
+        double bestGain = bestSplit.f0;
+        int bestSplitBinId = bestSplit.f1;
+        boolean missingGoLeft = bestSplit.f2;
+
+        if (bestGain <= Split.INVALID_GAIN || bestGain <= minInfoGain) {
+            return Split.ContinuousSplit.invalid(total.prediction());
+        }
+        int splitPoint =
+                useMissing && bestSplitBinId > featureMeta.missingBin
+                        ? bestSplitBinId - 1
+                        : bestSplitBinId;
+        return new Split.ContinuousSplit(
+                featureId,
+                bestGain,
+                featureMeta.missingBin,
+                missingGoLeft,
+                total.prediction(),
+                splitPoint,
+                !params.isInputVector,
+                ((FeatureMeta.ContinuousFeatureMeta) featureMeta).zeroBin);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/splitter/FeatureSplitter.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/splitter/FeatureSplitter.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.splitter;
+
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.common.gbt.defs.Split;
+
+/**
+ * Tests if the node can be split on a given feature and obtains best split.
+ *
+ * <p>When testing the node, we only check internal criteria, such as minimum info gain, minium
+ * samples per leaf, etc. The external criteria, like maximum depth or maximum number of leaves are
+ * not checked.
+ */
+public abstract class FeatureSplitter {
+    protected final int featureId;
+    protected final FeatureMeta featureMeta;
+    protected final GbtParams params;
+
+    protected final int minSamplesPerLeaf;
+    protected final double minSampleRatioPerChild;
+    protected final double minInfoGain;
+
+    public FeatureSplitter(int featureId, FeatureMeta featureMeta, GbtParams params) {
+        this.params = params;
+        this.featureId = featureId;
+        this.featureMeta = featureMeta;
+
+        this.minSamplesPerLeaf = params.minInstancesPerNode;
+        this.minSampleRatioPerChild = params.minWeightFractionPerNode; // TODO: not exactly the same
+        this.minInfoGain = params.minInfoGain;
+    }
+
+    public abstract Split bestSplit();
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/splitter/HistogramFeatureSplitter.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/splitter/HistogramFeatureSplitter.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.splitter;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.common.gbt.defs.HessianImpurity;
+import org.apache.flink.ml.common.gbt.defs.Impurity;
+import org.apache.flink.ml.common.gbt.defs.Slice;
+import org.apache.flink.ml.common.gbt.defs.Split;
+
+import static org.apache.flink.ml.common.gbt.DataUtils.BIN_SIZE;
+
+/** Histogram based feature splitter. */
+public abstract class HistogramFeatureSplitter extends FeatureSplitter {
+    protected final boolean useMissing;
+    protected double[] hists;
+    protected Slice slice;
+
+    public HistogramFeatureSplitter(int featureId, FeatureMeta featureMeta, GbtParams params) {
+        super(featureId, featureMeta, params);
+        this.useMissing = params.useMissing;
+    }
+
+    protected boolean isSplitIllegal(Impurity total, Impurity left, Impurity right) {
+        return (minSamplesPerLeaf > left.getTotalWeights()
+                        || minSamplesPerLeaf > right.getTotalWeights())
+                || minSampleRatioPerChild > 1. * left.getNumInstances() / total.getNumInstances()
+                || minSampleRatioPerChild > 1. * right.getNumInstances() / total.getNumInstances();
+    }
+
+    protected double gain(Impurity total, Impurity left, Impurity right) {
+        return isSplitIllegal(total, left, right) ? Split.INVALID_GAIN : total.gain(left, right);
+    }
+
+    protected void addBinToLeft(int binId, HessianImpurity left, HessianImpurity right) {
+        int index = (slice.start + binId) * BIN_SIZE;
+        left.add((int) hists[index + 3], hists[index + 2], hists[index], hists[index + 1]);
+        if (null != right) {
+            right.subtract(
+                    (int) hists[index + 3], hists[index + 2], hists[index], hists[index + 1]);
+        }
+    }
+
+    protected Tuple2<Double, Integer> findBestSplitWithInitial(
+            int[] sortedBinIds,
+            HessianImpurity total,
+            HessianImpurity left,
+            HessianImpurity right) {
+        // Bins [0, bestSplitBinId] go left.
+        int bestSplitBinId = 0;
+        double bestGain = Split.INVALID_GAIN;
+        for (int i = 0; i < sortedBinIds.length; i += 1) {
+            int binId = sortedBinIds[i];
+            if (useMissing && binId == featureMeta.missingBin) {
+                continue;
+            }
+            addBinToLeft(binId, left, right);
+            double gain = gain(total, left, right);
+            if (gain > bestGain && gain >= minInfoGain) {
+                bestGain = gain;
+                bestSplitBinId = i;
+            }
+        }
+        return Tuple2.of(bestGain, bestSplitBinId);
+    }
+
+    protected Tuple3<Double, Integer, Boolean> findBestSplit(
+            int[] sortedBinIds, HessianImpurity total, HessianImpurity missing) {
+        double bestGain = Split.INVALID_GAIN;
+        int bestSplitBinId = 0;
+        boolean missingGoLeft = false;
+
+        {
+            // The cases where the missing values go right, or missing values are not allowed.
+            HessianImpurity left = emptyImpurity();
+            HessianImpurity right = (HessianImpurity) total.clone();
+            Tuple2<Double, Integer> bestSplit =
+                    findBestSplitWithInitial(sortedBinIds, total, left, right);
+            if (bestSplit.f0 > bestGain) {
+                bestGain = bestSplit.f0;
+                bestSplitBinId = bestSplit.f1;
+            }
+        }
+
+        if (useMissing) {
+            // The cases where the missing values go left.
+            HessianImpurity leftWithMissing = emptyImpurity().add(missing);
+            HessianImpurity rightWithoutMissing = (HessianImpurity) total.clone().subtract(missing);
+            Tuple2<Double, Integer> bestSplitMissingGoLeft =
+                    findBestSplitWithInitial(
+                            sortedBinIds, total, leftWithMissing, rightWithoutMissing);
+            if (bestSplitMissingGoLeft.f0 > bestGain) {
+                bestGain = bestSplitMissingGoLeft.f0;
+                bestSplitBinId = bestSplitMissingGoLeft.f1;
+                missingGoLeft = true;
+            }
+        }
+        return Tuple3.of(bestGain, bestSplitBinId, missingGoLeft);
+    }
+
+    public void reset(double[] hists, Slice slice) {
+        this.hists = hists;
+        this.slice = slice;
+    }
+
+    protected Tuple2<HessianImpurity, HessianImpurity> countTotalMissing() {
+        HessianImpurity total = emptyImpurity();
+        HessianImpurity missing = emptyImpurity();
+        for (int i = 0; i < slice.size(); ++i) {
+            addBinToLeft(i, total, null);
+        }
+        if (useMissing) {
+            addBinToLeft(featureMeta.missingBin, missing, null);
+        }
+        return Tuple2.of(total, missing);
+    }
+
+    protected HessianImpurity emptyImpurity() {
+        return new HessianImpurity(params.lambda, params.gamma, 0, 0, 0, 0);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/BinnedInstanceSerializer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/BinnedInstanceSerializer.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.typeinfo;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.ml.common.gbt.defs.BinnedInstance;
+
+import org.eclipse.collections.impl.map.mutable.primitive.IntIntHashMap;
+
+import java.io.IOException;
+
+/** Serializer for {@link BinnedInstance}. */
+public final class BinnedInstanceSerializer extends TypeSerializerSingleton<BinnedInstance> {
+
+    public static final BinnedInstanceSerializer INSTANCE = new BinnedInstanceSerializer();
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public BinnedInstance createInstance() {
+        return new BinnedInstance();
+    }
+
+    @Override
+    public BinnedInstance copy(BinnedInstance from) {
+        BinnedInstance instance = new BinnedInstance();
+        instance.features = new IntIntHashMap(from.features);
+        instance.label = from.label;
+        instance.weight = from.weight;
+        return instance;
+    }
+
+    @Override
+    public BinnedInstance copy(BinnedInstance from, BinnedInstance reuse) {
+        assert from.getClass() == reuse.getClass();
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(BinnedInstance record, DataOutputView target) throws IOException {
+        IntSerializer.INSTANCE.serialize(record.features.size(), target);
+        for (int k : record.features.keysView().toArray()) {
+            IntSerializer.INSTANCE.serialize(k, target);
+            IntSerializer.INSTANCE.serialize(record.features.get(k), target);
+        }
+        DoubleSerializer.INSTANCE.serialize(record.label, target);
+        DoubleSerializer.INSTANCE.serialize(record.weight, target);
+    }
+
+    @Override
+    public BinnedInstance deserialize(DataInputView source) throws IOException {
+        BinnedInstance instance = new BinnedInstance();
+        int numFeatures = IntSerializer.INSTANCE.deserialize(source);
+        instance.features = new IntIntHashMap();
+        for (int i = 0; i < numFeatures; i += 1) {
+            int k = IntSerializer.INSTANCE.deserialize(source);
+            int v = IntSerializer.INSTANCE.deserialize(source);
+            instance.features.put(k, v);
+        }
+        instance.label = DoubleSerializer.INSTANCE.deserialize(source);
+        instance.weight = DoubleSerializer.INSTANCE.deserialize(source);
+        return instance;
+    }
+
+    @Override
+    public BinnedInstance deserialize(BinnedInstance reuse, DataInputView source)
+            throws IOException {
+        return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        serialize(deserialize(source), target);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public TypeSerializerSnapshot<BinnedInstance> snapshotConfiguration() {
+        return new BinnedInstanceSerializerSnapshot();
+    }
+
+    /** Serializer configuration snapshot for compatibility and format evolution. */
+    @SuppressWarnings("WeakerAccess")
+    public static final class BinnedInstanceSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<BinnedInstance> {
+
+        public BinnedInstanceSerializerSnapshot() {
+            super(BinnedInstanceSerializer::new);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/CategoricalSplitSerializer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/CategoricalSplitSerializer.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.typeinfo;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
+import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.ml.common.gbt.defs.Split;
+
+import java.io.IOException;
+import java.util.BitSet;
+
+/** Specialized serializer for {@link Split.CategoricalSplit}. */
+public final class CategoricalSplitSerializer
+        extends TypeSerializerSingleton<Split.CategoricalSplit> {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final CategoricalSplitSerializer INSTANCE = new CategoricalSplitSerializer();
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public Split.CategoricalSplit createInstance() {
+        return new Split.CategoricalSplit(-1, Split.INVALID_GAIN, 0, false, 0., new BitSet());
+    }
+
+    @Override
+    public Split.CategoricalSplit copy(Split.CategoricalSplit from) {
+        return new Split.CategoricalSplit(
+                from.featureId,
+                from.gain,
+                from.missingBin,
+                from.missingGoLeft,
+                from.prediction,
+                from.categoriesGoLeft);
+    }
+
+    @Override
+    public Split.CategoricalSplit copy(Split.CategoricalSplit from, Split.CategoricalSplit reuse) {
+        assert from.getClass() == reuse.getClass();
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(Split.CategoricalSplit record, DataOutputView target) throws IOException {
+        IntSerializer.INSTANCE.serialize(record.featureId, target);
+        DoubleSerializer.INSTANCE.serialize(record.gain, target);
+        IntSerializer.INSTANCE.serialize(record.missingBin, target);
+        BooleanSerializer.INSTANCE.serialize(record.missingGoLeft, target);
+        DoubleSerializer.INSTANCE.serialize(record.prediction, target);
+        BytePrimitiveArraySerializer.INSTANCE.serialize(
+                record.categoriesGoLeft.toByteArray(), target);
+    }
+
+    @Override
+    public Split.CategoricalSplit deserialize(DataInputView source) throws IOException {
+        return new Split.CategoricalSplit(
+                IntSerializer.INSTANCE.deserialize(source),
+                DoubleSerializer.INSTANCE.deserialize(source),
+                IntSerializer.INSTANCE.deserialize(source),
+                BooleanSerializer.INSTANCE.deserialize(source),
+                DoubleSerializer.INSTANCE.deserialize(source),
+                BitSet.valueOf(BytePrimitiveArraySerializer.INSTANCE.deserialize(source)));
+    }
+
+    @Override
+    public Split.CategoricalSplit deserialize(Split.CategoricalSplit reuse, DataInputView source)
+            throws IOException {
+        return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        serialize(deserialize(source), target);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public TypeSerializerSnapshot<Split.CategoricalSplit> snapshotConfiguration() {
+        return new CategoricalSplitSerializerSnapshot();
+    }
+
+    /** Serializer configuration snapshot for compatibility and format evolution. */
+    @SuppressWarnings("WeakerAccess")
+    public static final class CategoricalSplitSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<Split.CategoricalSplit> {
+
+        public CategoricalSplitSerializerSnapshot() {
+            super(CategoricalSplitSerializer::new);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/ContinuousSplitSerializer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/ContinuousSplitSerializer.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.typeinfo;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
+import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.ml.common.gbt.defs.Split;
+
+import java.io.IOException;
+
+/** Specialized serializer for {@link Split.ContinuousSplit}. */
+public final class ContinuousSplitSerializer
+        extends TypeSerializerSingleton<Split.ContinuousSplit> {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final ContinuousSplitSerializer INSTANCE = new ContinuousSplitSerializer();
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public Split.ContinuousSplit createInstance() {
+        return new Split.ContinuousSplit(-1, Split.INVALID_GAIN, 0, false, 0., 0., false, 0);
+    }
+
+    @Override
+    public Split.ContinuousSplit copy(Split.ContinuousSplit from) {
+        return new Split.ContinuousSplit(
+                from.featureId,
+                from.gain,
+                from.missingBin,
+                from.missingGoLeft,
+                from.prediction,
+                from.threshold,
+                from.isUnseenMissing,
+                from.zeroBin);
+    }
+
+    @Override
+    public Split.ContinuousSplit copy(Split.ContinuousSplit from, Split.ContinuousSplit reuse) {
+        assert from.getClass() == reuse.getClass();
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(Split.ContinuousSplit record, DataOutputView target) throws IOException {
+        IntSerializer.INSTANCE.serialize(record.featureId, target);
+        DoubleSerializer.INSTANCE.serialize(record.gain, target);
+        IntSerializer.INSTANCE.serialize(record.missingBin, target);
+        BooleanSerializer.INSTANCE.serialize(record.missingGoLeft, target);
+        DoubleSerializer.INSTANCE.serialize(record.prediction, target);
+        DoubleSerializer.INSTANCE.serialize(record.threshold, target);
+        BooleanSerializer.INSTANCE.serialize(record.isUnseenMissing, target);
+        IntSerializer.INSTANCE.serialize(record.zeroBin, target);
+    }
+
+    @Override
+    public Split.ContinuousSplit deserialize(DataInputView source) throws IOException {
+        return new Split.ContinuousSplit(
+                IntSerializer.INSTANCE.deserialize(source),
+                DoubleSerializer.INSTANCE.deserialize(source),
+                IntSerializer.INSTANCE.deserialize(source),
+                BooleanSerializer.INSTANCE.deserialize(source),
+                DoubleSerializer.INSTANCE.deserialize(source),
+                DoubleSerializer.INSTANCE.deserialize(source),
+                BooleanSerializer.INSTANCE.deserialize(source),
+                IntSerializer.INSTANCE.deserialize(source));
+    }
+
+    @Override
+    public Split.ContinuousSplit deserialize(Split.ContinuousSplit reuse, DataInputView source)
+            throws IOException {
+        return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        serialize(deserialize(source), target);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public TypeSerializerSnapshot<Split.ContinuousSplit> snapshotConfiguration() {
+        return new ContinuousSplitSplitSerializerSnapshot();
+    }
+
+    /** Serializer configuration snapshot for compatibility and format evolution. */
+    @SuppressWarnings("WeakerAccess")
+    public static final class ContinuousSplitSplitSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<Split.ContinuousSplit> {
+
+        public ContinuousSplitSplitSerializerSnapshot() {
+            super(ContinuousSplitSerializer::new);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/GBTModelDataSerializer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/GBTModelDataSerializer.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.typeinfo;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
+import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.api.common.typeutils.base.array.DoublePrimitiveArraySerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+import org.apache.flink.ml.common.gbt.defs.Node;
+
+import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectIntHashMap;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.BitSet;
+
+/** Specialized serializer for {@link GBTModelData}. */
+public final class GBTModelDataSerializer extends TypeSerializerSingleton<GBTModelData> {
+
+    public static final GBTModelDataSerializer INSTANCE = new GBTModelDataSerializer();
+    private static final long serialVersionUID = 1L;
+    private static final NodeSerializer NODE_SERIALIZER = NodeSerializer.INSTANCE;
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public GBTModelData createInstance() {
+        return new GBTModelData();
+    }
+
+    @Override
+    public GBTModelData copy(GBTModelData from) {
+        GBTModelData record = new GBTModelData();
+        record.type = from.type;
+        record.isInputVector = from.isInputVector;
+
+        record.prior = from.prior;
+        record.stepSize = from.stepSize;
+
+        record.roots = new ArrayList<>(from.roots);
+        record.categoryToIdMaps = new IntObjectHashMap<>(from.categoryToIdMaps);
+        record.featureIdToBinEdges = new IntObjectHashMap<>(from.featureIdToBinEdges);
+        record.isCategorical = BitSet.valueOf(from.isCategorical.toByteArray());
+        return record;
+    }
+
+    @Override
+    public GBTModelData copy(GBTModelData from, GBTModelData reuse) {
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(GBTModelData record, DataOutputView target) throws IOException {
+        StringSerializer.INSTANCE.serialize(record.type, target);
+        BooleanSerializer.INSTANCE.serialize(record.isInputVector, target);
+
+        DoubleSerializer.INSTANCE.serialize(record.prior, target);
+        DoubleSerializer.INSTANCE.serialize(record.stepSize, target);
+
+        IntSerializer.INSTANCE.serialize(record.roots.size(), target);
+        for (Node root : record.roots) {
+            NODE_SERIALIZER.serialize(root, target);
+        }
+
+        IntSerializer.INSTANCE.serialize(record.categoryToIdMaps.size(), target);
+        for (int featureId : record.categoryToIdMaps.keysView().toArray()) {
+            ObjectIntHashMap<String> categoryToIdMap = record.categoryToIdMaps.get(featureId);
+            IntSerializer.INSTANCE.serialize(featureId, target);
+            IntSerializer.INSTANCE.serialize(categoryToIdMap.size(), target);
+            for (String category : categoryToIdMap.keysView()) {
+                StringSerializer.INSTANCE.serialize(category, target);
+                IntSerializer.INSTANCE.serialize(categoryToIdMap.get(category), target);
+            }
+        }
+
+        IntSerializer.INSTANCE.serialize(record.featureIdToBinEdges.size(), target);
+        for (int featureId : record.featureIdToBinEdges.keysView().toArray()) {
+            double[] binEdges = record.featureIdToBinEdges.get(featureId);
+            IntSerializer.INSTANCE.serialize(featureId, target);
+            DoublePrimitiveArraySerializer.INSTANCE.serialize(binEdges, target);
+        }
+
+        BytePrimitiveArraySerializer.INSTANCE.serialize(record.isCategorical.toByteArray(), target);
+    }
+
+    @Override
+    public GBTModelData deserialize(DataInputView source) throws IOException {
+        GBTModelData record = new GBTModelData();
+
+        record.type = StringSerializer.INSTANCE.deserialize(source);
+        record.isInputVector = BooleanSerializer.INSTANCE.deserialize(source);
+
+        record.prior = DoubleSerializer.INSTANCE.deserialize(source);
+        record.stepSize = DoubleSerializer.INSTANCE.deserialize(source);
+
+        int numRoots = IntSerializer.INSTANCE.deserialize(source);
+        record.roots = new ArrayList<>();
+        for (int i = 0; i < numRoots; i += 1) {
+            record.roots.add(NODE_SERIALIZER.deserialize(source));
+        }
+
+        int numCategoricalFeatures = IntSerializer.INSTANCE.deserialize(source);
+        record.categoryToIdMaps = IntObjectHashMap.newMap();
+        for (int k = 0; k < numCategoricalFeatures; k += 1) {
+            int featureId = IntSerializer.INSTANCE.deserialize(source);
+            int categoryToIdMapSize = IntSerializer.INSTANCE.deserialize(source);
+            ObjectIntHashMap<String> categoryToIdMap = ObjectIntHashMap.newMap();
+            for (int i = 0; i < categoryToIdMapSize; i += 1) {
+                categoryToIdMap.put(
+                        StringSerializer.INSTANCE.deserialize(source),
+                        IntSerializer.INSTANCE.deserialize(source));
+            }
+            record.categoryToIdMaps.put(featureId, categoryToIdMap);
+        }
+
+        int numContinuousFeatures = IntSerializer.INSTANCE.deserialize(source);
+        record.featureIdToBinEdges = IntObjectHashMap.newMap();
+        for (int i = 0; i < numContinuousFeatures; i += 1) {
+            int featureId = IntSerializer.INSTANCE.deserialize(source);
+            double[] binEdges = DoublePrimitiveArraySerializer.INSTANCE.deserialize(source);
+            record.featureIdToBinEdges.put(featureId, binEdges);
+        }
+
+        record.isCategorical =
+                BitSet.valueOf(BytePrimitiveArraySerializer.INSTANCE.deserialize(source));
+        return record;
+    }
+
+    @Override
+    public GBTModelData deserialize(GBTModelData reuse, DataInputView source) throws IOException {
+        return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        serialize(deserialize(source), target);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public TypeSerializerSnapshot<GBTModelData> snapshotConfiguration() {
+        return new GBTModelDataSerializerSnapshot();
+    }
+
+    /** Serializer configuration snapshot for compatibility and format evolution. */
+    @SuppressWarnings("WeakerAccess")
+    public static final class GBTModelDataSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<GBTModelData> {
+
+        public GBTModelDataSerializerSnapshot() {
+            super(GBTModelDataSerializer::new);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/GBTModelDataTypeInfo.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/GBTModelDataTypeInfo.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.typeinfo;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+
+/** A {@link TypeInformation} for the {@link GBTModelData} type. */
+public class GBTModelDataTypeInfo extends TypeInformation<GBTModelData> {
+
+    public static final GBTModelDataTypeInfo INSTANCE = new GBTModelDataTypeInfo();
+
+    private GBTModelDataTypeInfo() {}
+
+    @Override
+    public boolean isBasicType() {
+        return false;
+    }
+
+    @Override
+    public boolean isTupleType() {
+        return false;
+    }
+
+    @Override
+    public int getArity() {
+        return 2;
+    }
+
+    @Override
+    public int getTotalFields() {
+        return 2;
+    }
+
+    @Override
+    public Class<GBTModelData> getTypeClass() {
+        return GBTModelData.class;
+    }
+
+    @Override
+    public boolean isKeyType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<GBTModelData> createSerializer(ExecutionConfig executionConfig) {
+        return new GBTModelDataSerializer();
+    }
+
+    @Override
+    public String toString() {
+        return "SplitTypeInfo";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof GBTModelDataTypeInfo;
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public boolean canEqual(Object o) {
+        return o instanceof GBTModelDataTypeInfo;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/GBTModelDataTypeInfoFactory.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/GBTModelDataTypeInfoFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.typeinfo;
+
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Used by {@link TypeExtractor} to create a {@link TypeInformation} for implementations of {@link
+ * GBTModelData}.
+ */
+public class GBTModelDataTypeInfoFactory extends TypeInfoFactory<GBTModelData> {
+    @Override
+    public TypeInformation<GBTModelData> createTypeInfo(
+            Type t, Map<String, TypeInformation<?>> genericParameters) {
+        return GBTModelDataTypeInfo.INSTANCE;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/NodeSerializer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/NodeSerializer.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.typeinfo;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.ml.common.gbt.defs.Node;
+
+import java.io.IOException;
+
+/** Serializer for {@link Node}. */
+public final class NodeSerializer extends TypeSerializerSingleton<Node> {
+
+    public static final NodeSerializer INSTANCE = new NodeSerializer();
+    private static final long serialVersionUID = 1L;
+
+    private static final SplitSerializer SPLIT_SERIALIZER = SplitSerializer.INSTANCE;
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public Node createInstance() {
+        return new Node();
+    }
+
+    @Override
+    public Node copy(Node from) {
+        Node node = new Node();
+        node.split = SPLIT_SERIALIZER.copy(from.split);
+        node.isLeaf = from.isLeaf;
+        if (!node.isLeaf) {
+            node.left = copy(from.left);
+            node.right = copy(from.right);
+        }
+        return node;
+    }
+
+    @Override
+    public Node copy(Node from, Node reuse) {
+        assert from.getClass() == reuse.getClass();
+        SPLIT_SERIALIZER.copy(from.split, reuse.split);
+        reuse.isLeaf = from.isLeaf;
+        if (!reuse.isLeaf) {
+            copy(from.left, reuse.left);
+            copy(from.right, reuse.right);
+        }
+        return reuse;
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(Node record, DataOutputView target) throws IOException {
+        SPLIT_SERIALIZER.serialize(record.split, target);
+        BooleanSerializer.INSTANCE.serialize(record.isLeaf, target);
+        if (!record.isLeaf) {
+            serialize(record.left, target);
+            serialize(record.right, target);
+        }
+    }
+
+    @Override
+    public Node deserialize(DataInputView source) throws IOException {
+        Node node = new Node();
+        node.split = SPLIT_SERIALIZER.deserialize(source);
+        node.isLeaf = BooleanSerializer.INSTANCE.deserialize(source);
+        if (!node.isLeaf) {
+            node.left = deserialize(source);
+            node.right = deserialize(source);
+        }
+        return node;
+    }
+
+    @Override
+    public Node deserialize(Node reuse, DataInputView source) throws IOException {
+        reuse.split = SPLIT_SERIALIZER.deserialize(source);
+        reuse.isLeaf = BooleanSerializer.INSTANCE.deserialize(source);
+        if (!reuse.isLeaf) {
+            reuse.left = deserialize(source);
+            reuse.right = deserialize(source);
+        }
+        return reuse;
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        serialize(deserialize(source), target);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public TypeSerializerSnapshot<Node> snapshotConfiguration() {
+        return new NodeSerializerSnapshot();
+    }
+
+    /** Serializer configuration snapshot for compatibility and format evolution. */
+    @SuppressWarnings("WeakerAccess")
+    public static final class NodeSerializerSnapshot extends SimpleTypeSerializerSnapshot<Node> {
+
+        public NodeSerializerSnapshot() {
+            super(NodeSerializer::new);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/PredGradHessSerializer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/PredGradHessSerializer.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.typeinfo;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.ml.common.gbt.defs.PredGradHess;
+
+import java.io.IOException;
+
+/** Serializer for {@link PredGradHess}. */
+public final class PredGradHessSerializer extends TypeSerializerSingleton<PredGradHess> {
+
+    public static final PredGradHessSerializer INSTANCE = new PredGradHessSerializer();
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public PredGradHess createInstance() {
+        return new PredGradHess();
+    }
+
+    @Override
+    public PredGradHess copy(PredGradHess from) {
+        PredGradHess instance = new PredGradHess();
+        instance.pred = from.pred;
+        instance.gradient = from.gradient;
+        instance.hessian = from.hessian;
+        return instance;
+    }
+
+    @Override
+    public PredGradHess copy(PredGradHess from, PredGradHess reuse) {
+        assert from.getClass() == reuse.getClass();
+        reuse.pred = from.pred;
+        reuse.gradient = from.gradient;
+        reuse.hessian = from.hessian;
+        return reuse;
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(PredGradHess record, DataOutputView target) throws IOException {
+        DoubleSerializer.INSTANCE.serialize(record.pred, target);
+        DoubleSerializer.INSTANCE.serialize(record.gradient, target);
+        DoubleSerializer.INSTANCE.serialize(record.hessian, target);
+    }
+
+    @Override
+    public PredGradHess deserialize(DataInputView source) throws IOException {
+        PredGradHess instance = new PredGradHess();
+        instance.pred = DoubleSerializer.INSTANCE.deserialize(source);
+        instance.gradient = DoubleSerializer.INSTANCE.deserialize(source);
+        instance.hessian = DoubleSerializer.INSTANCE.deserialize(source);
+        return instance;
+    }
+
+    @Override
+    public PredGradHess deserialize(PredGradHess reuse, DataInputView source) throws IOException {
+        reuse.pred = DoubleSerializer.INSTANCE.deserialize(source);
+        reuse.gradient = DoubleSerializer.INSTANCE.deserialize(source);
+        reuse.hessian = DoubleSerializer.INSTANCE.deserialize(source);
+        return reuse;
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        serialize(deserialize(source), target);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public TypeSerializerSnapshot<PredGradHess> snapshotConfiguration() {
+        return new PredGradHessSerializerSnapshot();
+    }
+
+    /** Serializer configuration snapshot for compatibility and format evolution. */
+    @SuppressWarnings("WeakerAccess")
+    public static final class PredGradHessSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<PredGradHess> {
+
+        public PredGradHessSerializerSnapshot() {
+            super(PredGradHessSerializer::new);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/SplitSerializer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/gbt/typeinfo/SplitSerializer.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt.typeinfo;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.ml.common.gbt.defs.Split;
+
+import java.io.IOException;
+
+/** Specialized serializer for {@link Split}. */
+public final class SplitSerializer extends TypeSerializerSingleton<Split> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final CategoricalSplitSerializer CATEGORICAL_SPLIT_SERIALIZER =
+            CategoricalSplitSerializer.INSTANCE;
+
+    private static final ContinuousSplitSerializer CONTINUOUS_SPLIT_SERIALIZER =
+            ContinuousSplitSerializer.INSTANCE;
+
+    public static final SplitSerializer INSTANCE = new SplitSerializer();
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public Split createInstance() {
+        return CATEGORICAL_SPLIT_SERIALIZER.createInstance();
+    }
+
+    @Override
+    public Split copy(Split from) {
+        if (from instanceof Split.CategoricalSplit) {
+            return CATEGORICAL_SPLIT_SERIALIZER.copy((Split.CategoricalSplit) from);
+        } else {
+            return CONTINUOUS_SPLIT_SERIALIZER.copy((Split.ContinuousSplit) from);
+        }
+    }
+
+    @Override
+    public Split copy(Split from, Split reuse) {
+        assert from.getClass() == reuse.getClass();
+        if (from instanceof Split.CategoricalSplit) {
+            return CATEGORICAL_SPLIT_SERIALIZER.copy(
+                    (Split.CategoricalSplit) from, (Split.CategoricalSplit) reuse);
+        } else {
+            return CONTINUOUS_SPLIT_SERIALIZER.copy(
+                    (Split.ContinuousSplit) from, (Split.ContinuousSplit) reuse);
+        }
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(Split record, DataOutputView target) throws IOException {
+        if (record instanceof Split.CategoricalSplit) {
+            target.writeByte(0);
+            CATEGORICAL_SPLIT_SERIALIZER.serialize((Split.CategoricalSplit) record, target);
+        } else {
+            target.writeByte(1);
+            CONTINUOUS_SPLIT_SERIALIZER.serialize((Split.ContinuousSplit) record, target);
+        }
+    }
+
+    @Override
+    public Split deserialize(DataInputView source) throws IOException {
+        byte type = source.readByte();
+        if (type == 0) {
+            return CATEGORICAL_SPLIT_SERIALIZER.deserialize(source);
+        } else {
+            return CONTINUOUS_SPLIT_SERIALIZER.deserialize(source);
+        }
+    }
+
+    @Override
+    public Split deserialize(Split reuse, DataInputView source) throws IOException {
+        byte type = source.readByte();
+        assert type == 0 && reuse instanceof Split.CategoricalSplit
+                || type == 1 && reuse instanceof Split.ContinuousSplit;
+        if (type == 0) {
+            return CATEGORICAL_SPLIT_SERIALIZER.deserialize((Split.CategoricalSplit) reuse, source);
+        } else {
+            return CONTINUOUS_SPLIT_SERIALIZER.deserialize((Split.ContinuousSplit) reuse, source);
+        }
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        serialize(deserialize(source), target);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public TypeSerializerSnapshot<Split> snapshotConfiguration() {
+        return new SplitSerializerSnapshot();
+    }
+
+    /** Serializer configuration snapshot for compatibility and format evolution. */
+    @SuppressWarnings("WeakerAccess")
+    public static final class SplitSerializerSnapshot extends SimpleTypeSerializerSnapshot<Split> {
+
+        public SplitSerializerSnapshot() {
+            super(SplitSerializer::new);
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasFeatureSubsetStrategy.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasFeatureSubsetStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param feature subset strategy. */
+public interface HasFeatureSubsetStrategy<T> extends WithParams<T> {
+    Param<String> FEATURE_SUBSET_STRATEGY =
+            new StringParam(
+                    "featureSubsetStrategy.",
+                    "Fraction of the training data used for learning one tree. Supports \"auto\", \"all\", \"onethird\", \"sqrt\", \"log2\", (0.0 - 1.0], and [1 - n].",
+                    "auto",
+                    ParamValidators.notNull());
+
+    default String getFeatureSubsetStrategy() {
+        return get(FEATURE_SUBSET_STRATEGY);
+    }
+
+    default T setFeatureSubsetStrategy(String value) {
+        return set(FEATURE_SUBSET_STRATEGY, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasLeafCol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasLeafCol.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param leaf column. */
+public interface HasLeafCol<T> extends WithParams<T> {
+    Param<String> LEAF_COL =
+            new StringParam("leafCol", "Predicted leaf index of each instance in each tree.", null);
+
+    default String getLeafCol() {
+        return get(LEAF_COL);
+    }
+
+    default T setLeafCol(String value) {
+        return set(LEAF_COL, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasLossType.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasLossType.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared maxBins param. */
+public interface HasLossType<T> extends WithParams<T> {
+
+    Param<String> LOSS_TYPE =
+            new StringParam(
+                    "lossType",
+                    "Loss type.",
+                    "squared",
+                    ParamValidators.inArray("squared", "absolute", "logistic"));
+
+    default String getLossType() {
+        return get(LOSS_TYPE);
+    }
+
+    default T setLossType(String value) {
+        set(LOSS_TYPE, value);
+        return (T) this;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMaxBins.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMaxBins.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared maxBins param. */
+public interface HasMaxBins<T> extends WithParams<T> {
+    Param<Integer> MAX_BINS =
+            new IntParam(
+                    "maxBins",
+                    "Maximum number of bins used for discretizing continuous features.",
+                    32,
+                    ParamValidators.gtEq(2));
+
+    default int getMaxBins() {
+        return get(MAX_BINS);
+    }
+
+    default T setMaxBins(int value) {
+        return set(MAX_BINS, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMaxDepth.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMaxDepth.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared maxDepth param. */
+public interface HasMaxDepth<T> extends WithParams<T> {
+    Param<Integer> MAX_DEPTH =
+            new IntParam("maxDepth", "Maximum depth of the tree.", 5, ParamValidators.gtEq(1));
+
+    default int getMaxDepth() {
+        return get(MAX_DEPTH);
+    }
+
+    default T setMaxDepth(int value) {
+        return set(MAX_DEPTH, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinInfoGain.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinInfoGain.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param minInfoGain. */
+public interface HasMinInfoGain<T> extends WithParams<T> {
+    Param<Double> MIN_INFO_GAIN =
+            new DoubleParam(
+                    "minInfoGain",
+                    "Minimum information gain for a split to be considered valid.",
+                    0.,
+                    ParamValidators.gtEq(0.));
+
+    default double getMinInfoGain() {
+        return get(MIN_INFO_GAIN);
+    }
+
+    default T setMinInfoGain(Double value) {
+        return set(MIN_INFO_GAIN, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinInstancesPerNode.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinInstancesPerNode.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.IntParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared minInstancesPerNode param. */
+public interface HasMinInstancesPerNode<T> extends WithParams<T> {
+    Param<Integer> MIN_INSTANCES_PER_NODE =
+            new IntParam(
+                    "minInstancesPerNode",
+                    "Minimum number of instances each node must have. If a split causes the left or right child to have fewer instances than minInstancesPerNode, the split is invalid.",
+                    1,
+                    ParamValidators.gtEq(1));
+
+    default int getMinInstancesPerNode() {
+        return get(MIN_INSTANCES_PER_NODE);
+    }
+
+    default T setMinInstancesPerNode(int value) {
+        return set(MIN_INSTANCES_PER_NODE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinWeightFractionPerNode.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasMinWeightFractionPerNode.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param minWeightFractionPerNode. */
+public interface HasMinWeightFractionPerNode<T> extends WithParams<T> {
+    Param<Double> MIN_WEIGHT_FRACTION_PER_NODE =
+            new DoubleParam(
+                    "minWeightFractionPerNode",
+                    "Minimum fraction of the weighted sample count that each node must have. If a split causes the left or right child to have a smaller fraction of the total weight than minWeightFractionPerNode, the split is invalid.",
+                    0.,
+                    ParamValidators.gtEq(0.));
+
+    default double getMinWeightFractionPerNode() {
+        return get(MIN_WEIGHT_FRACTION_PER_NODE);
+    }
+
+    default T setMinWeightFractionPerNode(Double value) {
+        return set(MIN_WEIGHT_FRACTION_PER_NODE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasProbabilityCol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasProbabilityCol.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param probability column. */
+public interface HasProbabilityCol<T> extends WithParams<T> {
+    Param<String> PROBABILITY_COL =
+            new StringParam(
+                    "probabilityCol",
+                    "Column name for predicted class conditional probabilities.",
+                    "probability",
+                    ParamValidators.notNull());
+
+    default String getProbabilityCol() {
+        return get(PROBABILITY_COL);
+    }
+
+    default T setProbabilityCol(String value) {
+        return set(PROBABILITY_COL, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasStepSize.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasStepSize.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared step size param. */
+public interface HasStepSize<T> extends WithParams<T> {
+    Param<Double> STEP_SIZE =
+            new DoubleParam(
+                    "stepSize",
+                    "Step size for shrinking the contribution of each estimator.",
+                    0.1,
+                    ParamValidators.inRange(0., 1.));
+
+    default double getStepSize() {
+        return get(STEP_SIZE);
+    }
+
+    default T setStepSize(Double value) {
+        return set(STEP_SIZE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasSubsamplingRate.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasSubsamplingRate.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for shared param subsampling rate. */
+public interface HasSubsamplingRate<T> extends WithParams<T> {
+    Param<Double> SUBSAMPLING_RATE =
+            new DoubleParam(
+                    "subsamplingRate",
+                    "Fraction of the training data used for learning one tree.",
+                    1.,
+                    ParamValidators.inRange(0., 1.));
+
+    default double getSubsamplingRate() {
+        return get(SUBSAMPLING_RATE);
+    }
+
+    default T setSubsamplingRate(Double value) {
+        return set(SUBSAMPLING_RATE, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasValidationIndicatorCol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasValidationIndicatorCol.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.StringParam;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared validation indicate column param. */
+public interface HasValidationIndicatorCol<T> extends WithParams<T> {
+    Param<String> VALIDATION_INDICATOR_COL =
+            new StringParam(
+                    "validationIndicatorCol",
+                    "The name of the column that indicates whether each row is for training or for validation.",
+                    null);
+
+    default String getValidationIndicatorCol() {
+        return get(VALIDATION_INDICATOR_COL);
+    }
+
+    default T setValidationIndicatorCol(String value) {
+        return set(VALIDATION_INDICATOR_COL, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasValidationTol.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/common/param/HasValidationTol.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.param;
+
+import org.apache.flink.ml.param.DoubleParam;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.WithParams;
+
+/** Interface for the shared tolerance param. */
+public interface HasValidationTol<T> extends WithParams<T> {
+
+    Param<Double> VALIDATION_TOL =
+            new DoubleParam(
+                    "validationTol",
+                    "Threshold for early stopping when fitting with validation is used.",
+                    .01,
+                    ParamValidators.gtEq(0));
+
+    default double getValidationTol() {
+        return get(VALIDATION_TOL);
+    }
+
+    default T setValidationTol(Double value) {
+        return set(VALIDATION_TOL, value);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/regression/gbtregressor/GBTRegressor.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/regression/gbtregressor/GBTRegressor.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.regression.gbtregressor;
+
+import org.apache.flink.ml.api.Estimator;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+import org.apache.flink.ml.common.gbt.GBTRunner;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.util.ParamUtils;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** An Estimator which implements the gradient boosting trees regression algorithm. */
+public class GBTRegressor
+        implements Estimator<GBTRegressor, GBTRegressorModel>, GBTRegressorParams<GBTRegressor> {
+
+    private final Map<Param<?>, Object> paramMap = new HashMap<>();
+
+    public GBTRegressor() {
+        ParamUtils.initializeMapWithDefaultValues(paramMap, this);
+    }
+
+    public static GBTRegressor load(StreamTableEnvironment tEnv, String path) throws IOException {
+        return ReadWriteUtils.loadStageParam(path);
+    }
+
+    @Override
+    public Map<Param<?>, Object> getParamMap() {
+        return paramMap;
+    }
+
+    @Override
+    public GBTRegressorModel fit(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<GBTModelData> modelData = GBTRunner.trainRegressor(inputs[0], this);
+        GBTRegressorModel model = new GBTRegressorModel();
+        model.setModelData(tEnv.fromDataStream(modelData).renameColumns($("f0").as("modelData")));
+        ReadWriteUtils.updateExistingParams(model, getParamMap());
+        return model;
+    }
+
+    @Override
+    public void save(String path) throws IOException {
+        ReadWriteUtils.saveMetadata(this, path);
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/regression/gbtregressor/GBTRegressorModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/regression/gbtregressor/GBTRegressorModel.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.regression.gbtregressor;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.common.broadcast.BroadcastUtils;
+import org.apache.flink.ml.common.datastream.TableUtils;
+import org.apache.flink.ml.common.gbt.BaseGBTModel;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.eclipse.collections.impl.map.mutable.primitive.IntDoubleHashMap;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/** A Model computed by {@link GBTRegressor}. */
+public class GBTRegressorModel extends BaseGBTModel<GBTRegressorModel> {
+
+    /**
+     * Loads model data from path.
+     *
+     * @param tEnv A StreamTableEnvironment instance.
+     * @param path Model path.
+     * @return GBT regression model.
+     */
+    public static GBTRegressorModel load(StreamTableEnvironment tEnv, String path)
+            throws IOException {
+        GBTRegressorModel model = ReadWriteUtils.loadStageParam(path);
+        Table modelDataTable =
+                ReadWriteUtils.loadModelData(tEnv, path, new GBTModelData.ModelDataDecoder());
+        return model.setModelData(modelDataTable);
+    }
+
+    @Override
+    public Table[] transform(Table... inputs) {
+        Preconditions.checkArgument(inputs.length == 1);
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
+        DataStream<Row> inputStream = tEnv.toDataStream(inputs[0]);
+        final String broadcastModelKey = "broadcastModelKey";
+        DataStream<GBTModelData> modelDataStream = GBTModelData.getModelDataStream(modelDataTable);
+        RowTypeInfo inputTypeInfo = TableUtils.getRowTypeInfo(inputs[0].getResolvedSchema());
+        RowTypeInfo outputTypeInfo =
+                new RowTypeInfo(
+                        ArrayUtils.addAll(inputTypeInfo.getFieldTypes(), Types.DOUBLE),
+                        ArrayUtils.addAll(inputTypeInfo.getFieldNames(), getPredictionCol()));
+        DataStream<Row> predictionResult =
+                BroadcastUtils.withBroadcastStream(
+                        Collections.singletonList(inputStream),
+                        Collections.singletonMap(broadcastModelKey, modelDataStream),
+                        inputList -> {
+                            //noinspection unchecked
+                            DataStream<Row> inputData = (DataStream<Row>) inputList.get(0);
+                            return inputData.map(
+                                    new PredictLabelFunction(
+                                            broadcastModelKey, getInputCols(), getFeaturesCol()),
+                                    outputTypeInfo);
+                        });
+        return new Table[] {tEnv.fromDataStream(predictionResult)};
+    }
+
+    private static class PredictLabelFunction extends RichMapFunction<Row, Row> {
+
+        private final String broadcastModelKey;
+        private final String[] inputCols;
+        private final String featuresCol;
+        private GBTModelData modelData;
+
+        public PredictLabelFunction(
+                String broadcastModelKey, String[] inputCols, String featuresCol) {
+            this.broadcastModelKey = broadcastModelKey;
+            this.inputCols = inputCols;
+            this.featuresCol = featuresCol;
+        }
+
+        @Override
+        public Row map(Row value) throws Exception {
+            if (null == modelData) {
+                modelData =
+                        (GBTModelData)
+                                getRuntimeContext().getBroadcastVariable(broadcastModelKey).get(0);
+            }
+            IntDoubleHashMap features = modelData.rowToFeatures(value, inputCols, featuresCol);
+            double pred = modelData.predictRaw(features);
+            return Row.join(value, Row.of(pred));
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/regression/gbtregressor/GBTRegressorParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/regression/gbtregressor/GBTRegressorParams.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.regression.gbtregressor;
+
+import org.apache.flink.ml.common.gbt.BaseGBTParams;
+import org.apache.flink.ml.param.Param;
+import org.apache.flink.ml.param.ParamValidators;
+import org.apache.flink.ml.param.StringParam;
+
+/**
+ * Parameters for {@link GBTRegressor}.
+ *
+ * @param <T> The class type of this instance.
+ */
+public interface GBTRegressorParams<T> extends BaseGBTParams<T> {
+    Param<String> LOSS_TYPE =
+            new StringParam(
+                    "lossType",
+                    "Loss type.",
+                    "squared",
+                    ParamValidators.inArray("squared", "absolute"));
+
+    default String getLossType() {
+        return get(LOSS_TYPE);
+    }
+
+    default T setLossType(String value) {
+        return set(LOSS_TYPE, value);
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/GBTClassifierTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/classification/GBTClassifierTest.java
@@ -1,0 +1,500 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.classification;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.classification.gbtclassifier.GBTClassifier;
+import org.apache.flink.ml.classification.gbtclassifier.GBTClassifierModel;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+import org.apache.flink.ml.common.gbt.defs.TaskType;
+import org.apache.flink.ml.linalg.DenseVector;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.TestUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Tests {@link GBTClassifier} and {@link GBTClassifierModel}. */
+public class GBTClassifierTest extends AbstractTestBase {
+    private static final List<Row> inputDataRows =
+            Arrays.asList(
+                    Row.of(1.2, 2, null, 40., 1., 0., Vectors.dense(1.2, 2, Double.NaN)),
+                    Row.of(2.3, 3, "b", 40., 2., 0., Vectors.dense(2.3, 3, 2.)),
+                    Row.of(3.4, 4, "c", 40., 3., 0., Vectors.dense(3.4, 4, 3.)),
+                    Row.of(4.5, 5, "a", 40., 4., 0., Vectors.dense(4.5, 5, 1.)),
+                    Row.of(5.6, 2, "b", 40., 5., 0., Vectors.dense(5.6, 2, 2.)),
+                    Row.of(null, 3, "c", 41., 1., 1., Vectors.dense(Double.NaN, 3, 3.)),
+                    Row.of(12.8, 4, "e", 41., 2., 1., Vectors.dense(12.8, 4, 5.)),
+                    Row.of(13.9, 2, "b", 41., 3., 1., Vectors.dense(13.9, 2, 2.)),
+                    Row.of(14.1, 4, "a", 41., 4., 1., Vectors.dense(14.1, 4, 1.)),
+                    Row.of(15.3, 1, "d", 41., 5., 1., Vectors.dense(15.3, 1, 4.)));
+
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+    List<Row> outputRows =
+            Arrays.asList(
+                    Row.of(
+                            0.0,
+                            Vectors.dense(2.376078066514637, -2.376078066514637),
+                            Vectors.dense(0.914984852695779, 0.08501514730422102)),
+                    Row.of(
+                            1.0,
+                            Vectors.dense(-2.5493892913102703, 2.5493892913102703),
+                            Vectors.dense(0.07246752402942669, 0.9275324759705733)),
+                    Row.of(
+                            1.0,
+                            Vectors.dense(-2.658830586839206, 2.658830586839206),
+                            Vectors.dense(0.06544682253255263, 0.9345531774674474)),
+                    Row.of(
+                            0.0,
+                            Vectors.dense(2.3309355512336296, -2.3309355512336296),
+                            Vectors.dense(0.9114069063091061, 0.08859309369089385)),
+                    Row.of(
+                            1.0,
+                            Vectors.dense(-2.6577392865785714, 2.6577392865785714),
+                            Vectors.dense(0.06551360197733425, 0.9344863980226658)),
+                    Row.of(
+                            0.0,
+                            Vectors.dense(2.5532653631402114, -2.5532653631402114),
+                            Vectors.dense(0.9277925785910718, 0.07220742140892823)),
+                    Row.of(
+                            0.0,
+                            Vectors.dense(2.3773197509703996, -2.3773197509703996),
+                            Vectors.dense(0.9150813905583675, 0.0849186094416325)),
+                    Row.of(
+                            1.0,
+                            Vectors.dense(-2.132645378098387, 2.132645378098387),
+                            Vectors.dense(0.10596411850817689, 0.8940358814918231)),
+                    Row.of(
+                            0.0,
+                            Vectors.dense(2.3105035625447106, -2.3105035625447106),
+                            Vectors.dense(0.9097432116019103, 0.09025678839808973)),
+                    Row.of(
+                            1.0,
+                            Vectors.dense(-2.0541952729346695, 2.0541952729346695),
+                            Vectors.dense(0.11362915817869357, 0.8863708418213064)));
+    private StreamTableEnvironment tEnv;
+    private Table inputTable;
+
+    private static void verifyPredictionResult(Table output, List<Row> expected) throws Exception {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) output).getTableEnvironment();
+        //noinspection unchecked
+        List<Row> results = IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
+        final double delta = 1e-3;
+        final Comparator<DenseVector> denseVectorComparator =
+                new TestUtils.DenseVectorComparatorWithDelta(delta);
+        final Comparator<Row> comparator =
+                Comparator.<Row, Double>comparing(d -> d.getFieldAs(0))
+                        .thenComparing(d -> d.getFieldAs(1), denseVectorComparator)
+                        .thenComparing(d -> d.getFieldAs(2), denseVectorComparator);
+        TestUtils.compareResultCollectionsWithComparator(expected, results, comparator);
+    }
+
+    @Before
+    public void before() {
+        Configuration config = new Configuration();
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.getConfig().enableObjectReuse();
+        env.setParallelism(4);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        tEnv = StreamTableEnvironment.create(env);
+
+        inputTable =
+                tEnv.fromDataStream(
+                        env.fromCollection(
+                                inputDataRows,
+                                new RowTypeInfo(
+                                        new TypeInformation[] {
+                                            Types.DOUBLE,
+                                            Types.INT,
+                                            Types.STRING,
+                                            Types.DOUBLE,
+                                            Types.DOUBLE,
+                                            Types.DOUBLE,
+                                            VectorTypeInfo.INSTANCE
+                                        },
+                                        new String[] {
+                                            "f0", "f1", "f2", "label", "weight", "cls_label", "vec"
+                                        })));
+    }
+
+    @Test
+    public void testParam() {
+        GBTClassifier gbtc = new GBTClassifier();
+        Assert.assertEquals("features", gbtc.getFeaturesCol());
+        Assert.assertNull(gbtc.getInputCols());
+        Assert.assertEquals("label", gbtc.getLabelCol());
+        Assert.assertArrayEquals(new String[] {}, gbtc.getCategoricalCols());
+        Assert.assertEquals("prediction", gbtc.getPredictionCol());
+
+        Assert.assertNull(gbtc.getLeafCol());
+        Assert.assertNull(gbtc.getWeightCol());
+        Assert.assertEquals(5, gbtc.getMaxDepth());
+        Assert.assertEquals(32, gbtc.getMaxBins());
+        Assert.assertEquals(1, gbtc.getMinInstancesPerNode());
+        Assert.assertEquals(0., gbtc.getMinWeightFractionPerNode(), 1e-12);
+        Assert.assertEquals(0., gbtc.getMinInfoGain(), 1e-12);
+        Assert.assertEquals(20, gbtc.getMaxIter());
+        Assert.assertEquals(.1, gbtc.getStepSize(), 1e-12);
+        Assert.assertEquals(GBTClassifier.class.getName().hashCode(), gbtc.getSeed());
+        Assert.assertEquals(1., gbtc.getSubsamplingRate(), 1e-12);
+        Assert.assertEquals("auto", gbtc.getFeatureSubsetStrategy());
+        Assert.assertNull(gbtc.getValidationIndicatorCol());
+        Assert.assertEquals(.01, gbtc.getValidationTol(), 1e-12);
+        Assert.assertEquals(0., gbtc.getRegLambda(), 1e-12);
+        Assert.assertEquals(1., gbtc.getRegGamma(), 1e-12);
+
+        Assert.assertEquals("logistic", gbtc.getLossType());
+        Assert.assertEquals("rawPrediction", gbtc.getRawPredictionCol());
+        Assert.assertEquals("probability", gbtc.getProbabilityCol());
+
+        gbtc.setFeaturesCol("vec")
+                .setInputCols("f0", "f1", "f2")
+                .setLabelCol("cls_label")
+                .setCategoricalCols("f0", "f1")
+                .setPredictionCol("pred")
+                .setLeafCol("leaf")
+                .setWeightCol("weight")
+                .setMaxDepth(6)
+                .setMaxBins(64)
+                .setMinInstancesPerNode(2)
+                .setMinWeightFractionPerNode(.1)
+                .setMinInfoGain(.1)
+                .setMaxIter(10)
+                .setStepSize(.2)
+                .setSeed(123)
+                .setSubsamplingRate(.8)
+                .setFeatureSubsetStrategy("0.5")
+                .setValidationIndicatorCol("val")
+                .setValidationTol(.1)
+                .setRegLambda(.1)
+                .setRegGamma(.1)
+                .setRawPredictionCol("raw_pred")
+                .setProbabilityCol("prob");
+
+        Assert.assertEquals("vec", gbtc.getFeaturesCol());
+        Assert.assertArrayEquals(new String[] {"f0", "f1", "f2"}, gbtc.getInputCols());
+        Assert.assertEquals("cls_label", gbtc.getLabelCol());
+        Assert.assertArrayEquals(new String[] {"f0", "f1"}, gbtc.getCategoricalCols());
+        Assert.assertEquals("pred", gbtc.getPredictionCol());
+
+        Assert.assertEquals("leaf", gbtc.getLeafCol());
+        Assert.assertEquals("weight", gbtc.getWeightCol());
+        Assert.assertEquals(6, gbtc.getMaxDepth());
+        Assert.assertEquals(64, gbtc.getMaxBins());
+        Assert.assertEquals(2, gbtc.getMinInstancesPerNode());
+        Assert.assertEquals(.1, gbtc.getMinWeightFractionPerNode(), 1e-12);
+        Assert.assertEquals(.1, gbtc.getMinInfoGain(), 1e-12);
+        Assert.assertEquals(10, gbtc.getMaxIter());
+        Assert.assertEquals(.2, gbtc.getStepSize(), 1e-12);
+        Assert.assertEquals(123, gbtc.getSeed());
+        Assert.assertEquals(.8, gbtc.getSubsamplingRate(), 1e-12);
+        Assert.assertEquals("0.5", gbtc.getFeatureSubsetStrategy());
+        Assert.assertEquals("val", gbtc.getValidationIndicatorCol());
+        Assert.assertEquals(.1, gbtc.getValidationTol(), 1e-12);
+        Assert.assertEquals(.1, gbtc.getRegLambda(), 1e-12);
+        Assert.assertEquals(.1, gbtc.getRegGamma(), 1e-12);
+
+        Assert.assertEquals("raw_pred", gbtc.getRawPredictionCol());
+        Assert.assertEquals("prob", gbtc.getProbabilityCol());
+    }
+
+    @Test
+    public void testOutputSchema() throws Exception {
+        GBTClassifier gbtc =
+                new GBTClassifier().setInputCols("f0", "f1", "f2").setCategoricalCols("f2");
+        GBTClassifierModel model = gbtc.fit(inputTable);
+        Table output = model.transform(inputTable)[0];
+        Assert.assertArrayEquals(
+                ArrayUtils.addAll(
+                        inputTable.getResolvedSchema().getColumnNames().toArray(new String[0]),
+                        gbtc.getPredictionCol(),
+                        gbtc.getRawPredictionCol(),
+                        gbtc.getProbabilityCol()),
+                output.getResolvedSchema().getColumnNames().toArray(new String[0]));
+    }
+
+    @Test
+    public void testFitAndPredict() throws Exception {
+        GBTClassifier gbtc =
+                new GBTClassifier()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("cls_label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTClassifierModel model = gbtc.fit(inputTable);
+        Table output =
+                model.transform(inputTable)[0].select(
+                        $(gbtc.getPredictionCol()),
+                        $(gbtc.getRawPredictionCol()),
+                        $(gbtc.getProbabilityCol()));
+        verifyPredictionResult(output, outputRows);
+    }
+
+    @Test
+    public void testFitAndPredictWithVectorCol() throws Exception {
+        GBTClassifier gbtc =
+                new GBTClassifier()
+                        .setFeaturesCol("vec")
+                        .setLabelCol("cls_label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTClassifierModel model = gbtc.fit(inputTable);
+        Table output =
+                model.transform(inputTable)[0].select(
+                        $(gbtc.getPredictionCol()),
+                        $(gbtc.getRawPredictionCol()),
+                        $(gbtc.getProbabilityCol()));
+        List<Row> outputRowsUsingVectorCol =
+                Arrays.asList(
+                        Row.of(
+                                0.0,
+                                Vectors.dense(1.9834935486026828, -1.9834935486026828),
+                                Vectors.dense(0.8790530839977041, 0.12094691600229594)),
+                        Row.of(
+                                1.0,
+                                Vectors.dense(-1.9962334686995544, 1.9962334686995544),
+                                Vectors.dense(0.11959895119804398, 0.880401048801956)),
+                        Row.of(
+                                0.0,
+                                Vectors.dense(2.2596958412285053, -2.2596958412285053),
+                                Vectors.dense(0.9054836034255209, 0.0945163965744791)),
+                        Row.of(
+                                1.0,
+                                Vectors.dense(-2.23023965816558, 2.23023965816558),
+                                Vectors.dense(0.09706763399626683, 0.9029323660037332)),
+                        Row.of(
+                                1.0,
+                                Vectors.dense(-2.520667396406638, 2.520667396406638),
+                                Vectors.dense(0.0744219596185437, 0.9255780403814563)),
+                        Row.of(
+                                0.0,
+                                Vectors.dense(2.5005544570205114, -2.5005544570205114),
+                                Vectors.dense(0.9241806803368346, 0.07581931966316532)),
+                        Row.of(
+                                0.0,
+                                Vectors.dense(2.155310746068554, -2.155310746068554),
+                                Vectors.dense(0.8961640042377698, 0.10383599576223027)),
+                        Row.of(
+                                1.0,
+                                Vectors.dense(-2.2386996519306424, 2.2386996519306424),
+                                Vectors.dense(0.09632867690962832, 0.9036713230903717)),
+                        Row.of(
+                                0.0,
+                                Vectors.dense(2.0375281995821273, -2.0375281995821273),
+                                Vectors.dense(0.8846813338862343, 0.11531866611376576)),
+                        Row.of(
+                                1.0,
+                                Vectors.dense(-1.9751553623558855, 1.9751553623558855),
+                                Vectors.dense(0.12183622723878906, 0.8781637727612109)));
+        verifyPredictionResult(output, outputRowsUsingVectorCol);
+    }
+
+    @Test
+    public void testFitAndPredictWithNoCategoricalCols() throws Exception {
+        GBTClassifier gbtc =
+                new GBTClassifier()
+                        .setInputCols("f0", "f1")
+                        .setLabelCol("cls_label")
+                        .setRegGamma(0.)
+                        .setMaxBins(5)
+                        .setSeed(123);
+        GBTClassifierModel model = gbtc.fit(inputTable);
+        Table output =
+                model.transform(inputTable)[0].select(
+                        $(gbtc.getPredictionCol()),
+                        $(gbtc.getRawPredictionCol()),
+                        $(gbtc.getProbabilityCol()));
+        List<Row> outputRowsUsingNoCategoricalCols =
+                Arrays.asList(
+                        Row.of(
+                                0.0,
+                                Vectors.dense(2.4386858360079877, -2.4386858360079877),
+                                Vectors.dense(0.9197301210345855, 0.08026987896541447)),
+                        Row.of(
+                                0.0,
+                                Vectors.dense(2.079593609142336, -2.079593609142336),
+                                Vectors.dense(0.8889039070093702, 0.11109609299062985)),
+                        Row.of(
+                                1.0,
+                                Vectors.dense(-2.4477766607449594, 2.4477766607449594),
+                                Vectors.dense(0.07960128978764613, 0.9203987102123539)),
+                        Row.of(
+                                0.0,
+                                Vectors.dense(2.3680506847981113, -2.3680506847981113),
+                                Vectors.dense(0.9143583384561507, 0.0856416615438493)),
+                        Row.of(
+                                1.0,
+                                Vectors.dense(-2.0115161495245792, 2.0115161495245792),
+                                Vectors.dense(0.11799909267017583, 0.8820009073298242)),
+                        Row.of(
+                                0.0,
+                                Vectors.dense(2.3680506847981113, -2.3680506847981113),
+                                Vectors.dense(0.9143583384561507, 0.0856416615438493)),
+                        Row.of(
+                                1.0,
+                                Vectors.dense(-2.1774376078697983, 2.1774376078697983),
+                                Vectors.dense(0.10179497553813543, 0.8982050244618646)),
+                        Row.of(
+                                0.0,
+                                Vectors.dense(2.434832949283468, -2.434832949283468),
+                                Vectors.dense(0.9194452150195366, 0.08055478498046341)),
+                        Row.of(
+                                1.0,
+                                Vectors.dense(-2.441225164856452, 2.441225164856452),
+                                Vectors.dense(0.08008260858505134, 0.9199173914149487)),
+                        Row.of(
+                                1.0,
+                                Vectors.dense(-2.672457199454413, 2.672457199454413),
+                                Vectors.dense(0.06461828968951666, 0.9353817103104833)));
+        verifyPredictionResult(output, outputRowsUsingNoCategoricalCols);
+    }
+
+    @Test
+    public void testEstimatorSaveLoadAndPredict() throws Exception {
+        GBTClassifier gbtc =
+                new GBTClassifier()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("cls_label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTClassifier loadedGbtc =
+                TestUtils.saveAndReload(tEnv, gbtc, tempFolder.newFolder().getAbsolutePath());
+        GBTClassifierModel model = loadedGbtc.fit(inputTable);
+        Assert.assertEquals(
+                Collections.singletonList("modelData"),
+                model.getModelData()[0].getResolvedSchema().getColumnNames());
+        Table output =
+                model.transform(inputTable)[0].select(
+                        $(gbtc.getPredictionCol()),
+                        $(gbtc.getRawPredictionCol()),
+                        $(gbtc.getProbabilityCol()));
+        verifyPredictionResult(output, outputRows);
+    }
+
+    @Test
+    public void testModelSaveLoadAndPredict() throws Exception {
+        GBTClassifier gbtc =
+                new GBTClassifier()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("cls_label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTClassifierModel model = gbtc.fit(inputTable);
+        GBTClassifierModel loadedModel =
+                TestUtils.saveAndReload(tEnv, model, tempFolder.newFolder().getAbsolutePath());
+        Table output =
+                loadedModel.transform(inputTable)[0].select(
+                        $(gbtc.getPredictionCol()),
+                        $(gbtc.getRawPredictionCol()),
+                        $(gbtc.getProbabilityCol()));
+        verifyPredictionResult(output, outputRows);
+    }
+
+    @Test
+    public void testGetModelData() throws Exception {
+        GBTClassifier gbtc =
+                new GBTClassifier()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("cls_label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTClassifierModel model = gbtc.fit(inputTable);
+        Table modelDataTable = model.getModelData()[0];
+        List<String> modelDataColumnNames = modelDataTable.getResolvedSchema().getColumnNames();
+        DataStream<Row> output = tEnv.toDataStream(modelDataTable);
+        Assert.assertArrayEquals(
+                new String[] {"modelData"}, modelDataColumnNames.toArray(new String[0]));
+
+        Row modelDataRow = (Row) IteratorUtils.toList(output.executeAndCollect()).get(0);
+        GBTModelData modelData = modelDataRow.getFieldAs(0);
+        Assert.assertNotNull(modelData);
+
+        Assert.assertEquals(TaskType.CLASSIFICATION, TaskType.valueOf(modelData.type));
+        Assert.assertFalse(modelData.isInputVector);
+        Assert.assertEquals(0., modelData.prior, 1e-12);
+        Assert.assertEquals(gbtc.getStepSize(), modelData.stepSize, 1e-12);
+        Assert.assertEquals(gbtc.getMaxIter(), modelData.roots.size());
+        Assert.assertEquals(gbtc.getCategoricalCols().length, modelData.categoryToIdMaps.size());
+        Assert.assertEquals(
+                gbtc.getInputCols().length - gbtc.getCategoricalCols().length,
+                modelData.featureIdToBinEdges.size());
+        Assert.assertEquals(BitSet.valueOf(new byte[] {4}), modelData.isCategorical);
+    }
+
+    @Test
+    public void testSetModelData() throws Exception {
+        GBTClassifier gbtc =
+                new GBTClassifier()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("cls_label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTClassifierModel modelA = gbtc.fit(inputTable);
+        Table modelDataTable = modelA.getModelData()[0];
+        GBTClassifierModel modelB = new GBTClassifierModel().setModelData(modelDataTable);
+        ReadWriteUtils.updateExistingParams(modelB, modelA.getParamMap());
+        Table output =
+                modelA.transform(inputTable)[0].select(
+                        $(gbtc.getPredictionCol()),
+                        $(gbtc.getRawPredictionCol()),
+                        $(gbtc.getProbabilityCol()));
+        verifyPredictionResult(output, outputRows);
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/common/gbt/DataUtilsTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/common/gbt/DataUtilsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Test {@link DataUtils}. */
+public class DataUtilsTest {
+    @Test
+    public void testFindBin() {
+        double[] binEdges = new double[] {1., 2., 3., 4.};
+        for (int i = 0; i < binEdges.length; i += 1) {
+            Assert.assertEquals(
+                    Math.min(binEdges.length - 2, i), DataUtils.findBin(binEdges, binEdges[i]));
+        }
+        double[] values = new double[] {.5, 1.5, 2.5, 3.5, 4.5};
+        int[] bins = new int[] {0, 0, 1, 2, 2};
+        for (int i = 0; i < values.length; i += 1) {
+            Assert.assertEquals(bins[i], DataUtils.findBin(binEdges, values[i]));
+        }
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/common/gbt/GBTRunnerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/common/gbt/GBTRunnerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.common.gbt.defs.TaskType;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class GBTRunnerTest extends AbstractTestBase {
+    private static final List<Row> inputDataRows =
+            Arrays.asList(
+                    Row.of(1.2, 2, null, 40., 1., 0., Vectors.dense(1.2, 2, Double.NaN)),
+                    Row.of(2.3, 3, "b", 40., 2., 0., Vectors.dense(2.3, 3, 2.)),
+                    Row.of(3.4, 4, "c", 40., 3., 0., Vectors.dense(3.4, 4, 3.)),
+                    Row.of(4.5, 5, "a", 40., 4., 0., Vectors.dense(4.5, 5, 1.)),
+                    Row.of(5.6, 2, "b", 40., 5., 0., Vectors.dense(5.6, 2, 2.)),
+                    Row.of(null, 3, "c", 41., 1., 1., Vectors.dense(Double.NaN, 3, 3.)),
+                    Row.of(12.8, 4, "e", 41., 2., 1., Vectors.dense(12.8, 4, 5.)),
+                    Row.of(13.9, 2, "b", 41., 3., 1., Vectors.dense(13.9, 2, 2.)),
+                    Row.of(14.1, 4, "a", 41., 4., 1., Vectors.dense(14.1, 4, 1.)),
+                    Row.of(15.3, 1, "d", 41., 5., 1., Vectors.dense(15.3, 1, 4.)));
+
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+    private Table inputTable;
+
+    @Before
+    public void before() {
+        Configuration config = new Configuration();
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.getConfig().enableObjectReuse();
+        env.setParallelism(4);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        inputTable =
+                tEnv.fromDataStream(
+                        env.fromCollection(
+                                inputDataRows,
+                                new RowTypeInfo(
+                                        new TypeInformation[] {
+                                            Types.DOUBLE,
+                                            Types.INT,
+                                            Types.STRING,
+                                            Types.DOUBLE,
+                                            Types.DOUBLE,
+                                            Types.DOUBLE,
+                                            VectorTypeInfo.INSTANCE
+                                        },
+                                        new String[] {
+                                            "f0", "f1", "f2", "label", "weight", "cls_label", "vec"
+                                        })));
+    }
+
+    private GbtParams getCommonGbtParams() {
+        GbtParams p = new GbtParams();
+        p.featureCols = new String[] {"f0", "f1", "f2"};
+        p.categoricalCols = new String[] {"f2"};
+        p.isInputVector = false;
+        p.gamma = 0.;
+        p.maxBins = 3;
+        p.seed = 123;
+        p.featureSubsetStrategy = "all";
+        p.maxDepth = 3;
+        p.maxNumLeaves = 1 << (p.maxDepth - 1);
+        p.maxIter = 20;
+        p.stepSize = 0.1;
+        return p;
+    }
+
+    private void verifyModelData(GBTModelData modelData, GbtParams p) {
+        Assert.assertEquals(p.taskType, TaskType.valueOf(modelData.type));
+        Assert.assertEquals(p.stepSize, modelData.stepSize, 1e-12);
+        Assert.assertEquals(p.maxIter, modelData.roots.size());
+    }
+
+    @Test
+    public void testTrainClassifier() throws Exception {
+        GbtParams p = getCommonGbtParams();
+        p.taskType = TaskType.CLASSIFICATION;
+        p.labelCol = "cls_label";
+        p.lossType = "logistic";
+
+        GBTModelData modelData = GBTRunner.train(inputTable, p).executeAndCollect().next();
+        verifyModelData(modelData, p);
+    }
+
+    @Test
+    public void testTrainRegressor() throws Exception {
+        GbtParams p = getCommonGbtParams();
+        p.taskType = TaskType.REGRESSION;
+        p.labelCol = "label";
+        p.lossType = "squared";
+
+        GBTModelData modelData = GBTRunner.train(inputTable, p).executeAndCollect().next();
+        verifyModelData(modelData, p);
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/common/gbt/PreprocessTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/common/gbt/PreprocessTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.gbt;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.ml.common.gbt.defs.FeatureMeta;
+import org.apache.flink.ml.common.gbt.defs.GbtParams;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
+import org.apache.flink.ml.util.TestUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.testutils.junit.SharedReference;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+
+/** Tests {@link Preprocess}. */
+public class PreprocessTest extends AbstractTestBase {
+
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+
+    private static final List<Row> inputDataRows =
+            Arrays.asList(
+                    Row.of(1.2, 2, null, 40., Vectors.dense(1.2, 2, Double.NaN)),
+                    Row.of(2.3, 3, "b", 40., Vectors.dense(2.3, 3, 2.)),
+                    Row.of(3.4, 4, "c", 40., Vectors.dense(3.4, 4, 3.)),
+                    Row.of(4.5, 5, "a", 40., Vectors.dense(4.5, 5, 1.)),
+                    Row.of(5.6, 2, "b", 40., Vectors.dense(5.6, 2, 2.)),
+                    Row.of(null, 3, "c", 41., Vectors.dense(Double.NaN, 3, 3.)),
+                    Row.of(12.8, 4, "e", 41., Vectors.dense(12.8, 4, 5.)),
+                    Row.of(13.9, 2, "b", 41., Vectors.dense(13.9, 2, 2.)),
+                    Row.of(14.1, 4, "a", 41., Vectors.dense(14.1, 4, 1.)),
+                    Row.of(15.3, 1, "d", 41., Vectors.dense(15.3, 1, 4.)));
+
+    private StreamTableEnvironment tEnv;
+    private Table inputTable;
+    private SharedReference<ArrayBlockingQueue<FeatureMeta>> actualMeta;
+
+    //    private static void verifyPredictionResult(Table output, List<Row> expected) throws
+    // Exception {
+    //        StreamTableEnvironment tEnv =
+    //                (StreamTableEnvironment) ((TableImpl) output).getTableEnvironment();
+    //        //noinspection unchecked
+    //        List<Row> results =
+    // IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
+    //        final double delta = 1e-3;
+    //        final Comparator<DenseVector> denseVectorComparator =
+    //                new TestUtils.DenseVectorComparatorWithDelta(delta);
+    //        final Comparator<Row> comparator =
+    //                Comparator.<Row, Double>comparing(d -> d.getFieldAs(0))
+    //                        .thenComparing(d -> d.getFieldAs(1), denseVectorComparator)
+    //                        .thenComparing(d -> d.getFieldAs(2), denseVectorComparator);
+    //        TestUtils.compareResultCollectionsWithComparator(expected, results, comparator);
+    //    }
+
+    @Before
+    public void before() {
+        StreamExecutionEnvironment env = TestUtils.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
+
+        inputTable =
+                tEnv.fromDataStream(
+                        env.fromCollection(
+                                inputDataRows,
+                                new RowTypeInfo(
+                                        new TypeInformation[] {
+                                            Types.DOUBLE,
+                                            Types.INT,
+                                            Types.STRING,
+                                            Types.DOUBLE,
+                                            DenseVectorTypeInfo.INSTANCE
+                                        },
+                                        new String[] {"f0", "f1", "f2", "label", "vec"})));
+
+        actualMeta = sharedObjects.add(new ArrayBlockingQueue<>(8));
+    }
+
+    private static class CollectSink<T> implements SinkFunction<T> {
+        private final SharedReference<ArrayBlockingQueue<T>> q;
+
+        public CollectSink(SharedReference<ArrayBlockingQueue<T>> q) {
+            this.q = q;
+        }
+
+        @Override
+        public void invoke(T value, Context context) {
+            q.get().add(value);
+        }
+    }
+
+    @Test
+    public void testPreprocessCols() throws Exception {
+        GbtParams p = new GbtParams();
+        p.featureCols = new String[] {"f0", "f1", "f2"};
+        p.categoricalCols = new String[] {"f2"};
+        p.labelCol = "label";
+        p.maxBins = 3;
+        Tuple2<Table, DataStream<FeatureMeta>> results = Preprocess.preprocessCols(inputTable, p);
+
+        actualMeta.get().clear();
+        results.f1.addSink(new CollectSink<>(actualMeta));
+        //noinspection unchecked
+        List<Row> preprocessedRows =
+                IteratorUtils.toList(tEnv.toDataStream(results.f0).executeAndCollect());
+
+        // TODO: correct `binEdges` of feature `f0` after FLINK-30734 resolved.
+        List<FeatureMeta> expectedMeta =
+                Arrays.asList(
+                        FeatureMeta.continuous("f0", 3, new double[] {1.2, 4.5, 13.9, Double.NaN}),
+                        FeatureMeta.continuous("f1", 3, new double[] {1.0, 2.0, 4.0, 5.0}),
+                        FeatureMeta.categorical("f2", 5, new String[] {"a", "b", "c", "d", "e"}));
+
+        List<Row> expectedPreprocessedRows =
+                Arrays.asList(
+                        Row.of(40.0, 0, 1, 5.0),
+                        Row.of(40.0, 0, 1, 1.0),
+                        Row.of(40.0, 0, 2, 2.0),
+                        Row.of(40.0, 1, 2, 0.0),
+                        Row.of(40.0, 1, 1, 1.0),
+                        Row.of(41.0, 2, 1, 2.0),
+                        Row.of(41.0, 1, 2, 4.0),
+                        Row.of(41.0, 2, 1, 1.0),
+                        Row.of(41.0, 2, 2, 0.0),
+                        Row.of(41.0, 2, 0, 3.0));
+        Comparator<Row> preprocessedRowComparator =
+                Comparator.<Row, Double>comparing(d -> d.getFieldAs(0))
+                        .thenComparing(d -> d.getFieldAs(1))
+                        .thenComparing(d -> d.getFieldAs(2))
+                        .thenComparing(d -> d.getFieldAs(3));
+
+        TestBaseUtils.compareResultCollections(
+                expectedPreprocessedRows, preprocessedRows, preprocessedRowComparator);
+        TestBaseUtils.compareResultCollections(
+                expectedMeta, new ArrayList<>(actualMeta.get()), Comparator.comparing(d -> d.name));
+    }
+
+    @Test
+    public void testPreprocessVectorCol() throws Exception {
+        GbtParams p = new GbtParams();
+        p.vectorCol = "vec";
+        p.labelCol = "label";
+        p.maxBins = 3;
+        Tuple2<Table, DataStream<FeatureMeta>> results = Preprocess.preprocessVecCol(inputTable, p);
+
+        actualMeta.get().clear();
+        results.f1.addSink(new CollectSink<>(actualMeta));
+        //noinspection unchecked
+        List<Row> preprocessedRows =
+                IteratorUtils.toList(tEnv.toDataStream(results.f0).executeAndCollect());
+
+        // TODO: correct `binEdges` of feature `_vec_f0` and `_vec_f2` after FLINK-30734 resolved.
+        List<FeatureMeta> expectedMeta =
+                Arrays.asList(
+                        FeatureMeta.continuous(
+                                "_vec_f0", 3, new double[] {1.2, 4.5, 13.9, Double.NaN}),
+                        FeatureMeta.continuous("_vec_f1", 3, new double[] {1.0, 2.0, 4.0, 5.0}),
+                        FeatureMeta.continuous(
+                                "_vec_f2", 3, new double[] {1.0, 2.0, 3.0, Double.NaN}));
+        List<Row> expectedPreprocessedRows =
+                Arrays.asList(
+                        Row.of(40.0, Vectors.dense(0, 1, 2.0)),
+                        Row.of(40.0, Vectors.dense(0, 1, 1.0)),
+                        Row.of(40.0, Vectors.dense(0, 2, 2.0)),
+                        Row.of(40.0, Vectors.dense(1, 2, 0.0)),
+                        Row.of(40.0, Vectors.dense(1, 1, 1.0)),
+                        Row.of(41.0, Vectors.dense(2, 1, 2.0)),
+                        Row.of(41.0, Vectors.dense(1, 2, 2.0)),
+                        Row.of(41.0, Vectors.dense(2, 1, 1.0)),
+                        Row.of(41.0, Vectors.dense(2, 2, 0.0)),
+                        Row.of(41.0, Vectors.dense(2, 0, 2.0)));
+
+        Comparator<Row> preprocessedRowComparator =
+                Comparator.<Row, Double>comparing(d -> d.getFieldAs(0))
+                        .thenComparing(d -> d.getFieldAs(1), TestUtils::compare);
+
+        TestBaseUtils.compareResultCollections(
+                expectedPreprocessedRows, preprocessedRows, preprocessedRowComparator);
+        TestBaseUtils.compareResultCollections(
+                expectedMeta, new ArrayList<>(actualMeta.get()), Comparator.comparing(d -> d.name));
+    }
+}

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/regression/GBTRegressorTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/regression/GBTRegressorTest.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.regression;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.ml.common.gbt.GBTModelData;
+import org.apache.flink.ml.common.gbt.defs.TaskType;
+import org.apache.flink.ml.linalg.Vectors;
+import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
+import org.apache.flink.ml.regression.gbtregressor.GBTRegressor;
+import org.apache.flink.ml.regression.gbtregressor.GBTRegressorModel;
+import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.TestUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Tests {@link GBTRegressor} and {@link GBTRegressorModel}. */
+public class GBTRegressorTest extends AbstractTestBase {
+    private static final List<Row> inputDataRows =
+            Arrays.asList(
+                    Row.of(1.2, 2, null, 40., 1., 0., Vectors.dense(1.2, 2, Double.NaN)),
+                    Row.of(2.3, 3, "b", 40., 2., 0., Vectors.dense(2.3, 3, 2.)),
+                    Row.of(3.4, 4, "c", 40., 3., 0., Vectors.dense(3.4, 4, 3.)),
+                    Row.of(4.5, 5, "a", 40., 4., 0., Vectors.dense(4.5, 5, 1.)),
+                    Row.of(5.6, 2, "b", 40., 5., 0., Vectors.dense(5.6, 2, 2.)),
+                    Row.of(null, 3, "c", 41., 1., 1., Vectors.dense(Double.NaN, 3, 3.)),
+                    Row.of(12.8, 4, "e", 41., 2., 1., Vectors.dense(12.8, 4, 5.)),
+                    Row.of(13.9, 2, "b", 41., 3., 1., Vectors.dense(13.9, 2, 2.)),
+                    Row.of(14.1, 4, "a", 41., 4., 1., Vectors.dense(14.1, 4, 1.)),
+                    Row.of(15.3, 1, "d", 41., 5., 1., Vectors.dense(15.3, 1, 4.)));
+
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+    List<Row> outputRows =
+            Arrays.asList(
+                    Row.of(40.06841194119824),
+                    Row.of(40.94100994144195),
+                    Row.of(40.93898887207972),
+                    Row.of(40.14918141164082),
+                    Row.of(40.90620397010659),
+                    Row.of(40.06041865505043),
+                    Row.of(40.1049148535624),
+                    Row.of(40.88096567879293),
+                    Row.of(40.08071914298763),
+                    Row.of(40.86772065751431));
+
+    private StreamTableEnvironment tEnv;
+    private Table inputTable;
+
+    private static void verifyPredictionResult(Table output, List<Row> expected) throws Exception {
+        StreamTableEnvironment tEnv =
+                (StreamTableEnvironment) ((TableImpl) output).getTableEnvironment();
+        //noinspection unchecked
+        List<Row> results = IteratorUtils.toList(tEnv.toDataStream(output).executeAndCollect());
+        final double delta = 1e-9;
+        final Comparator<Row> comparator =
+                Comparator.comparing(
+                        d -> d.getFieldAs(0), new TestUtils.DoubleComparatorWithDelta(delta));
+        TestUtils.compareResultCollectionsWithComparator(expected, results, comparator);
+    }
+
+    @Before
+    public void before() {
+        Configuration config = new Configuration();
+        config.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.getConfig().enableObjectReuse();
+        env.setParallelism(4);
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        tEnv = StreamTableEnvironment.create(env);
+
+        inputTable =
+                tEnv.fromDataStream(
+                        env.fromCollection(
+                                inputDataRows,
+                                new RowTypeInfo(
+                                        new TypeInformation[] {
+                                            Types.DOUBLE,
+                                            Types.INT,
+                                            Types.STRING,
+                                            Types.DOUBLE,
+                                            Types.DOUBLE,
+                                            Types.DOUBLE,
+                                            VectorTypeInfo.INSTANCE
+                                        },
+                                        new String[] {
+                                            "f0", "f1", "f2", "label", "weight", "cls_label", "vec"
+                                        })));
+    }
+
+    @Test
+    public void testParam() {
+        GBTRegressor gbtr = new GBTRegressor();
+        Assert.assertEquals("features", gbtr.getFeaturesCol());
+        Assert.assertNull(gbtr.getInputCols());
+        Assert.assertEquals("label", gbtr.getLabelCol());
+        Assert.assertArrayEquals(new String[] {}, gbtr.getCategoricalCols());
+        Assert.assertEquals("prediction", gbtr.getPredictionCol());
+
+        Assert.assertNull(gbtr.getLeafCol());
+        Assert.assertNull(gbtr.getWeightCol());
+        Assert.assertEquals(5, gbtr.getMaxDepth());
+        Assert.assertEquals(32, gbtr.getMaxBins());
+        Assert.assertEquals(1, gbtr.getMinInstancesPerNode());
+        Assert.assertEquals(0., gbtr.getMinWeightFractionPerNode(), 1e-12);
+        Assert.assertEquals(0., gbtr.getMinInfoGain(), 1e-12);
+        Assert.assertEquals(20, gbtr.getMaxIter());
+        Assert.assertEquals(.1, gbtr.getStepSize(), 1e-12);
+        Assert.assertEquals(GBTRegressor.class.getName().hashCode(), gbtr.getSeed());
+        Assert.assertEquals(1., gbtr.getSubsamplingRate(), 1e-12);
+        Assert.assertEquals("auto", gbtr.getFeatureSubsetStrategy());
+        Assert.assertNull(gbtr.getValidationIndicatorCol());
+        Assert.assertEquals(.01, gbtr.getValidationTol(), 1e-12);
+        Assert.assertEquals(0., gbtr.getRegLambda(), 1e-12);
+        Assert.assertEquals(1., gbtr.getRegGamma(), 1e-12);
+
+        Assert.assertEquals("squared", gbtr.getLossType());
+
+        gbtr.setFeaturesCol("vec")
+                .setInputCols("f0", "f1", "f2")
+                .setLabelCol("label")
+                .setCategoricalCols("f0", "f1")
+                .setPredictionCol("pred")
+                .setLeafCol("leaf")
+                .setWeightCol("weight")
+                .setMaxDepth(6)
+                .setMaxBins(64)
+                .setMinInstancesPerNode(2)
+                .setMinWeightFractionPerNode(.1)
+                .setMinInfoGain(.1)
+                .setMaxIter(10)
+                .setStepSize(.2)
+                .setSeed(123)
+                .setSubsamplingRate(.8)
+                .setFeatureSubsetStrategy("0.5")
+                .setValidationIndicatorCol("val")
+                .setValidationTol(.1)
+                .setRegLambda(.1)
+                .setRegGamma(.1);
+
+        Assert.assertEquals("vec", gbtr.getFeaturesCol());
+        Assert.assertArrayEquals(new String[] {"f0", "f1", "f2"}, gbtr.getInputCols());
+        Assert.assertEquals("label", gbtr.getLabelCol());
+        Assert.assertArrayEquals(new String[] {"f0", "f1"}, gbtr.getCategoricalCols());
+        Assert.assertEquals("pred", gbtr.getPredictionCol());
+
+        Assert.assertEquals("leaf", gbtr.getLeafCol());
+        Assert.assertEquals("weight", gbtr.getWeightCol());
+        Assert.assertEquals(6, gbtr.getMaxDepth());
+        Assert.assertEquals(64, gbtr.getMaxBins());
+        Assert.assertEquals(2, gbtr.getMinInstancesPerNode());
+        Assert.assertEquals(.1, gbtr.getMinWeightFractionPerNode(), 1e-12);
+        Assert.assertEquals(.1, gbtr.getMinInfoGain(), 1e-12);
+        Assert.assertEquals(10, gbtr.getMaxIter());
+        Assert.assertEquals(.2, gbtr.getStepSize(), 1e-12);
+        Assert.assertEquals(123, gbtr.getSeed());
+        Assert.assertEquals(.8, gbtr.getSubsamplingRate(), 1e-12);
+        Assert.assertEquals("0.5", gbtr.getFeatureSubsetStrategy());
+        Assert.assertEquals("val", gbtr.getValidationIndicatorCol());
+        Assert.assertEquals(.1, gbtr.getValidationTol(), 1e-12);
+        Assert.assertEquals(.1, gbtr.getRegLambda(), 1e-12);
+        Assert.assertEquals(.1, gbtr.getRegGamma(), 1e-12);
+    }
+
+    @Test
+    public void testOutputSchema() throws Exception {
+        GBTRegressor gbtr =
+                new GBTRegressor().setInputCols("f0", "f1", "f2").setCategoricalCols("f2");
+        GBTRegressorModel model = gbtr.fit(inputTable);
+        Table output = model.transform(inputTable)[0];
+        Assert.assertArrayEquals(
+                ArrayUtils.addAll(
+                        inputTable.getResolvedSchema().getColumnNames().toArray(new String[0]),
+                        gbtr.getPredictionCol()),
+                output.getResolvedSchema().getColumnNames().toArray(new String[0]));
+    }
+
+    @Test
+    public void testFitAndPredict() throws Exception {
+        GBTRegressor gbtr =
+                new GBTRegressor()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTRegressorModel model = gbtr.fit(inputTable);
+        Table output = model.transform(inputTable)[0].select($(gbtr.getPredictionCol()));
+        verifyPredictionResult(output, outputRows);
+    }
+
+    @Test
+    public void testFitAndPredictWithVectorCol() throws Exception {
+        GBTRegressor gbtr =
+                new GBTRegressor()
+                        .setFeaturesCol("vec")
+                        .setLabelCol("label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTRegressorModel model = gbtr.fit(inputTable);
+        Table output = model.transform(inputTable)[0].select($(gbtr.getPredictionCol()));
+        List<Row> outputRowsUsingVectorCol =
+                Arrays.asList(
+                        Row.of(40.11011764668384),
+                        Row.of(40.8838231947867),
+                        Row.of(40.064839102170275),
+                        Row.of(40.10374937485196),
+                        Row.of(40.909914467915144),
+                        Row.of(40.11472131282394),
+                        Row.of(40.88106076252836),
+                        Row.of(40.089859516616336),
+                        Row.of(40.90833852360301),
+                        Row.of(40.94920075468803));
+        verifyPredictionResult(output, outputRowsUsingVectorCol);
+    }
+
+    @Test
+    public void testFitAndPredictWithNoCategoricalCols() throws Exception {
+        GBTRegressor gbtr =
+                new GBTRegressor()
+                        .setInputCols("f0", "f1")
+                        .setLabelCol("label")
+                        .setRegGamma(0.)
+                        .setMaxBins(5)
+                        .setSeed(123);
+        GBTRegressorModel model = gbtr.fit(inputTable);
+        Table output = model.transform(inputTable)[0].select($(gbtr.getPredictionCol()));
+        List<Row> outputRowsUsingNoCategoricalCols =
+                Arrays.asList(
+                        Row.of(40.07663214615239),
+                        Row.of(40.92462268161843),
+                        Row.of(40.941626445241624),
+                        Row.of(40.06608854749729),
+                        Row.of(40.12272436518743),
+                        Row.of(40.92737873124178),
+                        Row.of(40.08092204935494),
+                        Row.of(40.898529570430696),
+                        Row.of(40.08092204935494),
+                        Row.of(40.88296818645738));
+        verifyPredictionResult(output, outputRowsUsingNoCategoricalCols);
+    }
+
+    @Test
+    public void testEstimatorSaveLoadAndPredict() throws Exception {
+        GBTRegressor gbtr =
+                new GBTRegressor()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTRegressor loadedgbtr =
+                TestUtils.saveAndReload(tEnv, gbtr, tempFolder.newFolder().getAbsolutePath());
+        GBTRegressorModel model = loadedgbtr.fit(inputTable);
+        Assert.assertEquals(
+                Collections.singletonList("modelData"),
+                model.getModelData()[0].getResolvedSchema().getColumnNames());
+        Table output = model.transform(inputTable)[0].select($(gbtr.getPredictionCol()));
+        verifyPredictionResult(output, outputRows);
+    }
+
+    @Test
+    public void testModelSaveLoadAndPredict() throws Exception {
+        GBTRegressor gbtr =
+                new GBTRegressor()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTRegressorModel model = gbtr.fit(inputTable);
+        GBTRegressorModel loadedModel =
+                TestUtils.saveAndReload(tEnv, model, tempFolder.newFolder().getAbsolutePath());
+        Table output = loadedModel.transform(inputTable)[0].select($(gbtr.getPredictionCol()));
+        verifyPredictionResult(output, outputRows);
+    }
+
+    @Test
+    public void testGetModelData() throws Exception {
+        GBTRegressor gbtr =
+                new GBTRegressor()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTRegressorModel model = gbtr.fit(inputTable);
+        Table modelDataTable = model.getModelData()[0];
+        List<String> modelDataColumnNames = modelDataTable.getResolvedSchema().getColumnNames();
+        DataStream<Row> output = tEnv.toDataStream(modelDataTable);
+        Assert.assertArrayEquals(
+                new String[] {"modelData"}, modelDataColumnNames.toArray(new String[0]));
+
+        Row modelDataRow = (Row) IteratorUtils.toList(output.executeAndCollect()).get(0);
+        GBTModelData modelData = modelDataRow.getFieldAs(0);
+        Assert.assertNotNull(modelData);
+
+        Assert.assertEquals(TaskType.REGRESSION, TaskType.valueOf(modelData.type));
+        Assert.assertFalse(modelData.isInputVector);
+        Assert.assertEquals(40.5, modelData.prior, .5);
+        Assert.assertEquals(gbtr.getStepSize(), modelData.stepSize, 1e-12);
+        Assert.assertEquals(gbtr.getMaxIter(), modelData.roots.size());
+        Assert.assertEquals(gbtr.getCategoricalCols().length, modelData.categoryToIdMaps.size());
+        Assert.assertEquals(
+                gbtr.getInputCols().length - gbtr.getCategoricalCols().length,
+                modelData.featureIdToBinEdges.size());
+        Assert.assertEquals(BitSet.valueOf(new byte[] {4}), modelData.isCategorical);
+    }
+
+    @Test
+    public void testSetModelData() throws Exception {
+        GBTRegressor gbtr =
+                new GBTRegressor()
+                        .setInputCols("f0", "f1", "f2")
+                        .setCategoricalCols("f2")
+                        .setLabelCol("label")
+                        .setRegGamma(0.)
+                        .setMaxBins(3)
+                        .setSeed(123);
+        GBTRegressorModel modelA = gbtr.fit(inputTable);
+        Table modelDataTable = modelA.getModelData()[0];
+        GBTRegressorModel modelB = new GBTRegressorModel().setModelData(modelDataTable);
+        ReadWriteUtils.updateExistingParams(modelB, modelA.getParamMap());
+        Table output = modelA.transform(inputTable)[0].select($(gbtr.getPredictionCol()));
+        verifyPredictionResult(output, outputRows);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add Transformer and Estimator for GBTClassifier and GBTRegressor. They are expected to support most features provided by SparkML, except for some minor ones.

## Brief change log

 - Add implementation of gradient-boosting trees.
 - Add Transformer and Estimator for GBTClassifier and GBTRegressor.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
