### PR TITLE
[FLINK-32292] Fix TableUtils.getRowTypeInfo when the input contains Tuple

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/TableUtils.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/TableUtils.java
@@ -60,6 +60,7 @@ public class TableUtils {
         LOGICAL_TYPE_ROOTS_USING_EXTERNAL_TYPE_INFO.add(LogicalTypeRoot.MAP);
         LOGICAL_TYPE_ROOTS_USING_EXTERNAL_TYPE_INFO.add(LogicalTypeRoot.MULTISET);
         LOGICAL_TYPE_ROOTS_USING_EXTERNAL_TYPE_INFO.add(LogicalTypeRoot.ROW);
+        LOGICAL_TYPE_ROOTS_USING_EXTERNAL_TYPE_INFO.add(LogicalTypeRoot.STRUCTURED_TYPE);
     }
 
     // Constructs a RowTypeInfo from the given schema. Currently, this function does not support

--- a/flink-ml-core/src/test/java/org/apache/flink/ml/common/datastream/TableUtilsTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/ml/common/datastream/TableUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.ml.common.datastream;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.ml.linalg.DenseMatrix;
 import org.apache.flink.ml.linalg.DenseVector;
@@ -119,6 +120,12 @@ public class TableUtilsTest {
         dataFields.add(new SparseVector(2, new int[] {0}, new double[] {0.1}));
         preDefinedDataTypes.add(DataTypes.RAW(DenseMatrixTypeInfo.INSTANCE));
         dataFields.add(new DenseMatrix(2, 2));
+        preDefinedDataTypes.add(
+                DataTypes.STRUCTURED(
+                        Tuple2.class,
+                        DataTypes.FIELD("f0", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f1", DataTypes.BIGINT())));
+        dataFields.add(Tuple2.of(1L, 2L));
 
         Schema.Builder builder = Schema.newBuilder();
         for (int i = 0; i < preDefinedDataTypes.size(); i++) {


### PR DESCRIPTION
## What is the purpose of the change

Fix TableUtils.getRowTypeInfo when the input contains Tuple.

## Brief change log
  - Uses `ExternalTypeInfo.of(..)` when the input contains Tuples.
  - Adds unit test to cover the fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
