### PR TITLE
[FLINK-31753] Support DataStream CoGroup in stream mode with similar performance as DataSet CoGroup

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/sort/BytesKeyNormalizationUtil.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/sort/BytesKeyNormalizationUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.datastream.sort;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * Utility class for common key normalization used both in {@link VariableLengthByteKeyComparator}
+ * and {@link FixedLengthByteKeyComparator}.
+ *
+ * <p>TODO: remove this class after making the corresponding class in Flink public.
+ */
+final class BytesKeyNormalizationUtil {
+    /**
+     * Writes the normalized key of given record. The normalized key consists of the key serialized
+     * as bytes and the timestamp of the record.
+     *
+     * <p>NOTE: The key does not represent a logical order. It can be used only for grouping keys!
+     */
+    static <IN> void putNormalizedKey(
+            Tuple2<byte[], StreamRecord<IN>> record,
+            int dataLength,
+            MemorySegment target,
+            int offset,
+            int numBytes) {
+        byte[] data = record.f0;
+
+        if (dataLength >= numBytes) {
+            putBytesArray(target, offset, numBytes, data);
+        } else {
+            // whole key fits into the normalized key
+            putBytesArray(target, offset, dataLength, data);
+            int lastOffset = offset + numBytes;
+            offset += dataLength;
+            long valueOfTimestamp = record.f1.asRecord().getTimestamp() - Long.MIN_VALUE;
+            if (dataLength + FixedLengthByteKeyComparator.TIMESTAMP_BYTE_SIZE <= numBytes) {
+                // whole timestamp fits into the normalized key
+                target.putLong(offset, valueOfTimestamp);
+                offset += FixedLengthByteKeyComparator.TIMESTAMP_BYTE_SIZE;
+                // fill in the remaining space with zeros
+                while (offset < lastOffset) {
+                    target.put(offset++, (byte) 0);
+                }
+            } else {
+                // only part of the timestamp fits into normalized key
+                for (int i = 0; offset < lastOffset; offset++, i++) {
+                    target.put(offset, (byte) (valueOfTimestamp >>> ((7 - i) << 3)));
+                }
+            }
+        }
+    }
+
+    private static void putBytesArray(MemorySegment target, int offset, int numBytes, byte[] data) {
+        for (int i = 0; i < numBytes; i++) {
+            // We're converting the signed byte in data into an unsigned representation.
+            // A Java byte goes from -128 to 127, i.e. is signed. By subtracting -128 (MIN_VALUE)
+            // here we're shifting the number to be from 0 to 255. The normalized key sorter sorts
+            // bytes as "unsigned", so we need to convert here to maintain a correct ordering.
+            int highByte = data[i] & 0xff;
+            highByte -= Byte.MIN_VALUE;
+            target.put(offset + i, (byte) highByte);
+        }
+    }
+
+    private BytesKeyNormalizationUtil() {}
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/sort/CoGroupOperator.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/sort/CoGroupOperator.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.datastream.sort;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.CoGroupFunction;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypePairComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.runtime.RuntimePairComparatorFactory;
+import org.apache.flink.configuration.AlgorithmOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.sort.ExternalSorter;
+import org.apache.flink.runtime.operators.sort.NonReusingSortMergeCoGroupIterator;
+import org.apache.flink.runtime.operators.sort.PushSorter;
+import org.apache.flink.runtime.operators.sort.ReusingSortMergeCoGroupIterator;
+import org.apache.flink.runtime.operators.util.CoGroupTaskIterator;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.util.MutableObjectIterator;
+import org.apache.flink.util.TraversableOnceException;
+
+import java.io.Serializable;
+import java.util.Iterator;
+
+/**
+ * An operator that implements the co-group logic.
+ *
+ * @param <IN1> The class type of the first input.
+ * @param <IN2> The class type of the second input.
+ * @param <KEY> The class type of the key.
+ * @param <OUT> The class type of the output values.
+ */
+public class CoGroupOperator<IN1, IN2, KEY extends Serializable, OUT>
+        extends AbstractUdfStreamOperator<OUT, CoGroupFunction<IN1, IN2, OUT>>
+        implements TwoInputStreamOperator<IN1, IN2, OUT>, BoundedMultiInput {
+
+    private PushSorter<Tuple2<byte[], StreamRecord<IN1>>> sorterA;
+    private PushSorter<Tuple2<byte[], StreamRecord<IN2>>> sorterB;
+    private TypeComparator<Tuple2<byte[], StreamRecord<IN1>>> comparatorA;
+    private TypeComparator<Tuple2<byte[], StreamRecord<IN2>>> comparatorB;
+    private KeySelector<IN1, KEY> keySelectorA;
+    private KeySelector<IN2, KEY> keySelectorB;
+    private TypeSerializer<Tuple2<byte[], StreamRecord<IN1>>> keyAndValueSerializerA;
+    private TypeSerializer<Tuple2<byte[], StreamRecord<IN2>>> keyAndValueSerializerB;
+    private TypeSerializer<KEY> keySerializer;
+    private DataOutputSerializer dataOutputSerializer;
+    private long lastWatermarkTimestamp = Long.MIN_VALUE;
+    private int remainingInputNum = 2;
+
+    public CoGroupOperator(CoGroupFunction<IN1, IN2, OUT> function) {
+        super(function);
+    }
+
+    @Override
+    public void setup(
+            StreamTask<?, ?> containingTask,
+            StreamConfig config,
+            Output<StreamRecord<OUT>> output) {
+        super.setup(containingTask, config, output);
+        ClassLoader userCodeClassLoader = containingTask.getUserCodeClassLoader();
+        MemoryManager memoryManager = containingTask.getEnvironment().getMemoryManager();
+        IOManager ioManager = containingTask.getEnvironment().getIOManager();
+
+        keySelectorA = config.getStatePartitioner(0, userCodeClassLoader);
+        keySelectorB = config.getStatePartitioner(1, userCodeClassLoader);
+        keySerializer = config.getStateKeySerializer(userCodeClassLoader);
+        int keyLength = keySerializer.getLength();
+
+        TypeSerializer<IN1> typeSerializerA = config.getTypeSerializerIn(0, userCodeClassLoader);
+        TypeSerializer<IN2> typeSerializerB = config.getTypeSerializerIn(1, userCodeClassLoader);
+        keyAndValueSerializerA = new KeyAndValueSerializer<>(typeSerializerA, keyLength);
+        keyAndValueSerializerB = new KeyAndValueSerializer<>(typeSerializerB, keyLength);
+
+        if (keyLength > 0) {
+            dataOutputSerializer = new DataOutputSerializer(keyLength);
+            comparatorA = new FixedLengthByteKeyComparator<>(keyLength);
+            comparatorB = new FixedLengthByteKeyComparator<>(keyLength);
+        } else {
+            dataOutputSerializer = new DataOutputSerializer(64);
+            comparatorA = new VariableLengthByteKeyComparator<>();
+            comparatorB = new VariableLengthByteKeyComparator<>();
+        }
+
+        ExecutionConfig executionConfig = containingTask.getEnvironment().getExecutionConfig();
+        double managedMemoryFraction =
+                config.getManagedMemoryFractionOperatorUseCaseOfSlot(
+                                ManagedMemoryUseCase.OPERATOR,
+                                containingTask.getEnvironment().getTaskConfiguration(),
+                                userCodeClassLoader)
+                        / 2;
+        Configuration jobConfiguration = containingTask.getEnvironment().getJobConfiguration();
+
+        try {
+            sorterA =
+                    ExternalSorter.newBuilder(
+                                    memoryManager,
+                                    containingTask,
+                                    keyAndValueSerializerA,
+                                    comparatorA,
+                                    executionConfig)
+                            .memoryFraction(managedMemoryFraction)
+                            .enableSpilling(
+                                    ioManager,
+                                    jobConfiguration.get(AlgorithmOptions.SORT_SPILLING_THRESHOLD))
+                            .maxNumFileHandles(
+                                    jobConfiguration.get(AlgorithmOptions.SPILLING_MAX_FAN))
+                            .objectReuse(executionConfig.isObjectReuseEnabled())
+                            .largeRecords(
+                                    jobConfiguration.get(
+                                            AlgorithmOptions.USE_LARGE_RECORDS_HANDLER))
+                            .build();
+            sorterB =
+                    ExternalSorter.newBuilder(
+                                    memoryManager,
+                                    containingTask,
+                                    keyAndValueSerializerB,
+                                    comparatorB,
+                                    executionConfig)
+                            .memoryFraction(managedMemoryFraction)
+                            .enableSpilling(
+                                    ioManager,
+                                    jobConfiguration.get(AlgorithmOptions.SORT_SPILLING_THRESHOLD))
+                            .maxNumFileHandles(
+                                    jobConfiguration.get(AlgorithmOptions.SPILLING_MAX_FAN))
+                            .objectReuse(executionConfig.isObjectReuseEnabled())
+                            .largeRecords(
+                                    jobConfiguration.get(
+                                            AlgorithmOptions.USE_LARGE_RECORDS_HANDLER))
+                            .build();
+        } catch (MemoryAllocationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void endInput(int inputId) throws Exception {
+        if (inputId == 1) {
+            sorterA.finishReading();
+            remainingInputNum--;
+        } else if (inputId == 2) {
+            sorterB.finishReading();
+            remainingInputNum--;
+        } else {
+            throw new RuntimeException("Unknown inputId " + inputId);
+        }
+
+        if (remainingInputNum > 0) {
+            return;
+        }
+
+        MutableObjectIterator<Tuple2<byte[], StreamRecord<IN1>>> iteratorA = sorterA.getIterator();
+        MutableObjectIterator<Tuple2<byte[], StreamRecord<IN2>>> iteratorB = sorterB.getIterator();
+        TypePairComparator<Tuple2<byte[], StreamRecord<IN1>>, Tuple2<byte[], StreamRecord<IN2>>>
+                pairComparator =
+                        (new RuntimePairComparatorFactory<
+                                        Tuple2<byte[], StreamRecord<IN1>>,
+                                        Tuple2<byte[], StreamRecord<IN2>>>())
+                                .createComparator12(comparatorA, comparatorB);
+
+        CoGroupTaskIterator<Tuple2<byte[], StreamRecord<IN1>>, Tuple2<byte[], StreamRecord<IN2>>>
+                coGroupIterator;
+        if (getExecutionConfig().isObjectReuseEnabled()) {
+            coGroupIterator =
+                    new ReusingSortMergeCoGroupIterator<
+                            Tuple2<byte[], StreamRecord<IN1>>, Tuple2<byte[], StreamRecord<IN2>>>(
+                            iteratorA,
+                            iteratorB,
+                            keyAndValueSerializerA,
+                            comparatorA,
+                            keyAndValueSerializerB,
+                            comparatorB,
+                            pairComparator);
+        } else {
+            coGroupIterator =
+                    new NonReusingSortMergeCoGroupIterator<
+                            Tuple2<byte[], StreamRecord<IN1>>, Tuple2<byte[], StreamRecord<IN2>>>(
+                            iteratorA,
+                            iteratorB,
+                            keyAndValueSerializerA,
+                            comparatorA,
+                            keyAndValueSerializerB,
+                            comparatorB,
+                            pairComparator);
+        }
+
+        coGroupIterator.open();
+        TupleUnwrappingIterator<IN1, byte[]> unWrappediteratorA = new TupleUnwrappingIterator<>();
+        TupleUnwrappingIterator<IN2, byte[]> unWrappediteratorB = new TupleUnwrappingIterator<>();
+
+        Output<OUT> timestampedCollector = new TimestampedCollector<>(output);
+        while (coGroupIterator.next()) {
+            unWrappediteratorA.set(coGroupIterator.getValues1().iterator());
+            unWrappediteratorB.set(coGroupIterator.getValues2().iterator());
+            userFunction.coGroup(unWrappediteratorA, unWrappediteratorB, timestampedCollector);
+        }
+        coGroupIterator.close();
+
+        Watermark watermark = new Watermark(lastWatermarkTimestamp);
+        if (getTimeServiceManager().isPresent()) {
+            getTimeServiceManager().get().advanceWatermark(watermark);
+        }
+        output.emitWatermark(watermark);
+    }
+
+    @Override
+    public void processWatermark(Watermark watermark) throws Exception {
+        if (lastWatermarkTimestamp > watermark.getTimestamp()) {
+            throw new RuntimeException("Invalid watermark");
+        }
+        lastWatermarkTimestamp = watermark.getTimestamp();
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        sorterA.close();
+        sorterB.close();
+    }
+
+    @Override
+    public void processElement1(StreamRecord<IN1> streamRecord) throws Exception {
+        KEY key = keySelectorA.getKey(streamRecord.getValue());
+        keySerializer.serialize(key, dataOutputSerializer);
+        byte[] serializedKey = dataOutputSerializer.getCopyOfBuffer();
+        dataOutputSerializer.clear();
+        sorterA.writeRecord(Tuple2.of(serializedKey, streamRecord));
+    }
+
+    @Override
+    public void processElement2(StreamRecord<IN2> streamRecord) throws Exception {
+        KEY key = keySelectorB.getKey(streamRecord.getValue());
+        keySerializer.serialize(key, dataOutputSerializer);
+        byte[] serializedKey = dataOutputSerializer.getCopyOfBuffer();
+        dataOutputSerializer.clear();
+        sorterB.writeRecord(Tuple2.of(serializedKey, streamRecord));
+    }
+
+    private static class TupleUnwrappingIterator<T, K>
+            implements Iterator<T>, Iterable<T>, java.io.Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private K lastKey;
+        private Iterator<Tuple2<K, StreamRecord<T>>> iterator;
+        private boolean iteratorAvailable;
+
+        public void set(Iterator<Tuple2<K, StreamRecord<T>>> iterator) {
+            this.iterator = iterator;
+            this.iteratorAvailable = true;
+        }
+
+        public K getLastKey() {
+            return lastKey;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public T next() {
+            Tuple2<K, StreamRecord<T>> t = iterator.next();
+            this.lastKey = t.f0;
+            return t.f1.getValue();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            if (iteratorAvailable) {
+                iteratorAvailable = false;
+                return this;
+            } else {
+                throw new TraversableOnceException();
+            }
+        }
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/sort/FixedLengthByteKeyComparator.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/sort/FixedLengthByteKeyComparator.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.datastream.sort;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.streaming.api.operators.sort.SortingDataInput;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * A comparator used in {@link SortingDataInput} which compares records keys and timestamps. It uses
+ * binary format produced by the {@link KeyAndValueSerializer}.
+ *
+ * <p>It assumes keys are always of a fixed length and thus the length of the record is not
+ * serialized.
+ *
+ * <p>TODO: remove this class after making the corresponding class in Flink public.
+ */
+public final class FixedLengthByteKeyComparator<IN>
+        extends TypeComparator<Tuple2<byte[], StreamRecord<IN>>> {
+    static final int TIMESTAMP_BYTE_SIZE = 8;
+    private final int keyLength;
+    private byte[] keyReference;
+    private long timestampReference;
+
+    public FixedLengthByteKeyComparator(int keyLength) {
+        this.keyLength = keyLength;
+    }
+
+    @Override
+    public int hash(Tuple2<byte[], StreamRecord<IN>> record) {
+        return record.hashCode();
+    }
+
+    @Override
+    public void setReference(Tuple2<byte[], StreamRecord<IN>> toCompare) {
+        this.keyReference = toCompare.f0;
+        this.timestampReference = toCompare.f1.asRecord().getTimestamp();
+    }
+
+    @Override
+    public boolean equalToReference(Tuple2<byte[], StreamRecord<IN>> candidate) {
+        return Arrays.equals(keyReference, candidate.f0)
+                && timestampReference == candidate.f1.asRecord().getTimestamp();
+    }
+
+    @Override
+    public int compareToReference(
+            TypeComparator<Tuple2<byte[], StreamRecord<IN>>> referencedComparator) {
+        byte[] otherKey = ((FixedLengthByteKeyComparator<IN>) referencedComparator).keyReference;
+        long otherTimestamp =
+                ((FixedLengthByteKeyComparator<IN>) referencedComparator).timestampReference;
+
+        int keyCmp = compare(otherKey, this.keyReference);
+        if (keyCmp != 0) {
+            return keyCmp;
+        }
+        return Long.compare(otherTimestamp, this.timestampReference);
+    }
+
+    @Override
+    public int compare(
+            Tuple2<byte[], StreamRecord<IN>> first, Tuple2<byte[], StreamRecord<IN>> second) {
+        int keyCmp = compare(first.f0, second.f0);
+        if (keyCmp != 0) {
+            return keyCmp;
+        }
+        return Long.compare(
+                first.f1.asRecord().getTimestamp(), second.f1.asRecord().getTimestamp());
+    }
+
+    private int compare(byte[] first, byte[] second) {
+        for (int i = 0; i < keyLength; i++) {
+            int cmp = Byte.compare(first[i], second[i]);
+
+            if (cmp != 0) {
+                return cmp < 0 ? -1 : 1;
+            }
+        }
+
+        return 0;
+    }
+
+    @Override
+    public int compareSerialized(DataInputView firstSource, DataInputView secondSource)
+            throws IOException {
+        int minCount = keyLength;
+        while (minCount-- > 0) {
+            byte firstValue = firstSource.readByte();
+            byte secondValue = secondSource.readByte();
+
+            int cmp = Byte.compare(firstValue, secondValue);
+            if (cmp != 0) {
+                return cmp < 0 ? -1 : 1;
+            }
+        }
+
+        return Long.compare(firstSource.readLong(), secondSource.readLong());
+    }
+
+    @Override
+    public boolean supportsNormalizedKey() {
+        return true;
+    }
+
+    @Override
+    public int getNormalizeKeyLen() {
+        return keyLength + TIMESTAMP_BYTE_SIZE;
+    }
+
+    @Override
+    public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+        return keyBytes < getNormalizeKeyLen();
+    }
+
+    @Override
+    public void putNormalizedKey(
+            Tuple2<byte[], StreamRecord<IN>> record,
+            MemorySegment target,
+            int offset,
+            int numBytes) {
+        BytesKeyNormalizationUtil.putNormalizedKey(record, keyLength, target, offset, numBytes);
+    }
+
+    @Override
+    public boolean invertNormalizedKey() {
+        return false;
+    }
+
+    @Override
+    public TypeComparator<Tuple2<byte[], StreamRecord<IN>>> duplicate() {
+        return new FixedLengthByteKeyComparator<>(this.keyLength);
+    }
+
+    @Override
+    public int extractKeys(Object record, Object[] target, int index) {
+        target[index] = record;
+        return 1;
+    }
+
+    @Override
+    public TypeComparator<?>[] getFlatComparators() {
+        return new TypeComparator[] {this};
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // unsupported normalization
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public boolean supportsSerializationWithKeyNormalization() {
+        return false;
+    }
+
+    @Override
+    public void writeWithKeyNormalization(
+            Tuple2<byte[], StreamRecord<IN>> record, DataOutputView target) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Tuple2<byte[], StreamRecord<IN>> readWithKeyDenormalization(
+            Tuple2<byte[], StreamRecord<IN>> reuse, DataInputView source) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/sort/KeyAndValueSerializer.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/sort/KeyAndValueSerializer.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.datastream.sort;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.streaming.api.operators.sort.SortingDataInput;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * A serializer used in {@link SortingDataInput} for serializing elements alongside their key and
+ * timestamp. It serializes the record in a format known by the {@link FixedLengthByteKeyComparator}
+ * and {@link VariableLengthByteKeyComparator}.
+ *
+ * <p>If the key is of known constant length, the length is not serialized with the data. Therefore
+ * the serialized data is as follows:
+ *
+ * <pre>
+ *      [key-length] | &lt;key&gt; | &lt;timestamp&gt; | &lt;record&gt;
+ * </pre>
+ *
+ * <p>TODO: remove this class after making the corresponding class in Flink public.
+ */
+public final class KeyAndValueSerializer<IN>
+        extends TypeSerializer<Tuple2<byte[], StreamRecord<IN>>> {
+    private static final int TIMESTAMP_LENGTH = 8;
+    private final TypeSerializer<IN> valueSerializer;
+
+    // This represents either a variable length (-1) or a fixed one (>= 0).
+    private final int serializedKeyLength;
+
+    public KeyAndValueSerializer(TypeSerializer<IN> valueSerializer, int serializedKeyLength) {
+        this.valueSerializer = valueSerializer;
+        this.serializedKeyLength = serializedKeyLength;
+    }
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<Tuple2<byte[], StreamRecord<IN>>> duplicate() {
+        return new KeyAndValueSerializer<>(valueSerializer.duplicate(), this.serializedKeyLength);
+    }
+
+    @Override
+    public Tuple2<byte[], StreamRecord<IN>> copy(Tuple2<byte[], StreamRecord<IN>> from) {
+        StreamRecord<IN> fromRecord = from.f1;
+        return Tuple2.of(
+                Arrays.copyOf(from.f0, from.f0.length),
+                fromRecord.copy(valueSerializer.copy(fromRecord.getValue())));
+    }
+
+    @Override
+    public Tuple2<byte[], StreamRecord<IN>> createInstance() {
+        return Tuple2.of(new byte[0], new StreamRecord<>(valueSerializer.createInstance()));
+    }
+
+    @Override
+    public Tuple2<byte[], StreamRecord<IN>> copy(
+            Tuple2<byte[], StreamRecord<IN>> from, Tuple2<byte[], StreamRecord<IN>> reuse) {
+        StreamRecord<IN> fromRecord = from.f1;
+        StreamRecord<IN> reuseRecord = reuse.f1;
+
+        IN valueCopy = valueSerializer.copy(fromRecord.getValue(), reuseRecord.getValue());
+        fromRecord.copyTo(valueCopy, reuseRecord);
+        reuse.f0 = Arrays.copyOf(from.f0, from.f0.length);
+        reuse.f1 = reuseRecord;
+        return reuse;
+    }
+
+    @Override
+    public int getLength() {
+        if (valueSerializer.getLength() < 0 || serializedKeyLength < 0) {
+            return -1;
+        }
+        return valueSerializer.getLength() + serializedKeyLength + TIMESTAMP_LENGTH;
+    }
+
+    @Override
+    public void serialize(Tuple2<byte[], StreamRecord<IN>> record, DataOutputView target)
+            throws IOException {
+        if (serializedKeyLength < 0) {
+            target.writeInt(record.f0.length);
+        }
+        target.write(record.f0);
+        StreamRecord<IN> toSerialize = record.f1;
+        target.writeLong(toSerialize.getTimestamp());
+        valueSerializer.serialize(toSerialize.getValue(), target);
+    }
+
+    @Override
+    public Tuple2<byte[], StreamRecord<IN>> deserialize(DataInputView source) throws IOException {
+        final int length = getKeyLength(source);
+        byte[] bytes = new byte[length];
+        source.read(bytes);
+        long timestamp = source.readLong();
+        IN value = valueSerializer.deserialize(source);
+        return Tuple2.of(bytes, new StreamRecord<>(value, timestamp));
+    }
+
+    @Override
+    public Tuple2<byte[], StreamRecord<IN>> deserialize(
+            Tuple2<byte[], StreamRecord<IN>> reuse, DataInputView source) throws IOException {
+        final int length = getKeyLength(source);
+        byte[] bytes = new byte[length];
+        source.read(bytes);
+        long timestamp = source.readLong();
+        IN value = valueSerializer.deserialize(source);
+        StreamRecord<IN> reuseRecord = reuse.f1;
+        reuseRecord.replace(value, timestamp);
+        reuse.f0 = bytes;
+        reuse.f1 = reuseRecord;
+        return reuse;
+    }
+
+    private int getKeyLength(DataInputView source) throws IOException {
+        final int length;
+        if (serializedKeyLength < 0) {
+            length = source.readInt();
+        } else {
+            length = serializedKeyLength;
+        }
+        return length;
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        final int length;
+        if (serializedKeyLength < 0) {
+            length = source.readInt();
+            target.writeInt(length);
+        } else {
+            length = serializedKeyLength;
+        }
+        for (int i = 0; i < length; i++) {
+            target.writeByte(source.readByte());
+        }
+        target.writeLong(source.readLong());
+        valueSerializer.copy(source, target);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KeyAndValueSerializer<?> that = (KeyAndValueSerializer<?>) o;
+        return Objects.equals(valueSerializer, that.valueSerializer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(valueSerializer);
+    }
+
+    @Override
+    public TypeSerializerSnapshot<Tuple2<byte[], StreamRecord<IN>>> snapshotConfiguration() {
+        throw new UnsupportedOperationException(
+                "The KeyAndValueSerializer should not be used for persisting into State!");
+    }
+}

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/sort/VariableLengthByteKeyComparator.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/sort/VariableLengthByteKeyComparator.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.common.datastream.sort;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.streaming.api.operators.sort.SortingDataInput;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * A comparator used in {@link SortingDataInput} which compares records keys and timestamps,. It
+ * uses binary format produced by the {@link KeyAndValueSerializer}.
+ *
+ * <p>It assumes keys are of a variable length and thus expects the length of the record to be
+ * serialized.
+ *
+ * <p>TODO: remove this class after making the corresponding class in Flink public.
+ */
+public final class VariableLengthByteKeyComparator<IN>
+        extends TypeComparator<Tuple2<byte[], StreamRecord<IN>>> {
+    private byte[] keyReference;
+    private long timestampReference;
+
+    @Override
+    public int hash(Tuple2<byte[], StreamRecord<IN>> record) {
+        return record.hashCode();
+    }
+
+    @Override
+    public void setReference(Tuple2<byte[], StreamRecord<IN>> toCompare) {
+        this.keyReference = Arrays.copyOf(toCompare.f0, toCompare.f0.length);
+        this.timestampReference = toCompare.f1.asRecord().getTimestamp();
+    }
+
+    @Override
+    public boolean equalToReference(Tuple2<byte[], StreamRecord<IN>> candidate) {
+        return Arrays.equals(keyReference, candidate.f0)
+                && timestampReference == candidate.f1.asRecord().getTimestamp();
+    }
+
+    @Override
+    public int compareToReference(
+            TypeComparator<Tuple2<byte[], StreamRecord<IN>>> referencedComparator) {
+        byte[] otherKey = ((VariableLengthByteKeyComparator<IN>) referencedComparator).keyReference;
+        long otherTimestamp =
+                ((VariableLengthByteKeyComparator<IN>) referencedComparator).timestampReference;
+
+        int keyCmp = compare(otherKey, this.keyReference);
+        if (keyCmp != 0) {
+            return keyCmp;
+        }
+        return Long.compare(otherTimestamp, this.timestampReference);
+    }
+
+    @Override
+    public int compare(
+            Tuple2<byte[], StreamRecord<IN>> first, Tuple2<byte[], StreamRecord<IN>> second) {
+        int keyCmp = compare(first.f0, second.f0);
+        if (keyCmp != 0) {
+            return keyCmp;
+        }
+        return Long.compare(
+                first.f1.asRecord().getTimestamp(), second.f1.asRecord().getTimestamp());
+    }
+
+    private int compare(byte[] first, byte[] second) {
+        int firstLength = first.length;
+        int secondLength = second.length;
+        int minLength = Math.min(firstLength, secondLength);
+        for (int i = 0; i < minLength; i++) {
+            int cmp = Byte.compare(first[i], second[i]);
+
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+
+        return Integer.compare(firstLength, secondLength);
+    }
+
+    @Override
+    public int compareSerialized(DataInputView firstSource, DataInputView secondSource)
+            throws IOException {
+        int firstLength = firstSource.readInt();
+        int secondLength = secondSource.readInt();
+        int minLength = Math.min(firstLength, secondLength);
+        while (minLength-- > 0) {
+            byte firstValue = firstSource.readByte();
+            byte secondValue = secondSource.readByte();
+
+            int cmp = Byte.compare(firstValue, secondValue);
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+
+        int lengthCompare = Integer.compare(firstLength, secondLength);
+        if (lengthCompare != 0) {
+            return lengthCompare;
+        } else {
+            return Long.compare(firstSource.readLong(), secondSource.readLong());
+        }
+    }
+
+    @Override
+    public boolean supportsNormalizedKey() {
+        return true;
+    }
+
+    @Override
+    public int getNormalizeKeyLen() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+        return true;
+    }
+
+    @Override
+    public void putNormalizedKey(
+            Tuple2<byte[], StreamRecord<IN>> record,
+            MemorySegment target,
+            int offset,
+            int numBytes) {
+        BytesKeyNormalizationUtil.putNormalizedKey(
+                record, record.f0.length, target, offset, numBytes);
+    }
+
+    @Override
+    public boolean invertNormalizedKey() {
+        return false;
+    }
+
+    @Override
+    public TypeComparator<Tuple2<byte[], StreamRecord<IN>>> duplicate() {
+        return new VariableLengthByteKeyComparator<>();
+    }
+
+    @Override
+    public int extractKeys(Object record, Object[] target, int index) {
+        target[index] = record;
+        return 1;
+    }
+
+    @Override
+    public TypeComparator<?>[] getFlatComparators() {
+        return new TypeComparator[] {this};
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // unsupported normalization
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public boolean supportsSerializationWithKeyNormalization() {
+        return false;
+    }
+
+    @Override
+    public void writeWithKeyNormalization(
+            Tuple2<byte[], StreamRecord<IN>> record, DataOutputView target) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Tuple2<byte[], StreamRecord<IN>> readWithKeyDenormalization(
+            Tuple2<byte[], StreamRecord<IN>> reuse, DataInputView source) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
@@ -160,7 +160,7 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
                                                     DenseVectorTypeInfo.INSTANCE)),
                                     new CentroidsUpdateAccumulator(distanceMeasure));
 
-            DataStreamUtils.setManagedMemoryWeight(centroidIdAndPoints.getTransformation(), 100);
+            DataStreamUtils.setManagedMemoryWeight(centroidIdAndPoints, 100);
 
             int parallelism = centroidIdAndPoints.getParallelism();
             DataStream<KMeansModelData> newModelData =


### PR DESCRIPTION
## What is the purpose of the change

Add util methods that allow algorithm developers to co-group two DataStreams with the same semantics and similar performance as `DataSet#coGroup(...)`

Here are the results of running the benchmark specified in FLINK-31753's JIRA description:
- DataSet#coGroup takes 27.6 seconds.
- DataStreamUtils#coGroup takes  31.5 seconds.

The DataStream is roughly 12.3% slower than DataSet. The performance difference should be negligible for real-word applications whose co-group function is non-trivial.

Notes: 
- The benchmark is run with Flink 1.18 snapshot.
- Most classes under the `sort` folder are copied from the corresponding classes in apache/flink. We can remove these classese from apache/flink-ml after making the corresponding classes in apache/flink public.

## Brief change log

Added the static method `DataStreamUtils#coGroup(...)`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs