### PR TITLE
[FLINK-31026] Fix KBinsDiscretizer when the input values of one column are same

### DIFF
--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/kbinsdiscretizer/KBinsDiscretizer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/kbinsdiscretizer/KBinsDiscretizer.java
@@ -61,8 +61,8 @@ import java.util.Set;
  *
  * <ul>
  *   <li>When the input values of one column are all the same, then they should be mapped to the
- *       same bin (i.e., the zero-th bin). Thus the corresponding bin edges are `{Double.MIN_VALUE,
- *       Double.MAX_VALUE}`.
+ *       same bin (i.e., the zero-th bin). Thus the corresponding bin edges are
+ *       `{Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY}`.
  *   <li>When the number of distinct values of one column is less than the specified number of bins
  *       and the {@link KBinsDiscretizerParams#STRATEGY} is set as {@link
  *       KBinsDiscretizerParams#KMEANS}, we switch to {@link KBinsDiscretizerParams#UNIFORM}.
@@ -188,7 +188,8 @@ public class KBinsDiscretizer
             double max = maxVector.get(columnId);
             if (min == max) {
                 LOG.warn("Feature " + columnId + " is constant and the output will all be zero.");
-                binEdges[columnId] = new double[] {Double.MIN_VALUE, Double.MAX_VALUE};
+                binEdges[columnId] =
+                        new double[] {Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY};
             } else {
                 double width = (max - min) / numBins;
                 binEdges[columnId] = new double[numBins + 1];
@@ -216,7 +217,8 @@ public class KBinsDiscretizer
 
             if (features[0] == features[numData - 1]) {
                 LOG.warn("Feature " + columnId + " is constant and the output will all be zero.");
-                binEdges[columnId] = new double[] {Double.MIN_VALUE, Double.MAX_VALUE};
+                binEdges[columnId] =
+                        new double[] {Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY};
             } else {
                 double width = 1.0 * features.length / numBins;
                 double[] tempBinEdges = new double[numBins + 1];
@@ -256,7 +258,8 @@ public class KBinsDiscretizer
 
             if (features[0] == features[numData - 1]) {
                 LOG.warn("Feature " + columnId + " is constant and the output will all be zero.");
-                binEdges[columnId] = new double[] {Double.MIN_VALUE, Double.MAX_VALUE};
+                binEdges[columnId] =
+                        new double[] {Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY};
             } else {
                 // Checks whether there are more than {numBins} distinct feature values in each
                 // column.

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/KBinsDiscretizerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/KBinsDiscretizerTest.java
@@ -83,7 +83,7 @@ public class KBinsDiscretizerTest extends AbstractTestBase {
     private static final double[][] UNIFORM_MODEL_DATA =
             new double[][] {
                 new double[] {1, 5, 9, 13},
-                new double[] {Double.MIN_VALUE, Double.MAX_VALUE},
+                new double[] {Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY},
                 new double[] {0, 1, 2, 3}
             };
 

--- a/flink-ml-python/pyflink/ml/feature/kbinsdiscretizer.py
+++ b/flink-ml-python/pyflink/ml/feature/kbinsdiscretizer.py
@@ -17,10 +17,10 @@
 ################################################################################
 import typing
 
+from pyflink.ml.common.param import HasInputCol, HasOutputCol
+from pyflink.ml.feature.common import JavaFeatureModel, JavaFeatureEstimator
 from pyflink.ml.param import IntParam, StringParam, ParamValidators
 from pyflink.ml.wrapper import JavaWithParams
-from pyflink.ml.feature.common import JavaFeatureModel, JavaFeatureEstimator
-from pyflink.ml.common.param import HasInputCol, HasOutputCol
 
 
 class _KBinsDiscretizerModelParams(
@@ -143,7 +143,7 @@ class KBinsDiscretizer(JavaFeatureEstimator, _KBinsDiscretizerParams):
     <ul>
         <li>When the input values of one column are all the same, then they should be mapped
         to the same bin (i.e., the zero-th bin). Thus the corresponding bin edges are
-        {Double.MIN_VALUE, Double.MAX_VALUE}.
+        {Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY}.
         <li>When the number of distinct values of one column is less than the specified
         number of bins and the {@link KBinsDiscretizerParams#STRATEGY} is set as {@link
         KBinsDiscretizerParams#KMEANS}, we switch to {@link KBinsDiscretizerParams#UNIFORM}.

--- a/flink-ml-python/pyflink/ml/feature/tests/test_kbinsdiscretizer.py
+++ b/flink-ml-python/pyflink/ml/feature/tests/test_kbinsdiscretizer.py
@@ -18,6 +18,7 @@
 
 import os
 
+import numpy as np
 from pyflink.common import Types
 
 from pyflink.ml.linalg import Vectors, DenseVectorTypeInfo
@@ -171,7 +172,7 @@ class KBinsDiscretizerTest(PyFlinkMLTestCase):
         bin_edges = model_rows[0][expected_field_names.index('binEdges')]
         self.assertEqual(3, len(bin_edges))
         self.assertListEqual([1, 5, 9, 13], bin_edges[0])
-        self.assertListEqual([4.9e-324, 1.7976931348623157e+308], bin_edges[1])
+        self.assertListEqual([-np.inf, np.inf], bin_edges[1])
         self.assertListEqual([0, 1, 2, 3], bin_edges[2])
 
     def test_set_model_data(self):


### PR DESCRIPTION
## What is the purpose of the change

KBinsDiscretizer produces `{Double.MIN_VALUE, Double.MAX_VALUE}` for columns whose input values are same which is not correct, as it doesn't cover negative values and 0. A more reasonable value should be `{Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY}`.

## Brief change log

  - Change bin edges for columns whose input values are same to `{Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY}`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
