### PR TITLE
[FLINK-31374] ProxyStreamPartitioner should implement ConfigurableStreamPartitioner

### DIFF
--- a/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/ProxyStreamPartitioner.java
+++ b/flink-ml-iteration/src/main/java/org/apache/flink/iteration/proxy/ProxyStreamPartitioner.java
@@ -24,6 +24,7 @@ import org.apache.flink.iteration.typeinfo.IterationRecordSerializer;
 import org.apache.flink.iteration.utils.ReflectionUtils;
 import org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.streaming.runtime.partitioner.ConfigurableStreamPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -31,7 +32,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import java.util.Objects;
 
 /** Proxy stream partitioner for the wrapped one. */
-public class ProxyStreamPartitioner<T> extends StreamPartitioner<IterationRecord<T>> {
+public class ProxyStreamPartitioner<T> extends StreamPartitioner<IterationRecord<T>>
+        implements ConfigurableStreamPartitioner {
 
     private final StreamPartitioner<T> wrappedStreamPartitioner;
 
@@ -97,5 +99,12 @@ public class ProxyStreamPartitioner<T> extends StreamPartitioner<IterationRecord
     @Override
     public String toString() {
         return wrappedStreamPartitioner.toString();
+    }
+
+    @Override
+    public void configure(int maxParallelism) {
+        if (wrappedStreamPartitioner instanceof ConfigurableStreamPartitioner) {
+            ((ConfigurableStreamPartitioner) wrappedStreamPartitioner).configure(maxParallelism);
+        }
     }
 }

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundStreamIterationITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedAllRoundStreamIterationITCase.java
@@ -167,6 +167,7 @@ public class BoundedAllRoundStreamIterationITCase extends TestLogger {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
         env.setParallelism(1);
+        env.setMaxParallelism(5);
         DataStream<EpochRecord> variableSource =
                 env.addSource(new DraftExecutionEnvironment.EmptySource<EpochRecord>() {})
                         .setParallelism(numSources)
@@ -231,6 +232,7 @@ public class BoundedAllRoundStreamIterationITCase extends TestLogger {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
         env.setParallelism(1);
+        env.setMaxParallelism(5);
         DataStream<EpochRecord> variableSource =
                 env.addSource(new DraftExecutionEnvironment.EmptySource<EpochRecord>() {})
                         .setParallelism(numSources)

--- a/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundStreamIterationITCase.java
+++ b/flink-ml-tests/src/test/java/org/apache/flink/test/iteration/BoundedPerRoundStreamIterationITCase.java
@@ -144,6 +144,7 @@ public class BoundedPerRoundStreamIterationITCase extends TestLogger {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
         env.setParallelism(1);
+        env.setMaxParallelism(5);
 
         DataStream<Integer> variableSource = env.fromElements(0);
         DataStream<Integer> constSource =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink ML - we are happy that you want to help us improve Flink ML. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to one [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] Title of the pull request`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Make the ProxyStreamPartitioner implement ConfigurableStreamPartitioner. Otherwise, the KeyGroupRange that is computed in StreamTaskStateInitializerImpl.java doesn't match the subTaskId that is computed in KeyGroupStreamPartitioner.java.

For more information, please refer to the [blog](https://flink.apache.org/2017/07/04/a-deep-dive-into-rescalable-state-in-apache-flink/).

## Brief change log

  - Make the ProxyStreamPartitioner implement ConfigurableStreamPartitioner.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
