### PR TITLE
[FLINK-31127] Add public API classes for FLIP-289

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/api/Transformer.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/api/Transformer.java
@@ -19,12 +19,19 @@
 package org.apache.flink.ml.api;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.ml.servable.api.TransformerServable;
 
 /**
  * A Transformer is an AlgoOperator with the semantic difference that it encodes the Transformation
  * logic, such that a record in the output typically corresponds to one record in the input. In
  * contrast, an AlgoOperator is a better fit to express aggregation logic where a record in the
  * output could be computed from an arbitrary number of records in the input.
+ *
+ * <p>NOTE: If a Transformer has a corresponding {@link TransformerServable}, it should implement a
+ * static method with the signature {@code static T loadServable(String path)}, where {@code T}
+ * refers to the concrete subclass of {@link TransformerServable}. This static method should
+ * instantiate a new {@link TransformerServable} instance based on the data read from the given
+ * path.
  *
  * @param <T> The class type of the Transformer implementation itself.
  */

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/linalg/DenseMatrix.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/linalg/DenseMatrix.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.ml.linalg;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInfo;
 import org.apache.flink.ml.linalg.typeinfo.DenseMatrixTypeInfoFactory;
 import org.apache.flink.util.Preconditions;
@@ -27,6 +28,7 @@ import org.apache.flink.util.Preconditions;
  * listed in sequence.
  */
 @TypeInfo(DenseMatrixTypeInfoFactory.class)
+@PublicEvolving
 public class DenseMatrix implements Matrix {
 
     /** Row dimension. */

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/linalg/DenseVector.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/linalg/DenseVector.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.ml.linalg;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInfo;
 import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfoFactory;
 
@@ -25,6 +26,7 @@ import java.util.Arrays;
 
 /** A dense vector of double values. */
 @TypeInfo(DenseVectorTypeInfoFactory.class)
+@PublicEvolving
 public class DenseVector implements Vector {
     public final double[] values;
 

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/linalg/SparseVector.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/linalg/SparseVector.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.ml.linalg;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInfo;
 import org.apache.flink.ml.linalg.typeinfo.SparseVectorTypeInfoFactory;
 import org.apache.flink.util.Preconditions;
@@ -27,6 +28,7 @@ import java.util.Objects;
 
 /** A sparse vector of double values. */
 @TypeInfo(SparseVectorTypeInfoFactory.class)
+@PublicEvolving
 public class SparseVector implements Vector {
     public final int n;
     public int[] indices;

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/linalg/Vector.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/linalg/Vector.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.ml.linalg;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInfo;
 import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfoFactory;
 
@@ -25,6 +26,7 @@ import java.io.Serializable;
 
 /** A vector of double values. */
 @TypeInfo(VectorTypeInfoFactory.class)
+@PublicEvolving
 public interface Vector extends Serializable {
 
     /** Gets the size of the vector. */

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/linalg/Vectors.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/linalg/Vectors.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.ml.linalg;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 /** Utility methods for instantiating Vector. */
+@PublicEvolving
 public class Vectors {
 
     /** Creates a dense vector from its values. */

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/api/DataFrame.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/api/DataFrame.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.servable.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.ml.servable.types.DataType;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A DataFrame consists of several rows, each of which has the same column names and data types.
+ *
+ * <p>Values in the same column must have the same data type: integer, float, string etc.
+ */
+@PublicEvolving
+public class DataFrame {
+
+    private final List<String> columnNames;
+    private final List<DataType> dataTypes;
+    private final List<Row> rows;
+
+    /**
+     * The given columnNames and dataTypes should be mutable in order for TransformerServable
+     * classes to update DataFrame with the serving results.
+     */
+    public DataFrame(List<String> columnNames, List<DataType> dataTypes, List<Row> rows) {
+        int numColumns = columnNames.size();
+        if (dataTypes.size() != numColumns) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "The number of data types %d is different from the number of column names %d.",
+                            dataTypes.size(), numColumns));
+        }
+        for (Row row : rows) {
+            if (row.size() != numColumns) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "The row size %d is different from the number of column names %d.",
+                                row.size(), numColumns));
+            }
+        }
+
+        this.columnNames = columnNames;
+        this.dataTypes = dataTypes;
+        this.rows = rows;
+    }
+
+    /** Returns a list of the names of all the columns in this DataFrame. */
+    public List<String> getColumnNames() {
+        return columnNames;
+    }
+
+    /**
+     * Returns the index of the column with the given name.
+     *
+     * @throws IllegalArgumentException if the column is not present in this table
+     */
+    public int getIndex(String name) {
+        int index = columnNames.indexOf(name);
+        if (index == -1) {
+            throw new IllegalArgumentException(
+                    String.format("Failed to find the column with the name %s.", name));
+        }
+        return index;
+    }
+
+    /**
+     * Returns the data type of the column with the given name.
+     *
+     * @throws IllegalArgumentException if the column is not present in this table
+     */
+    public DataType getDataType(String name) {
+        int index = getIndex(name);
+        return dataTypes.get(index);
+    }
+
+    /**
+     * Adds to this DataFrame a column with the given name, data type, and values.
+     *
+     * @throws IllegalArgumentException if the number of values is different from the number of
+     *     rows.
+     */
+    public DataFrame addColumn(String columnName, DataType dataType, List<Object> values) {
+        if (values.size() != rows.size()) {
+            throw new RuntimeException(
+                    String.format(
+                            "The number of values %d is different from the number of rows %d.",
+                            values.size(), rows.size()));
+        }
+        columnNames.add(columnName);
+        dataTypes.add(dataType);
+
+        Iterator<Object> iter = values.iterator();
+        for (Row row : rows) {
+            Object value = iter.next();
+            row.add(value);
+        }
+        return this;
+    }
+
+    /** Returns all rows of this table. */
+    public List<Row> collect() {
+        return rows;
+    }
+}

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/api/ModelServable.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/api/ModelServable.java
@@ -16,25 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.linalg;
+package org.apache.flink.ml.servable.api;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.io.Serializable;
+import java.io.IOException;
+import java.io.InputStream;
 
-/** A matrix of double values. */
+/**
+ * A ModelServable is a TransformerServable with the extra API to set model data.
+ *
+ * @param <T> The class type of the ModelServable implementation itself.
+ */
 @PublicEvolving
-public interface Matrix extends Serializable {
+public interface ModelServable<T extends ModelServable<T>> extends TransformerServable<T> {
 
-    /** Gets number of rows. */
-    int numRows();
-
-    /** Gets number of columns. */
-    int numCols();
-
-    /** Gets value of the (i,j) element. */
-    double get(int i, int j);
-
-    /** Converts the instance to a dense matrix. */
-    DenseMatrix toDense();
+    /** Sets model data using the serialized model data from the given input streams. */
+    default T setModelData(InputStream... modelDataInputs) throws IOException {
+        throw new UnsupportedOperationException("This operation is not supported.");
+    }
 }

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/api/Row.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/api/Row.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.servable.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.List;
+
+/** Represents an ordered list of values. */
+@PublicEvolving
+public class Row {
+    private final List<Object> values;
+
+    /**
+     * The given values should be mutable in order for TransformerServable classes to update
+     * DataFrame with the serving results.
+     */
+    public Row(List<Object> values) {
+        this.values = values;
+    }
+
+    /** Returns the value at the given index. */
+    public Object get(int index) {
+        return values.get(index);
+    }
+
+    /** Returns the value at the given index as the given type. */
+    @SuppressWarnings("unchecked")
+    public <T> T getAs(int index) {
+        return (T) values.get(index);
+    }
+
+    /** Adds the value to the end of this row and returns this row. */
+    public Row add(Object value) {
+        values.add(value);
+        return this;
+    }
+
+    /** Returns the number of values in this row. */
+    public int size() {
+        return values.size();
+    }
+}

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/api/TransformerServable.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/api/TransformerServable.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.servable.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.ml.param.WithParams;
+
+/**
+ * A TransformerServable takes a DataFrame as input and produces a DataFrame as the result. It can
+ * be used to encode online inference computation logic.
+ *
+ * <p>NOTE: Every TransformerServable subclass should have a no-arg constructor.
+ *
+ * <p>NOTE: Every TransformerServable subclass should implement a static method with signature
+ * {@code static T load(String path) throws IOException;}, where {@code T} refers to the concrete
+ * subclass. This static method should instantiate a new TransformerServable instance based on the
+ * data read from the given path.
+ *
+ * @param <T> The class type of the TransformerServable implementation itself.
+ */
+@PublicEvolving
+public interface TransformerServable<T extends TransformerServable<T>> extends WithParams<T> {
+    /**
+     * Applies the TransformerServable on the given input DataFrame and returns the result
+     * DataFrame.
+     *
+     * @param input the input data
+     * @return the result data
+     */
+    DataFrame transform(DataFrame input);
+}

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/types/BasicType.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/types/BasicType.java
@@ -16,25 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.linalg;
+package org.apache.flink.ml.servable.types;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.io.Serializable;
-
-/** A matrix of double values. */
+/** This enum class lists primitive types such as boolean, int, long, etc. */
 @PublicEvolving
-public interface Matrix extends Serializable {
-
-    /** Gets number of rows. */
-    int numRows();
-
-    /** Gets number of columns. */
-    int numCols();
-
-    /** Gets value of the (i,j) element. */
-    double get(int i, int j);
-
-    /** Converts the instance to a dense matrix. */
-    DenseMatrix toDense();
+public enum BasicType {
+    BOOLEAN,
+    BYTE,
+    SHORT,
+    INT,
+    LONG,
+    FLOAT,
+    DOUBLE,
+    STRING,
+    BYTE_STRING;
 }

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/types/DataType.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/types/DataType.java
@@ -16,25 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.linalg;
+package org.apache.flink.ml.servable.types;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.io.Serializable;
-
-/** A matrix of double values. */
+/** This class describes the data type of a value. */
 @PublicEvolving
-public interface Matrix extends Serializable {
-
-    /** Gets number of rows. */
-    int numRows();
-
-    /** Gets number of columns. */
-    int numCols();
-
-    /** Gets value of the (i,j) element. */
-    double get(int i, int j);
-
-    /** Converts the instance to a dense matrix. */
-    DenseMatrix toDense();
-}
+public abstract class DataType {}

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/types/MatrixType.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/types/MatrixType.java
@@ -16,25 +16,21 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.linalg;
+package org.apache.flink.ml.servable.types;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.io.Serializable;
-
-/** A matrix of double values. */
+/** A DataType representing a Matrix. */
 @PublicEvolving
-public interface Matrix extends Serializable {
+public final class MatrixType extends DataType {
 
-    /** Gets number of rows. */
-    int numRows();
+    private final BasicType elementType;
 
-    /** Gets number of columns. */
-    int numCols();
+    public MatrixType(BasicType elementType) {
+        this.elementType = elementType;
+    }
 
-    /** Gets value of the (i,j) element. */
-    double get(int i, int j);
-
-    /** Converts the instance to a dense matrix. */
-    DenseMatrix toDense();
+    public BasicType getElementType() {
+        return elementType;
+    }
 }

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/types/ScalarType.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/types/ScalarType.java
@@ -16,25 +16,21 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.linalg;
+package org.apache.flink.ml.servable.types;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.io.Serializable;
-
-/** A matrix of double values. */
+/** A DataType representing a single element of the given BasicType. */
 @PublicEvolving
-public interface Matrix extends Serializable {
+public final class ScalarType extends DataType {
 
-    /** Gets number of rows. */
-    int numRows();
+    private final BasicType elementType;
 
-    /** Gets number of columns. */
-    int numCols();
+    public ScalarType(BasicType elementType) {
+        this.elementType = elementType;
+    }
 
-    /** Gets value of the (i,j) element. */
-    double get(int i, int j);
-
-    /** Converts the instance to a dense matrix. */
-    DenseMatrix toDense();
+    public BasicType getElementType() {
+        return elementType;
+    }
 }

--- a/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/types/VectorType.java
+++ b/flink-ml-servable-core/src/main/java/org/apache/flink/ml/servable/types/VectorType.java
@@ -16,25 +16,21 @@
  * limitations under the License.
  */
 
-package org.apache.flink.ml.linalg;
+package org.apache.flink.ml.servable.types;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.io.Serializable;
-
-/** A matrix of double values. */
+/** A DataType representing a Vector. */
 @PublicEvolving
-public interface Matrix extends Serializable {
+public final class VectorType extends DataType {
 
-    /** Gets number of rows. */
-    int numRows();
+    private final BasicType elementType;
 
-    /** Gets number of columns. */
-    int numCols();
+    public VectorType(BasicType elementType) {
+        this.elementType = elementType;
+    }
 
-    /** Gets value of the (i,j) element. */
-    double get(int i, int j);
-
-    /** Converts the instance to a dense matrix. */
-    DenseMatrix toDense();
+    public BasicType getElementType() {
+        return elementType;
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

Add public API classes for FLIP-289 with the exception specified below.

## Brief change log

Added most public API classes specified in FLIP-289.

The following class and methods are not added:
- GraphModel#supportServable
- PipelineModel#supportServable
- PipelineModelServable

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs