### PR TITLE
[FLINK-31029] Fix bug when using quantile in KbinsDiscretizer

### DIFF
--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/KBinsDiscretizerTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/feature/KBinsDiscretizerTest.java
@@ -101,11 +101,11 @@ public class KBinsDiscretizerTest extends AbstractTestBase {
             Arrays.asList(
                     Row.of(Vectors.dense(0, 0, 0)),
                     Row.of(Vectors.dense(0, 0, 0)),
-                    Row.of(Vectors.dense(0, 0, 0)),
-                    Row.of(Vectors.dense(1, 0, 0)),
-                    Row.of(Vectors.dense(2, 0, 0)),
-                    Row.of(Vectors.dense(2, 0, 0)),
-                    Row.of(Vectors.dense(2, 0, 0)));
+                    Row.of(Vectors.dense(0, 0, 1)),
+                    Row.of(Vectors.dense(1, 0, 1)),
+                    Row.of(Vectors.dense(2, 0, 1)),
+                    Row.of(Vectors.dense(2, 0, 1)),
+                    Row.of(Vectors.dense(2, 0, 1)));
 
     private static final List<Row> KMEANS_OUTPUT =
             Arrays.asList(
@@ -273,5 +273,24 @@ public class KBinsDiscretizerTest extends AbstractTestBase {
         } catch (Throwable e) {
             assertEquals("The training set is empty.", ExceptionUtils.getRootCause(e).getMessage());
         }
+    }
+
+    @Test
+    public void testBinsWithWidthAsZero() throws Exception {
+        final List<Row> expectedOutput =
+                Arrays.asList(
+                        Row.of(Vectors.dense(0, 0, 0)),
+                        Row.of(Vectors.dense(0, 0, 0)),
+                        Row.of(Vectors.dense(0, 0, 1)),
+                        Row.of(Vectors.dense(3, 0, 1)),
+                        Row.of(Vectors.dense(5, 0, 1)),
+                        Row.of(Vectors.dense(6, 0, 1)),
+                        Row.of(Vectors.dense(6, 0, 1)));
+
+        KBinsDiscretizer kBinsDiscretizer =
+                new KBinsDiscretizer().setNumBins(10).setStrategy(KBinsDiscretizerParams.QUANTILE);
+
+        Table output = kBinsDiscretizer.fit(trainTable).transform(testTable)[0];
+        verifyPredictionResult(expectedOutput, output, kBinsDiscretizer.getOutputCol());
     }
 }

--- a/flink-ml-python/pyflink/ml/feature/kbinsdiscretizer.py
+++ b/flink-ml-python/pyflink/ml/feature/kbinsdiscretizer.py
@@ -147,8 +147,11 @@ class KBinsDiscretizer(JavaFeatureEstimator, _KBinsDiscretizerParams):
         <li>When the number of distinct values of one column is less than the specified
         number of bins and the {@link KBinsDiscretizerParams#STRATEGY} is set as {@link
         KBinsDiscretizerParams#KMEANS}, we switch to {@link KBinsDiscretizerParams#UNIFORM}.
-        <li>When the width of one output bin is zero, i.e., the left edge equals to the right
-        edge of the bin, we remove it.
+        <li>When the width of one output bin is zero, i.e., the left edge equals to the
+        right edge of the bin, we replace the right edge as the average value of its two
+        neighbors. One exception is that the last two edges are the same --- in this case,
+        the left edge is updated as the average of its two neighbors. For example,
+        the bin edges {0, 1, 1, 2, 2} are transformed into {0, 1, 1.5, 1.75, 2}.
     </ul>
     """
 

--- a/flink-ml-python/pyflink/ml/feature/tests/test_kbinsdiscretizer.py
+++ b/flink-ml-python/pyflink/ml/feature/tests/test_kbinsdiscretizer.py
@@ -72,11 +72,11 @@ class KBinsDiscretizerTest(PyFlinkMLTestCase):
         self.quantile_output = [
             Vectors.dense(0, 0, 0),
             Vectors.dense(0, 0, 0),
-            Vectors.dense(0, 0, 0),
-            Vectors.dense(1, 0, 0),
-            Vectors.dense(2, 0, 0),
-            Vectors.dense(2, 0, 0),
-            Vectors.dense(2, 0, 0),
+            Vectors.dense(0, 0, 1),
+            Vectors.dense(1, 0, 1),
+            Vectors.dense(2, 0, 1),
+            Vectors.dense(2, 0, 1),
+            Vectors.dense(2, 0, 1),
         ]
 
         self.kmeans_output = [


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to fix the bug when using quantile strategy in KbinsDiscretizer. 

- In the original version, we remove bins with zero width by simply merging it with the next bin. However it is not always true. For example, if the histograms computed are [0, 0, 0, 1], then it is transformed into [0, 1]. Thus is 0 and 1 are mapped in to the same bin, which is wrong.
- In this PR, the histogram will be transformed into [0, 0.5, 1]. It is computed with the following logic:
    - Remove the repeated elements in the histgram such that there are no 3+ consecutive same elements.
    - If there two consecutive same elements, the second one is updated as the average of the element before and after.
    - If the last two elements in the histogram are the same, the last one is removed.

## Brief change log
  - Changed the computing logic of handling zero-width bins.
  - Added unit test to verify it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
