### PR TITLE
[FLINK-31191] Fix null pointer exception in VectorIndexer

### DIFF
--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorindexer/VectorIndexer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorindexer/VectorIndexer.java
@@ -224,8 +224,10 @@ public class VectorIndexer
         @Override
         public void snapshotState(StateSnapshotContext context) throws Exception {
             super.snapshotState(context);
-            doublesByColumnState.update(
-                    Collections.singletonList(convertToListArray(doublesByColumn)));
+            if (doublesByColumn != null) {
+                doublesByColumnState.update(
+                        Collections.singletonList(convertToListArray(doublesByColumn)));
+            }
         }
 
         private List<Double>[] convertToListArray(HashSet<Double>[] array) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink ML - we are happy that you want to help us improve Flink ML. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to one [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] Title of the pull request`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

- Fix NPE in VectorIndexer.

## Brief change log
- Add check for `doublesByColumn` when doing snapshot.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
