### PR TITLE
[FLINK-31125] Flink ML benchmark framework should minimize the source operator overhead

### DIFF
--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DenseVectorArrayGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DenseVectorArrayGenerator.java
@@ -42,7 +42,7 @@ public class DenseVectorArrayGenerator extends InputTableGenerator<DenseVectorAr
         return new RowGenerator[] {
             new RowGenerator(getNumValues(), getSeed()) {
                 @Override
-                protected Row nextRow() {
+                protected Row getRow() {
                     DenseVector[] result = new DenseVector[arraySize];
                     for (int i = 0; i < arraySize; i++) {
                         result[i] = new DenseVector(vectorDim);

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DenseVectorGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DenseVectorGenerator.java
@@ -41,7 +41,7 @@ public class DenseVectorGenerator extends InputTableGenerator<DenseVectorGenerat
             new RowGenerator(getNumValues(), getSeed()) {
 
                 @Override
-                protected Row nextRow() {
+                protected Row getRow() {
                     double[] values = new double[vectorDim];
                     for (int i = 0; i < values.length; i++) {
                         values[i] = random.nextDouble();

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DoubleGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/DoubleGenerator.java
@@ -59,7 +59,7 @@ public class DoubleGenerator extends InputTableGenerator<DoubleGenerator> {
         return new RowGenerator[] {
             new RowGenerator(getNumValues(), getSeed()) {
                 @Override
-                public Row nextRow() {
+                public Row getRow() {
                     Row r = new Row(numOutputCols);
                     for (int i = 0; i < numOutputCols; i++) {
                         if (arity > 0) {

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/LabeledPointWithWeightGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/LabeledPointWithWeightGenerator.java
@@ -96,7 +96,7 @@ public class LabeledPointWithWeightGenerator
         return new RowGenerator[] {
             new RowGenerator(getNumValues(), getSeed()) {
                 @Override
-                protected Row nextRow() {
+                protected Row getRow() {
                     double[] features = new double[vectorDim];
                     for (int i = 0; i < vectorDim; i++) {
                         features[i] = getValue(featureArity);

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/RandomStringArrayGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/RandomStringArrayGenerator.java
@@ -44,7 +44,7 @@ public class RandomStringArrayGenerator extends InputTableGenerator<RandomString
         return new RowGenerator[] {
             new RowGenerator(getNumValues(), getSeed()) {
                 @Override
-                public Row nextRow() {
+                public Row getRow() {
                     Row r = new Row(numOutputCols);
 
                     for (int i = 0; i < numOutputCols; i++) {

--- a/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/RandomStringGenerator.java
+++ b/flink-ml-benchmark/src/main/java/org/apache/flink/ml/benchmark/datagenerator/common/RandomStringGenerator.java
@@ -41,7 +41,7 @@ public class RandomStringGenerator extends InputTableGenerator<RandomStringGener
         return new RowGenerator[] {
             new RowGenerator(getNumValues(), getSeed()) {
                 @Override
-                public Row nextRow() {
+                public Row getRow() {
                     Row r = new Row(numOutputCols);
                     for (int i = 0; i < numOutputCols; i++) {
                         r.setField(i, Integer.toString(random.nextInt(numDistinctValues)));

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/TableUtils.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/TableUtils.java
@@ -31,7 +31,9 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.types.Row;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /** Utility class for operations related to Table API. */
@@ -83,6 +85,21 @@ public class TableUtils {
             }
         }
         return null;
+    }
+
+    public static int[] getColumnIndexes(ResolvedSchema schema, String[] columnNames) {
+        Map<String, Integer> nameToIndex = new HashMap<>();
+        int[] result = new int[columnNames.length];
+
+        for (int i = 0; i < schema.getColumnCount(); i++) {
+            Column column = schema.getColumn(i).get();
+            nameToIndex.put(column.getName(), i);
+        }
+
+        for (int i = 0; i < columnNames.length; i++) {
+            result[i] = nameToIndex.get(columnNames[i]);
+        }
+        return result;
     }
 
     public static StreamExecutionEnvironment getExecutionEnvironment(StreamTableEnvironment tEnv) {


### PR DESCRIPTION
## What is the purpose of the change

Minimize the source operator overhead in Flink ML benchmark and optimize the bucketizer performance.

Here is the total execution time of the Bucketizer benchmark for 3 different setups. The execution time is obtained by taking the average execution time across 5 runs for each setup.

- Execution time is 33.26 sec prior to this PR.
- Execution time is 31.14 sec after optimizing the benchmark framework.
- Execution time is 30.88 sec after optimizing both the benchmark framework and the Bucketizer.

Thus the benchmark framework optimization reduces the total time by 6.4%. The Bucketizer reduces the total time by another 0.83%.

## Brief change log

- Updated RowGenerator to pre-generate at least 1/000 of the expected number of rows  and re-use those rows as the source function output.
- Renamed RowGenerator#nextRow to RowGenerator#getRow. This is because there is no order of rows emitted by `nextRow`. 
- Updated Bucketizer#FindBucketFunction to fetch values from input rows using column index.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable