### PR TITLE
[hotfix] Update quickstart to require a given Flink version

### DIFF
--- a/docs/content/docs/try-flink-ml/java/quick-start.md
+++ b/docs/content/docs/try-flink-ml/java/quick-start.md
@@ -50,8 +50,7 @@ $ java -version
 
 ## Download Flink
 
-[Download 1.17 or a higher version of
-Flink](https://flink.apache.org/downloads.html), then extract the archive:
+[Download Flink 1.17](https://flink.apache.org/downloads.html), then extract the archive:
 
 ```shell
 $ tar -xzf flink-*.tgz
@@ -141,3 +140,8 @@ Features: [9.0, 0.6]    Cluster ID: 1
 
 Now you have successfully run a Flink ML job.
 
+Finally, you can stop the Flink standalone cluster with the following command.
+
+```bash
+$FLINK_HOME/bin/stop-cluster.sh
+```

--- a/docs/content/docs/try-flink-ml/python/quick-start.md
+++ b/docs/content/docs/try-flink-ml/python/quick-start.md
@@ -248,8 +248,7 @@ $ java -version
 
 ### Download Flink
 
-[Download 1.17 or a higher version of
-Flink](https://flink.apache.org/downloads.html), then extract the archive:
+[Download Flink 1.17](https://flink.apache.org/downloads.html), then extract the archive:
 
 ```shell
 $ tar -xzf flink-*.tgz
@@ -339,4 +338,8 @@ detailed instructions to submit it to a Flink cluster can be found in [Job
 Submission
 Examples](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/cli/#submitting-pyflink-jobs).
 
+Finally, you can stop the Flink standalone cluster with the following command.
 
+```bash
+$FLINK_HOME/bin/stop-cluster.sh
+```


### PR DESCRIPTION
## What is the purpose of the change

Update the quickstart to require a given Flink version. This is because we can not guarantee that a given Flink ML version can work with multiple Flink versions.

## Brief change log

- Updated the quickstart to require Flink 1.17 rather than "Flink 1.17 or higher versions".
- Added instruction to stop Flink cluster in the quickstart.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs