### PR TITLE
[FLINK-31623] Fix DataStreamUtils#sample with approximate uniform sampling

### DIFF
--- a/flink-ml-core/src/test/java/org/apache/flink/ml/common/datastream/DataStreamUtilsTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/common/datastream/DataStreamUtilsTest.java
@@ -101,6 +101,21 @@ public class DataStreamUtilsTest {
     }
 
     @Test
+    public void testSample() throws Exception {
+        int numSamples = 10;
+        int[] totalMinusOneChoices = new int[] {0, 5, 9, 10, 11, 20, 30, 40, 200};
+        for (int totalMinusOne : totalMinusOneChoices) {
+            DataStream<Long> dataStream =
+                    env.fromParallelCollection(
+                            new NumberSequenceIterator(0L, totalMinusOne), Types.LONG);
+            DataStream<Long> result = DataStreamUtils.sample(dataStream, numSamples, 0);
+            //noinspection unchecked
+            List<String> sampled = IteratorUtils.toList(result.executeAndCollect());
+            assertEquals(Math.min(numSamples, totalMinusOne + 1), sampled.size());
+        }
+    }
+
+    @Test
     public void testGenerateBatchData() throws Exception {
         DataStream<Long> dataStream =
                 env.fromParallelCollection(new NumberSequenceIterator(0L, 19L), Types.LONG);


### PR DESCRIPTION
## What is the purpose of the change

This modification will resolve the issue with `DataStreamUtils#sample` by implementing uniform sampling.

The current implementation utilizes a two-level sampling method. However, if the elements are unevenly distributed among partitions (subtasks), the sampling probabilities may differ across partitions, resulting in non-uniform sampling.

Furthermore, the current implementation has a side-effect where one subtask has a memory footprint of `2 * numSamples * sizeof(element)`, potentially leading to unexpected OOM errors in certain scenarios.

## Brief change log

  - Adds `rebalance` to the input data, and decrease the number of samples in the first round.
  - Adds unit tests for this method.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
