### PR TITLE
[FLINK-31189] Add HasMaxIndexNum param to StringIndexer

### DIFF
--- a/docs/content/docs/operators/feature/stringindexer.md
+++ b/docs/content/docs/operators/feature/stringindexer.md
@@ -62,7 +62,7 @@ Below are the parameters required by `StringIndexerModel`.
 | Key             | Default       | Type    | Required | Description                                                                                                                         |
 |-----------------|---------------|---------|----------|-------------------------------------------------------------------------------------------------------------------------------------|
 | stringOrderType | `"arbitrary"` | String  | no       | How to order strings of each column. Supported values: 'arbitrary', 'frequencyDesc', 'frequencyAsc', 'alphabetDesc', 'alphabetAsc'. |
-| MaxIndexNum     | `2147483647`  | Integer | no       | The max number of indices for each column. It only works when stringOrderType is set as frequencyDesc.                              |
+| MaxIndexNum     | `2147483647`  | Integer | no       | The max number of indices for each column. It only works when 'stringOrderType' is set as 'frequencyDesc'.                          |
 
 ### Examples
 

--- a/docs/content/docs/operators/feature/stringindexer.md
+++ b/docs/content/docs/operators/feature/stringindexer.md
@@ -38,7 +38,7 @@ StringIndexerModel.
 ### Input Columns
 
 | Param name | Type          | Default | Description                            |
-| :--------- | :------------ | :------ |:---------------------------------------|
+|:-----------|:--------------|:--------|:---------------------------------------|
 | inputCols  | Number/String | `null`  | String/Numerical values to be indexed. |
 
 ### Output Columns
@@ -59,9 +59,10 @@ Below are the parameters required by `StringIndexerModel`.
 
 `StringIndexer` needs parameters above and also below.
 
-| Key             | Default       | Type   | Required | Description                                                                                                                         |
-|-----------------|---------------|--------|----------|-------------------------------------------------------------------------------------------------------------------------------------|
-| stringOrderType | `"arbitrary"` | String | no       | How to order strings of each column. Supported values: 'arbitrary', 'frequencyDesc', 'frequencyAsc', 'alphabetDesc', 'alphabetAsc'. |
+| Key             | Default       | Type    | Required | Description                                                                                                                         |
+|-----------------|---------------|---------|----------|-------------------------------------------------------------------------------------------------------------------------------------|
+| stringOrderType | `"arbitrary"` | String  | no       | How to order strings of each column. Supported values: 'arbitrary', 'frequencyDesc', 'frequencyAsc', 'alphabetDesc', 'alphabetAsc'. |
+| MaxIndexNum     | `2147483647`  | Integer | no       | The max number of indices for each column. It only works when stringOrderType is set as frequencyDesc.                              |
 
 ### Examples
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexer.java
@@ -66,7 +66,7 @@ import java.util.Map.Entry;
  *
  * <p>User can also control the max number of output indices by setting {@link
  * StringIndexerParams#MAX_INDEX_NUM}. This parameter only works if {@link
- * StringIndexerParams#STRING_ORDER_TYPE} is set as frequencyDesc.
+ * StringIndexerParams#STRING_ORDER_TYPE} is set as 'frequencyDesc'.
  *
  * <p>The `keep` option of {@link HasHandleInvalid} means that we transform the invalid input into a
  * special index, whose value is the number of distinct values in this column.

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexer.java
@@ -64,8 +64,12 @@ import java.util.Map.Entry;
  * is arbitrarily ordered. Users can control this by setting {@link
  * StringIndexerParams#STRING_ORDER_TYPE}.
  *
- * <p>The `keep` option of {@link HasHandleInvalid} means that we put the invalid entries in a
- * special bucket, whose index is the number of distinct values in this column.
+ * <p>User can also control the max number of output indices by setting {@link
+ * StringIndexerParams#MAX_INDEX_NUM}. This parameter only works if {@link
+ * StringIndexerParams#STRING_ORDER_TYPE} is set as frequencyDesc.
+ *
+ * <p>The `keep` option of {@link HasHandleInvalid} means that we transform the invalid input into a
+ * special index, whose value is the number of distinct values in this column.
  */
 public class StringIndexer
         implements Estimator<StringIndexer, StringIndexerModel>,
@@ -96,6 +100,17 @@ public class StringIndexer
         String[] inputCols = getInputCols();
         String[] outputCols = getOutputCols();
         Preconditions.checkArgument(inputCols.length == outputCols.length);
+        if (getMaxIndexNum() < Integer.MAX_VALUE) {
+            Preconditions.checkArgument(
+                    getStringOrderType().equals(StringIndexerParams.FREQUENCY_DESC_ORDER),
+                    "Setting "
+                            + MAX_INDEX_NUM.name
+                            + " smaller than INT.MAX only works when "
+                            + STRING_ORDER_TYPE.name
+                            + " is set as "
+                            + StringIndexerParams.FREQUENCY_DESC_ORDER
+                            + ".");
+        }
         StreamTableEnvironment tEnv =
                 (StreamTableEnvironment) ((TableImpl) inputs[0]).getTableEnvironment();
 
@@ -127,7 +142,7 @@ public class StringIndexer
                         Types.OBJECT_ARRAY(Types.MAP(Types.STRING, Types.LONG)));
 
         DataStream<StringIndexerModelData> modelData =
-                countedString.map(new ModelGenerator(getStringOrderType()));
+                countedString.map(new ModelGenerator(getStringOrderType(), getMaxIndexNum()));
         modelData.getTransformation().setParallelism(1);
 
         StringIndexerModel model =
@@ -205,14 +220,19 @@ public class StringIndexer
 
     /**
      * Merges all the extracted strings and generates the {@link StringIndexerModelData} according
-     * to the specified string order type.
+     * to the specified string order type and maxIndexNum.
+     *
+     * <p>Note that the maxIndexNum works only when the strings are ordered by {@link
+     * StringIndexerParams#ALPHABET_DESC_ORDER}.
      */
     private static class ModelGenerator
             implements MapFunction<Map<String, Long>[], StringIndexerModelData> {
         private final String stringOrderType;
+        private final int maxIndexNum;
 
-        public ModelGenerator(String stringOrderType) {
+        public ModelGenerator(String stringOrderType, int maxIndexNum) {
             this.stringOrderType = stringOrderType;
+            this.maxIndexNum = maxIndexNum;
         }
 
         @Override
@@ -220,6 +240,7 @@ public class StringIndexer
             int numCols = value.length;
             String[][] stringArrays = new String[numCols][];
             ArrayList<Tuple2<String, Long>> stringsAndCnts = new ArrayList<>();
+
             for (int i = 0; i < numCols; i++) {
                 stringsAndCnts.clear();
                 stringsAndCnts.ensureCapacity(value[i].size());
@@ -242,6 +263,18 @@ public class StringIndexer
                         stringsAndCnts.sort(
                                 (valAndCnt1, valAndCnt2) ->
                                         -valAndCnt1.f1.compareTo(valAndCnt2.f1));
+
+                        if (stringsAndCnts.size() > maxIndexNum) {
+                            ArrayList<Tuple2<String, Long>> frequentStringsAndCnts =
+                                    new ArrayList<>();
+                            // Reserves the last index for infrequent element.
+                            frequentStringsAndCnts.ensureCapacity(maxIndexNum - 1);
+                            for (int indexId = 0; indexId < maxIndexNum - 1; indexId++) {
+                                frequentStringsAndCnts.add(stringsAndCnts.get(indexId));
+                            }
+                            stringsAndCnts = frequentStringsAndCnts;
+                        }
+
                         break;
                     case ARBITRARY_ORDER:
                         break;

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerModel.java
@@ -49,8 +49,8 @@ import java.util.Map;
  * A Model which transforms input string/numeric column(s) to double column(s) using the model data
  * computed by {@link StringIndexer}.
  *
- * <p>The `keep` option of {@link HasHandleInvalid} means that we put the invalid entries in a
- * special bucket, whose index is the number of distinct values in this column.
+ * <p>The `keep` option of {@link HasHandleInvalid} means that we transform the invalid input into a
+ * special index, whose value is the number of distinct values in this column.
  */
 public class StringIndexerModel
         implements Model<StringIndexerModel>, StringIndexerModelParams<StringIndexerModel> {

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerParams.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.ml.feature.stringindexer;
 
+import org.apache.flink.ml.param.IntParam;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.param.ParamValidators;
 import org.apache.flink.ml.param.StringParam;
@@ -58,11 +59,27 @@ public interface StringIndexerParams<T> extends StringIndexerModelParams<T> {
                             ALPHABET_DESC_ORDER,
                             ALPHABET_ASC_ORDER));
 
+    Param<Integer> MAX_INDEX_NUM =
+            new IntParam(
+                    "maxIndexNum",
+                    "The max number of indices for each column. It only works when "
+                            + "stringOrderType is set as frequencyDesc.",
+                    Integer.MAX_VALUE,
+                    ParamValidators.gt(1));
+
     default String getStringOrderType() {
         return get(STRING_ORDER_TYPE);
     }
 
     default T setStringOrderType(String value) {
         return set(STRING_ORDER_TYPE, value);
+    }
+
+    default int getMaxIndexNum() {
+        return get(MAX_INDEX_NUM);
+    }
+
+    default T setMaxIndexNum(int value) {
+        return set(MAX_INDEX_NUM, value);
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerParams.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/StringIndexerParams.java
@@ -63,7 +63,7 @@ public interface StringIndexerParams<T> extends StringIndexerModelParams<T> {
             new IntParam(
                     "maxIndexNum",
                     "The max number of indices for each column. It only works when "
-                            + "stringOrderType is set as frequencyDesc.",
+                            + "'stringOrderType' is set as 'frequencyDesc'.",
                     Integer.MAX_VALUE,
                     ParamValidators.gt(1));
 

--- a/flink-ml-python/pyflink/ml/feature/stringindexer.py
+++ b/flink-ml-python/pyflink/ml/feature/stringindexer.py
@@ -17,7 +17,7 @@
 ################################################################################
 import typing
 
-from pyflink.ml.param import Param, StringParam, ParamValidators
+from pyflink.ml.param import Param, IntParam, StringParam, ParamValidators
 from pyflink.ml.wrapper import JavaWithParams
 from pyflink.ml.feature.common import JavaFeatureModel, JavaFeatureEstimator
 from pyflink.ml.common.param import HasInputCols, HasOutputCols, HasHandleInvalid
@@ -62,6 +62,13 @@ class _StringIndexerParams(_StringIndexerModelParams):
         ParamValidators.in_array(
             ['arbitrary', 'frequencyDesc', 'frequencyAsc', 'alphabetDesc', 'alphabetAsc']))
 
+    MAX_INDEX_NUM: Param[int] = IntParam(
+        "max_index_num",
+        "The max number of indices for each column. It only works when "
+        + "stringOrderType is set as frequencyDesc.",
+        2 ** 31 - 1,
+        ParamValidators.gt(1))
+
     def __init__(self, java_params):
         super(_StringIndexerParams, self).__init__(java_params)
 
@@ -71,9 +78,19 @@ class _StringIndexerParams(_StringIndexerModelParams):
     def get_string_order_type(self) -> str:
         return self.get(self.STRING_ORDER_TYPE)
 
+    def set_max_index_num(self, value: int):
+        return typing.cast(_StringIndexerParams, self.set(self.MAX_INDEX_NUM, value))
+
+    def get_max_index_num(self) -> int:
+        return self.get(self.MAX_INDEX_NUM)
+
     @property
     def string_order_type(self):
         return self.get_string_order_type()
+
+    @property
+    def max_index_num(self):
+        return self.get_max_index_num()
 
 
 class IndexToStringModel(JavaFeatureModel, _IndexToStringModelParams):
@@ -99,8 +116,8 @@ class StringIndexerModel(JavaFeatureModel, _StringIndexerModelParams):
     A Model which transforms input string/numeric column(s) to integer column(s) using the model
     data computed by :class:StringIndexer.
 
-    The `keep` option of {@link HasHandleInvalid} means that we put the invalid entries in a
-    special bucket, whose index is the number of distinct values in this column.
+    The `keep` option of {@link HasHandleInvalid} means that we transform the invalid input
+    into a special index, whose value is the number of distinct values in this column.
     """
 
     def __init__(self, java_model=None):
@@ -128,8 +145,12 @@ class StringIndexer(JavaFeatureEstimator, _StringIndexerParams):
     is arbitrarily ordered. Users can control this by setting {@link
     StringIndexerParams#STRING_ORDER_TYPE}.
 
-    The `keep` option of {@link HasHandleInvalid} means that we put the invalid entries in a
-    special bucket, whose index is the number of distinct values in this column.
+    User can also control the max number of output indices by setting {@link
+    StringIndexerParams#MAX_INDEX_NUM}. This parameter only works if {@link
+    StringIndexerParams#STRING_ORDER_TYPE} is set as frequencyDesc.
+
+    The `keep` option of {@link HasHandleInvalid} means that we transform the invalid input
+    into a special index, whose value is the number of distinct values in this column.
     """
 
     def __init__(self):

--- a/flink-ml-python/pyflink/ml/feature/stringindexer.py
+++ b/flink-ml-python/pyflink/ml/feature/stringindexer.py
@@ -65,7 +65,7 @@ class _StringIndexerParams(_StringIndexerModelParams):
     MAX_INDEX_NUM: Param[int] = IntParam(
         "max_index_num",
         "The max number of indices for each column. It only works when "
-        + "stringOrderType is set as frequencyDesc.",
+        + "'stringOrderType' is set as 'frequencyDesc'.",
         2 ** 31 - 1,
         ParamValidators.gt(1))
 
@@ -147,7 +147,7 @@ class StringIndexer(JavaFeatureEstimator, _StringIndexerParams):
 
     User can also control the max number of output indices by setting {@link
     StringIndexerParams#MAX_INDEX_NUM}. This parameter only works if {@link
-    StringIndexerParams#STRING_ORDER_TYPE} is set as frequencyDesc.
+    StringIndexerParams#STRING_ORDER_TYPE} is set as 'frequencyDesc'.
 
     The `keep` option of {@link HasHandleInvalid} means that we transform the invalid input
     into a special index, whose value is the number of distinct values in this column.


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to support the use case when users want to filter out infrequent strings in StringIndexer.
To achieve this, I have added a `HasMaxIndexNum` param. The default value is `Int.MAX` so it is consistent with the existing behavior.

Note that `HasMaxIndexNum` only works when `stringOrderType` is set as `frequencyDesc`.

## Brief change log
  - Added `HasMaxIndexNum` param and the corresponding logic.
  - Added java/python test
  - Updated the correponding doc.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (javaDocs)
