### PR TITLE
[FLINK-32545] Improves the performance by optimizing row operations

### DIFF
--- a/flink-ml-benchmark/src/main/resources/elementwiseproduct-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/elementwiseproduct-benchmark.json
@@ -15,18 +15,18 @@
 
 {
   "version": 1,
-  "elementwiseproduct10000000": {
+  "elementwiseproduct100000000": {
     "inputData": {
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "vectorDim": 5,
         "colNames": [
           [
-            "featuresCol"
+            "input"
           ]
         ],
         "seed": 2,
-        "numValues": 10000000
+        "numValues": 100000000
       }
     },
     "stage": {

--- a/flink-ml-benchmark/src/main/resources/maxabsscaler-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/maxabsscaler-benchmark.json
@@ -22,7 +22,7 @@
         "vectorDim": 100,
         "colNames": [
           [
-            "featuresCol"
+            "input"
           ]
         ],
         "seed": 2,

--- a/flink-ml-benchmark/src/main/resources/normalizer-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/normalizer-benchmark.json
@@ -15,18 +15,18 @@
 
 {
   "version": 1,
-  "normalizer10000000": {
+  "normalizer100000000": {
     "inputData": {
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "vectorDim": 5,
         "colNames": [
           [
-            "featuresCol"
+            "input"
           ]
         ],
         "seed": 2,
-        "numValues": 10000000
+        "numValues": 100000000
       }
     },
     "stage": {

--- a/flink-ml-benchmark/src/main/resources/polynoimalexpansion-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/polynoimalexpansion-benchmark.json
@@ -15,18 +15,18 @@
 
 {
   "version": 1,
-  "polynoimalexpansion10000000": {
+  "polynoimalexpansion100000000": {
     "inputData": {
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "vectorDim": 5,
         "colNames": [
           [
-            "featuresCol"
+            "input"
           ]
         ],
         "seed": 2,
-        "numValues": 10000000
+        "numValues": 100000000
       }
     },
     "stage": {

--- a/flink-ml-benchmark/src/main/resources/vectorassembler-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/vectorassembler-benchmark.json
@@ -15,7 +15,7 @@
 
 {
   "version": 1,
-  "vectorassembler1000000": {
+  "vectorassembler10000000": {
     "inputData": {
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DoubleGenerator",
       "paramMap": {
@@ -39,7 +39,7 @@
           ]
         ],
         "seed": 2,
-        "numValues": 1000000
+        "numValues": 10000000
       }
     },
     "stage": {

--- a/flink-ml-benchmark/src/main/resources/vectorslicer-benchmark.json
+++ b/flink-ml-benchmark/src/main/resources/vectorslicer-benchmark.json
@@ -15,18 +15,18 @@
 
 {
   "version": 1,
-  "vectorslicer10000000": {
+  "vectorslicer100000000": {
     "inputData": {
       "className": "org.apache.flink.ml.benchmark.datagenerator.common.DenseVectorGenerator",
       "paramMap": {
         "vectorDim": 10,
         "colNames": [
           [
-            "featuresCol"
+            "input"
           ]
         ],
         "seed": 2,
-        "numValues": 10000000
+        "numValues": 100000000
       }
     },
     "stage": {

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/util/RowUtils.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/util/RowUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.util;
+
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+
+/** Utilities to deal with {@link Row} instances. */
+public class RowUtils {
+
+    /**
+     * Creates a new row with fields that are copied from the existing one, and reserves some empty
+     * fields for further writing. The {@link RowKind} of the first row determines the {@link
+     * RowKind} of the result.
+     *
+     * @param existing The existing row to be cloned.
+     * @param reservedFields Num of fields to be reserved.
+     */
+    public static Row cloneWithReservedFields(Row existing, int reservedFields) {
+        Row result = new Row(existing.getKind(), existing.getArity() + reservedFields);
+        for (int i = 0; i < existing.getArity(); i++) {
+            result.setField(i, existing.getField(i));
+        }
+        return result;
+    }
+
+    /**
+     * Creates a new row with fields that are copied from the existing one, and appends a new filed
+     * with the specific value.
+     *
+     * @param existing The existing row to be cloned.
+     * @param value The value to be appended.
+     */
+    public static Row append(Row existing, Object value) {
+        Row result = cloneWithReservedFields(existing, 1);
+        result.setField(existing.getArity(), value);
+        return result;
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/knn/KnnModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/knn/KnnModel.java
@@ -31,6 +31,7 @@ import org.apache.flink.ml.linalg.Vector;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -148,7 +149,7 @@ public class KnnModel implements Model<KnnModel>, KnnModelParams<KnnModel> {
             }
             DenseVector feature = ((Vector) row.getField(featureCol)).toDense();
             double prediction = predictLabel(feature);
-            return Row.join(row, Row.of(prediction));
+            return RowUtils.append(row, prediction);
         }
 
         private double predictLabel(DenseVector feature) {

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/LogisticRegressionModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/LogisticRegressionModel.java
@@ -31,6 +31,7 @@ import org.apache.flink.ml.linalg.Vector;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -157,7 +158,10 @@ public class LogisticRegressionModel
 
             Tuple2<Double, DenseVector> predictionResult = servable.transform(features);
 
-            return Row.join(dataPoint, Row.of(predictionResult.f0, predictionResult.f1));
+            Row result = RowUtils.cloneWithReservedFields(dataPoint, 2);
+            result.setField(dataPoint.getArity(), predictionResult.f0);
+            result.setField(dataPoint.getArity() + 1, predictionResult.f1);
+            return result;
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/naivebayes/NaiveBayesModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/naivebayes/NaiveBayesModel.java
@@ -31,6 +31,7 @@ import org.apache.flink.ml.linalg.Vector;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -148,7 +149,7 @@ public class NaiveBayesModel
             }
             Vector vector = (Vector) row.getField(featuresCol);
             double label = findMaxProbLabel(calculateProb(modelData, vector), modelData.labels);
-            return Row.join(row, Row.of(label));
+            return RowUtils.append(row, label);
         }
     }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/agglomerativeclustering/AgglomerativeClustering.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/agglomerativeclustering/AgglomerativeClustering.java
@@ -33,6 +33,7 @@ import org.apache.flink.ml.linalg.VectorWithNorm;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.windowing.ProcessAllWindowFunction;
@@ -263,7 +264,7 @@ public class AgglomerativeClustering
             }
 
             for (int i = 0; i < numDataPoints; i++) {
-                output.collect(Row.join(inputList.get(i), Row.of(clusterIds[i])));
+                output.collect(RowUtils.append(inputList.get(i), clusterIds[i]));
             }
 
             // Outputs the merge info.

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeansModel.java
@@ -32,6 +32,7 @@ import org.apache.flink.ml.linalg.VectorWithNorm;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -140,7 +141,7 @@ public class KMeansModel implements Model<KMeansModel>, KMeansModelParams<KMeans
             DenseVector point = ((Vector) dataPoint.getField(featuresCol)).toDense();
             int closestCentroidId =
                     distanceMeasure.findClosest(centroids, new VectorWithNorm(point));
-            return Row.join(dataPoint, Row.of(closestCentroidId));
+            return RowUtils.append(dataPoint, closestCentroidId);
         }
     }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeansModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/OnlineKMeansModel.java
@@ -32,6 +32,7 @@ import org.apache.flink.ml.linalg.VectorWithNorm;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -176,7 +177,7 @@ public class OnlineKMeansModel
             DenseVector point = ((Vector) dataPoint.getField(featuresCol)).toDense();
             int closestCentroidId =
                     distanceMeasure.findClosest(centroids, new VectorWithNorm(point));
-            output.collect(new StreamRecord<>(Row.join(dataPoint, Row.of(closestCentroidId))));
+            output.collect(new StreamRecord<>(RowUtils.append(dataPoint, closestCentroidId)));
         }
 
         @Override

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/binarizer/Binarizer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/binarizer/Binarizer.java
@@ -33,6 +33,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -111,11 +112,13 @@ public class Binarizer implements Transformer<Binarizer>, BinarizerParams<Binari
                 return null;
             }
 
-            Row result = new Row(inputCols.length);
+            Row result = RowUtils.cloneWithReservedFields(input, inputCols.length);
             for (int i = 0; i < inputCols.length; ++i) {
-                result.setField(i, binarizerFunc(input.getField(inputCols[i]), thresholds[i]));
+                result.setField(
+                        i + input.getArity(),
+                        binarizerFunc(input.getField(inputCols[i]), thresholds[i]));
             }
-            return Row.join(input, result);
+            return result;
         }
 
         private Object binarizerFunc(Object obj, double threshold) {

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/countvectorizer/CountVectorizerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/countvectorizer/CountVectorizerModel.java
@@ -29,6 +29,7 @@ import org.apache.flink.ml.linalg.typeinfo.SparseVectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -182,7 +183,7 @@ public class CountVectorizerModel
                             termCounts.length,
                             indices.stream().mapToInt(i -> i).toArray(),
                             values.stream().mapToDouble(i -> i).toArray());
-            return Row.join(row, Row.of(outputVec));
+            return RowUtils.append(row, outputVec);
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/dct/DCT.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/dct/DCT.java
@@ -29,6 +29,7 @@ import org.apache.flink.ml.linalg.typeinfo.DenseVectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -119,7 +120,7 @@ public class DCT implements Transformer<DCT>, DCTParams<DCT> {
 
             dctTransformer.accept(array, true);
 
-            return Row.join(row, Row.of(Vectors.dense(array)));
+            return RowUtils.append(row, Vectors.dense(array));
         }
     }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/elementwiseproduct/ElementwiseProduct.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/elementwiseproduct/ElementwiseProduct.java
@@ -28,6 +28,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -98,9 +99,9 @@ public class ElementwiseProduct
                 }
                 Vector retVec = inputVec.clone();
                 BLAS.hDot(scalingVec, retVec);
-                return Row.join(value, Row.of(retVec));
+                return RowUtils.append(value, retVec);
             } else {
-                return Row.join(value, Row.of((Object) null));
+                return RowUtils.append(value, null);
             }
         }
     }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/featurehasher/FeatureHasher.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/featurehasher/FeatureHasher.java
@@ -27,6 +27,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
@@ -137,7 +138,7 @@ public class FeatureHasher
                 values[pos] = entry.getValue();
                 pos++;
             }
-            return Row.join(row, Row.of(new SparseVector(numFeatures, indices, values)));
+            return RowUtils.append(row, new SparseVector(numFeatures, indices, values));
         }
     }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/hashingtf/HashingTF.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/hashingtf/HashingTF.java
@@ -27,6 +27,7 @@ import org.apache.flink.ml.linalg.typeinfo.SparseVectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -153,7 +154,7 @@ public class HashingTF implements Transformer<HashingTF>, HashingTFParams<Hashin
                 values[idx] = entry.getValue();
                 idx++;
             }
-            return Row.join(row, Row.of(Vectors.sparse(numFeatures, indices, values)));
+            return RowUtils.append(row, Vectors.sparse(numFeatures, indices, values));
         }
     }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/idf/IDFModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/idf/IDFModel.java
@@ -29,6 +29,7 @@ import org.apache.flink.ml.linalg.Vector;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -143,7 +144,7 @@ public class IDFModel implements Model<IDFModel>, IDFModelParams<IDFModel> {
 
             Vector outputVec = ((Vector) Objects.requireNonNull(row.getField(inputCol))).clone();
             BLAS.hDot(idf, outputVec);
-            return Row.join(row, Row.of(outputVec));
+            return RowUtils.append(row, outputVec);
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/imputer/ImputerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/imputer/ImputerModel.java
@@ -28,6 +28,7 @@ import org.apache.flink.ml.common.datastream.TableUtils;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -153,18 +154,18 @@ public class ImputerModel implements Model<ImputerModel>, ImputerModelParams<Imp
                                                 col));
             }
 
-            Row outputRow = new Row(inputCols.length);
+            Row result = RowUtils.cloneWithReservedFields(row, inputCols.length);
             for (int i = 0; i < inputCols.length; i++) {
                 Object value = row.getField(i);
                 if (value == null || Double.valueOf(value.toString()).equals(missingValue)) {
                     double surrogate = surrogates.get(inputCols[i]);
-                    outputRow.setField(i, surrogate);
+                    result.setField(i + row.getArity(), surrogate);
                 } else {
-                    outputRow.setField(i, Double.valueOf(value.toString()));
+                    result.setField(i + row.getArity(), Double.valueOf(value.toString()));
                 }
             }
 
-            return Row.join(row, outputRow);
+            return result;
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/interaction/Interaction.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/interaction/Interaction.java
@@ -30,6 +30,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -101,7 +102,7 @@ public class Interaction implements Transformer<Interaction>, InteractionParams<
             for (int i = 0; i < inputCols.length; ++i) {
                 Object obj = value.getField(inputCols[i]);
                 if (obj == null) {
-                    return Row.join(value, Row.of((Object) null));
+                    return RowUtils.append(value, null);
                 }
 
                 if (obj instanceof DenseVector) {
@@ -173,7 +174,7 @@ public class Interaction implements Transformer<Interaction>, InteractionParams<
                 ret = new DenseVector(values);
             }
 
-            return Row.join(value, Row.of(ret));
+            return RowUtils.append(value, ret);
         }
     }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/kbinsdiscretizer/KBinsDiscretizerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/kbinsdiscretizer/KBinsDiscretizerModel.java
@@ -29,6 +29,7 @@ import org.apache.flink.ml.linalg.Vector;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -166,7 +167,7 @@ public class KBinsDiscretizerModel
 
                 outputVec.set(i, index);
             }
-            return Row.join(row, Row.of(outputVec));
+            return RowUtils.append(row, outputVec);
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/maxabsscaler/MaxAbsScalerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/maxabsscaler/MaxAbsScalerModel.java
@@ -30,6 +30,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -159,7 +160,7 @@ public class MaxAbsScalerModel
             Vector inputVec = row.getFieldAs(inputCol);
             Vector outputVec = inputVec.clone();
             BLAS.hDot(scaleVector, outputVec);
-            return Row.join(row, Row.of(outputVec));
+            return RowUtils.append(row, outputVec);
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/minmaxscaler/MinMaxScalerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/minmaxscaler/MinMaxScalerModel.java
@@ -29,6 +29,7 @@ import org.apache.flink.ml.linalg.Vector;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -171,7 +172,7 @@ public class MinMaxScalerModel
                 outputVec.values[i] =
                         inputVec.values[i] * scaleVector.values[i] + offsetVector.values[i];
             }
-            return Row.join(row, Row.of(outputVec));
+            return RowUtils.append(row, outputVec);
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/normalizer/Normalizer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/normalizer/Normalizer.java
@@ -28,6 +28,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -99,7 +100,7 @@ public class Normalizer implements Transformer<Normalizer>, NormalizerParams<Nor
             Vector outputVec = inputVec.clone();
             double norm = BLAS.norm(inputVec, p);
             BLAS.scal(1.0 / norm, outputVec);
-            return Row.join(row, Row.of(outputVec));
+            return RowUtils.append(row, outputVec);
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoderModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/onehotencoder/OneHotEncoderModel.java
@@ -31,6 +31,7 @@ import org.apache.flink.ml.linalg.typeinfo.SparseVectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -167,7 +168,7 @@ public class OneHotEncoderModel
             for (Tuple2<Integer, Integer> tup : model) {
                 categorySizes[tup.f0] = tup.f1 + offset;
             }
-            Row result = new Row(categorySizes.length);
+            Row result = RowUtils.cloneWithReservedFields(row, categorySizes.length);
             for (int i = 0; i < categorySizes.length; i++) {
                 Number number = (Number) row.getField(inputCols[i]);
                 Preconditions.checkArgument(
@@ -175,15 +176,17 @@ public class OneHotEncoderModel
                         String.format("Value %s cannot be parsed as indexed integer.", number));
                 int idx = number.intValue();
                 if (idx == categorySizes[i]) {
-                    result.setField(i, Vectors.sparse(categorySizes[i], new int[0], new double[0]));
+                    result.setField(
+                            i + row.getArity(),
+                            Vectors.sparse(categorySizes[i], new int[0], new double[0]));
                 } else {
                     result.setField(
-                            i,
+                            i + row.getArity(),
                             Vectors.sparse(categorySizes[i], new int[] {idx}, new double[] {1.0}));
                 }
             }
 
-            return Row.join(row, result);
+            return result;
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/polynomialexpansion/PolynomialExpansion.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/polynomialexpansion/PolynomialExpansion.java
@@ -30,6 +30,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -166,7 +167,7 @@ public class PolynomialExpansion
                 throw new UnsupportedOperationException(
                         "Only supports DenseVector or SparseVector.");
             }
-            return Row.join(row, Row.of(outputVec));
+            return RowUtils.append(row, outputVec);
         }
 
         /** Calculates the length of the expended vector. */

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/robustscaler/RobustScalerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/robustscaler/RobustScalerModel.java
@@ -30,6 +30,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -138,7 +139,7 @@ public class RobustScalerModel
             if (withScaling) {
                 BLAS.hDot(scales, outputVec);
             }
-            return Row.join(row, Row.of(outputVec));
+            return RowUtils.append(row, outputVec);
         }
     }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/OnlineStandardScalerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/OnlineStandardScalerModel.java
@@ -36,6 +36,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -276,13 +277,13 @@ public class OnlineStandardScalerModel
             if (modelVersionCol == null) {
                 output.collect(
                         new StreamRecord<>(
-                                Row.join(dataPoint, Row.of(outputVec)),
+                                RowUtils.append(dataPoint, outputVec),
                                 streamRecord.getTimestamp()));
             } else {
-                output.collect(
-                        new StreamRecord<>(
-                                Row.join(dataPoint, Row.of(outputVec, modelVersion)),
-                                streamRecord.getTimestamp()));
+                Row result = RowUtils.cloneWithReservedFields(dataPoint, 2);
+                result.setField(dataPoint.getArity(), outputVec);
+                result.setField(dataPoint.getArity() + 1, modelVersion);
+                output.collect(new StreamRecord<>(result, streamRecord.getTimestamp()));
             }
         }
     }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/standardscaler/StandardScalerModel.java
@@ -30,6 +30,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -134,7 +135,7 @@ public class StandardScalerModel
                 BLAS.hDot(scale, outputVec);
             }
 
-            return Row.join(dataPoint, Row.of(outputVec));
+            return RowUtils.append(dataPoint, outputVec);
         }
     }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/IndexToStringModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/stringindexer/IndexToStringModel.java
@@ -28,6 +28,7 @@ import org.apache.flink.ml.common.datastream.TableUtils;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -146,18 +147,18 @@ public class IndexToStringModel
                 stringArrays = modelData.stringArrays;
             }
 
-            Row outputStrings = new Row(inputCols.length);
+            Row result = RowUtils.cloneWithReservedFields(input, inputCols.length);
             for (int i = 0; i < inputCols.length; i++) {
                 int stringId = (Integer) input.getField(inputCols[i]);
                 if (stringId < stringArrays[i].length && stringId >= 0) {
-                    outputStrings.setField(i, stringArrays[i][stringId]);
+                    result.setField(i + input.getArity(), stringArrays[i][stringId]);
                 } else {
                     throw new RuntimeException(
                             "The input contains unseen index: " + stringId + ".");
                 }
             }
 
-            out.collect(Row.join(input, outputStrings));
+            out.collect(result);
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/univariatefeatureselector/UnivariateFeatureSelectorModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/univariatefeatureselector/UnivariateFeatureSelectorModel.java
@@ -30,6 +30,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -125,7 +126,7 @@ public class UnivariateFeatureSelectorModel
             }
 
             if (indices.length == 0) {
-                return Row.join(row, Row.of(Vectors.dense()));
+                return RowUtils.append(row, Vectors.dense());
             } else {
                 Vector inputVec = ((Vector) row.getField(inputCol));
                 Preconditions.checkArgument(
@@ -135,7 +136,7 @@ public class UnivariateFeatureSelectorModel
                         inputVec.size(),
                         indices[indices.length - 1] + 1);
                 Vector outputVec = VectorUtils.selectByIndices(inputVec, indices);
-                return Row.join(row, Row.of(outputVec));
+                return RowUtils.append(row, outputVec);
             }
         }
     }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/variancethresholdselector/VarianceThresholdSelectorModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/variancethresholdselector/VarianceThresholdSelectorModel.java
@@ -30,6 +30,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -160,10 +161,10 @@ public class VarianceThresholdSelectorModel
                     inputVec.size(),
                     expectedNumOfFeatures);
             if (indices.length == 0) {
-                return Row.join(row, Row.of(Vectors.dense()));
+                return RowUtils.append(row, Vectors.dense());
             } else {
                 Vector outputVec = VectorUtils.selectByIndices(inputVec, indices);
-                return Row.join(row, Row.of(outputVec));
+                return RowUtils.append(row, outputVec);
             }
         }
     }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssembler.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorassembler/VectorAssembler.java
@@ -32,6 +32,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -116,7 +117,7 @@ public class VectorAssembler
                         nnz * RATIO > vectorSize
                                 ? assembleDense(inputCols, value, vectorSize)
                                 : assembleSparse(inputCols, value, vectorSize, nnz);
-                out.collect(Row.join(value, Row.of(assembledVec)));
+                out.collect(RowUtils.append(value, assembledVec));
             } catch (Exception e) {
                 if (handleInvalid.equals(ERROR_INVALID)) {
                     throw new RuntimeException("Vector assembler failed with exception : " + e);

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorindexer/VectorIndexerModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorindexer/VectorIndexerModel.java
@@ -29,6 +29,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -162,7 +163,7 @@ public class VectorIndexerModel
                 }
             }
 
-            out.collect(Row.join(input, Row.of(outputVector)));
+            out.collect(RowUtils.append(input, outputVector));
         }
     }
 

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorslicer/VectorSlicer.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/feature/vectorslicer/VectorSlicer.java
@@ -29,6 +29,7 @@ import org.apache.flink.ml.linalg.typeinfo.VectorTypeInfo;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -142,7 +143,7 @@ public class VectorSlicer implements Transformer<VectorSlicer>, VectorSlicerPara
                 }
                 outputVec = new SparseVector(indices.length, outputIndices, outputValues);
             }
-            return Row.join(row, Row.of(outputVec));
+            return RowUtils.append(row, outputVec);
         }
     }
 }

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/regression/linearregression/LinearRegressionModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/regression/linearregression/LinearRegressionModel.java
@@ -30,6 +30,7 @@ import org.apache.flink.ml.linalg.Vector;
 import org.apache.flink.ml.param.Param;
 import org.apache.flink.ml.util.ParamUtils;
 import org.apache.flink.ml.util.ReadWriteUtils;
+import org.apache.flink.ml.util.RowUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -143,8 +144,8 @@ public class LinearRegressionModel
                 coefficient = modelData.coefficient;
             }
             DenseVector features = ((Vector) dataPoint.getField(featuresCol)).toDense();
-            Row predictionResult = predictOneDataPoint(features, coefficient);
-            return Row.join(dataPoint, predictionResult);
+            double predictionResult = predictOneDataPoint(features, coefficient);
+            return RowUtils.append(dataPoint, predictionResult);
         }
     }
 
@@ -155,7 +156,7 @@ public class LinearRegressionModel
      * @param coefficient The model parameters.
      * @return The prediction label and the raw probabilities.
      */
-    private static Row predictOneDataPoint(DenseVector feature, DenseVector coefficient) {
-        return Row.of(BLAS.dot(feature, coefficient));
+    private static double predictOneDataPoint(DenseVector feature, DenseVector coefficient) {
+        return BLAS.dot(feature, coefficient);
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink ML - we are happy that you want to help us improve Flink ML. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to one [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] Title of the pull request`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Improves the performance by optimizing row operations.

Here is a performance comparison of some algorithms before and after optimization using `flink-ml-benchmark` by analyzing the seconds that each algorithm costs on average. We can see that for these algorithms, the time consumption is reduced by about 10%-25%.

|    | Before  | After  | 
|  ----  | ----  | ----  |
| Bucketizer | 48.481 | 38.185 |
| ElementWiseProduct | 43.437 | 31.094 |
| Normalizer | 55.811 | 44.629 |
| PolynomialExpansion | 72.050 | 65.050 |
| VectorSlicer | 40.515 | 31.186 |

For the other 31 algorithms, their benchmarks are configured with a small dataset, however, the optimization effect is positively correlated with dataset size, so they are of the same performance as the original on my workstation.

## Brief change log

  - Adds RowUtils to help with Row operations.
  - Replaces all Row.join() function call with new utility.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
