### PR TITLE
[hotfix] Update pattern matching in test_ml_lib_completeness to work with release branch

### DIFF
--- a/flink-ml-python/pyflink/ml/tests/test_ml_lib_completeness.py
+++ b/flink-ml-python/pyflink/ml/tests/test_ml_lib_completeness.py
@@ -49,8 +49,12 @@ class MLLibTest(PyFlinkMLTestCase):
         FLINK_ML_LIB_SOURCE_PATH = os.path.abspath(os.path.join(
             this_directory, "../../../../flink-ml-lib"))
 
-        ml_lib_jar = glob.glob(os.path.join(
-            FLINK_ML_LIB_SOURCE_PATH, "target", "flink-ml-lib-*SNAPSHOT.jar"))[0]
+        paths = glob.glob(os.path.join(
+            FLINK_ML_LIB_SOURCE_PATH, "target", "flink-ml-lib-*.jar"))
+        paths = [path for path in paths if "test" not in path]
+        if len(paths) != 1:
+            raise Exception("The number of matched paths " + str(paths) + " is unexpected.")
+        ml_lib_jar = paths[0]
 
         StageAnalyzer = get_gateway().jvm.org.apache.flink.ml.util.StageAnalyzer
         module_path = 'org.apache.flink.ml.{0}'.format(self.module_name())


### PR DESCRIPTION
## What is the purpose of the change

For the non-release branch (e.g. master), `mvn package` will generate a jar file named like `flink-ml-lib-2.2-SNAPSHOT.jar`. For release branch, the Flink ML version in pom.xml will no longer include `snapshot` and the jar file will be named like `flink-ml-lib-2.2.jar`. And the method `MLLibTest#_load_java_stages` will fail due to this change.

This PR updates the pattern-matching logic in `MLLibTest#_load_java_stages` so that it will work with both release and non-release branches.


## Brief change log

Updated the pattern-matching logic in `MLLibTest#_load_java_stages`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable