### PR TITLE
[hotfix] Update quick-start.md to correctly install Flink ML library jars

### DIFF
--- a/docs/content/docs/try-flink-ml/java/quick-start.md
+++ b/docs/content/docs/try-flink-ml/java/quick-start.md
@@ -50,7 +50,7 @@ $ java -version
 
 ## Download Flink
 
-[Download Flink 1.17](https://flink.apache.org/downloads.html), then extract the archive:
+Download [Flink 1.17](https://flink.apache.org/downloads.html), then extract the archive:
 
 ```shell
 $ tar -xzf flink-*.tgz
@@ -58,8 +58,7 @@ $ tar -xzf flink-*.tgz
 
 ## Set Up Flink Environment Variables
 
-After having downloaded Flink, please register `$FLINK_HOME` as an environment
-variable into your local environment.
+Run the following commands after having downloaded Flink:
 
 ```bash
 cd ${path_to_flink}
@@ -73,20 +72,13 @@ initialization.
 
 {{< stable >}}
 
-Please [download the correponding binary
-release](https://flink.apache.org/downloads.html) of Flink ML, then extract the
-archive:
+Please download [Flink ML Python
+source](https://flink.apache.org/downloads.html) and extract the jar files into
+Flink's library folder.
 
 ```shell
-tar -xzf flink-ml-*.tgz
-```
-
-Then you may copy the extracted library files to Flink's folder with the
-following commands.
-
-```shell
-cd ${path_to_flink_ml}
-cp ./lib/*.jar $FLINK_HOME/lib/
+tar -xzf apache-flink-ml*.tar.gz
+cp apache-flink-ml-*/deps/lib/* $FLINK_HOME/lib/
 ```
 
 {{< /stable >}} {{< unstable >}}

--- a/docs/content/docs/try-flink-ml/python/quick-start.md
+++ b/docs/content/docs/try-flink-ml/python/quick-start.md
@@ -248,19 +248,19 @@ $ java -version
 
 ### Download Flink
 
-[Download Flink 1.17](https://flink.apache.org/downloads.html), then extract the archive:
+Download [Flink 1.17](https://flink.apache.org/downloads.html), then extract the archive:
 
 ```shell
 $ tar -xzf flink-*.tgz
 ```
 
-### Set Up Flink Environment Variables
+### Set Up Flink Library and Environment Variables
 
-After having downloaded Flink, please register `$FLINK_HOME` as an environment
-variable into your local environment.
+Run the following commands after having downloaded Flink:
 
 ```bash
 cd ${path_to_flink}
+cp opt/flink-python* lib/
 export FLINK_HOME=`pwd`
 ```
 
@@ -271,26 +271,19 @@ initialization.
 
 {{< stable >}}
 
-Please [download the correponding binary
-release](https://flink.apache.org/downloads.html) of Flink ML, then extract the
-archive:
+Please download [Flink ML Python
+source](https://flink.apache.org/downloads.html) and extract the jar files into
+Flink's library folder.
 
 ```shell
-tar -xzf flink-ml-*.tgz
-```
-
-Then you may copy the extracted library files to Flink's folder with the
-following commands.
-
-```shell
-cd ${path_to_flink_ml}
-cp ./lib/*.jar $FLINK_HOME/lib/
+tar -xzf apache-flink-ml*.tar.gz
+cp apache-flink-ml-*/deps/lib/* $FLINK_HOME/lib/
 ```
 
 {{< /stable >}} {{< unstable >}}
 
 Given that you have followed this [guideline]({{< ref
-"docs/development/build-and-install#build-and-install-python-sdk" >}}), you
+"docs/development/build-and-install#build-and-install-java-sdk" >}}), you
 would have already built Flink ML's Java SDK. Now, you need to copy the
 generated library files to Flink's folder with the following commands.
 


### PR DESCRIPTION
## What is the purpose of the change

Prior to this PR, the quick-starts will not work for both Java and Python quick-starts because Flink library jars are not correctly loaded. This PR fixes the issue.


## Brief change log

Fixed Python and Java quick-starts.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable