### PR TITLE
[hotfix] Discard watermarks when feed a datastream into iteration body

### DIFF
--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/Iterations.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/Iterations.java
@@ -85,6 +85,9 @@ import static org.apache.flink.util.Preconditions.checkState;
  * <p>The limitation of constructing the subgraph inside the iteration body could be refer in {@link
  * IterationBody}.
  *
+ * <p>Note that the iteration framework cannot deal with watermarks correctly for now. It should be
+ * resolved by FLINK-31373.
+ *
  * <p>An example of the iteration is like:
  *
  * <pre>{@code

--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/InputOperator.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/operator/InputOperator.java
@@ -22,6 +22,7 @@ import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /** Input operator that wraps the user record into {@link IterationRecord}. */
@@ -45,5 +46,10 @@ public class InputOperator<T> extends AbstractStreamOperator<IterationRecord<T>>
         reusable.setTimestamp(streamRecord.getTimestamp());
         reusable.getValue().setValue(streamRecord.getValue());
         output.collect(reusable);
+    }
+
+    @Override
+    public void processWatermark(Watermark mark) {
+        // TODO: FLINK-31373 Support processing watermarks in iterations.
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
This PR proposes to discard watermarks when feeding a datastream into iteration body since watermarks are not correctly processed in iteration module. (See https://issues.apache.org/jira/browse/FLINK-31373)

To avoid the possible bugs, we plan to add a java doc to explain that `flink-m-iteration` module cannot deal with watermarks for now. We also leave it as a TODO here and plan to support it in the future.

## Brief change log
  - Added a java doc to explain that iterations cannot deal with watermarks correctly.
  - Removed watermarks for all datastreams that are fed into a iteration body.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
