### PR TITLE
[FLINK-32810] Improve memory allocation in ListStateWithCache

### DIFF
--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/DataStreamUtils.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/DataStreamUtils.java
@@ -486,7 +486,7 @@ public class DataStreamUtils {
         public void initializeState(StateInitializationContext context) throws Exception {
             super.initializeState(context);
 
-            StreamTask<?, ?> containingTask = getContainingTask();
+            final StreamTask<?, ?> containingTask = getContainingTask();
             final OperatorID operatorID = config.getOperatorID();
             final OperatorScopeManagedMemoryManager manager =
                     OperatorScopeManagedMemoryManager.getOrCreate(containingTask, operatorID);
@@ -496,10 +496,8 @@ public class DataStreamUtils {
                     new ListStateWithCache<>(
                             getOperatorConfig().getTypeSerializerIn(0, getClass().getClassLoader()),
                             stateKey,
-                            containingTask,
-                            getRuntimeContext(),
                             context,
-                            operatorID);
+                            this);
         }
 
         @Override

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/DataStreamUtils.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/DataStreamUtils.java
@@ -74,6 +74,7 @@ import org.apache.flink.streaming.api.windowing.windows.GlobalWindow;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.util.Collector;
 
@@ -485,16 +486,17 @@ public class DataStreamUtils {
         public void initializeState(StateInitializationContext context) throws Exception {
             super.initializeState(context);
 
+            StreamTask<?, ?> containingTask = getContainingTask();
             final OperatorID operatorID = config.getOperatorID();
             final OperatorScopeManagedMemoryManager manager =
-                    OperatorScopeManagedMemoryManager.getOrCreate(operatorID);
+                    OperatorScopeManagedMemoryManager.getOrCreate(containingTask, operatorID);
             final String stateKey = "values-state";
             manager.register(stateKey, 1.);
             valuesState =
                     new ListStateWithCache<>(
                             getOperatorConfig().getTypeSerializerIn(0, getClass().getClassLoader()),
                             stateKey,
-                            getContainingTask(),
+                            containingTask,
                             getRuntimeContext(),
                             context,
                             operatorID);

--- a/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/DataStreamUtils.java
+++ b/flink-ml-core/src/main/java/org/apache/flink/ml/common/datastream/DataStreamUtils.java
@@ -38,6 +38,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.iteration.datacache.nonkeyed.ListStateWithCache;
+import org.apache.flink.iteration.datacache.nonkeyed.OperatorScopeManagedMemoryManager;
 import org.apache.flink.iteration.operator.OperatorStateUtils;
 import org.apache.flink.ml.common.datastream.sort.CoGroupOperator;
 import org.apache.flink.ml.common.window.CountTumblingWindows;
@@ -483,9 +484,13 @@ public class DataStreamUtils {
         public void initializeState(StateInitializationContext context) throws Exception {
             super.initializeState(context);
 
+            OperatorScopeManagedMemoryManager manager = new OperatorScopeManagedMemoryManager();
+            manager.register("values-state", 1.);
             valuesState =
                     new ListStateWithCache<>(
                             getOperatorConfig().getTypeSerializerIn(0, getClass().getClassLoader()),
+                            manager,
+                            "values-state",
                             getContainingTask(),
                             getRuntimeContext(),
                             context,

--- a/flink-ml-core/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCacheTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCacheTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.ml.common.datastream.DataStreamUtils;
+import org.apache.flink.ml.util.TestUtils;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.memory.MemoryReservationException;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorStateHandler;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
+
+/** Tests {@link ListStateWithCache}. */
+public class ListStateWithCacheTest {
+
+    @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private MiniClusterConfiguration createMiniClusterConfiguration() {
+        Configuration configuration = new Configuration();
+        // Set managed memory size to a small value, so when the instance of ListStateWithCache
+        // tries to allocate memory, it will use up all managed memory assigned to itself.
+        configuration.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.ofMebiBytes(16));
+        configuration.set(RestOptions.PORT, 18082);
+        configuration.set(
+                ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        return new MiniClusterConfiguration.Builder()
+                .setConfiguration(configuration)
+                .setNumTaskManagers(1)
+                .setNumSlotsPerTaskManager(1)
+                .build();
+    }
+
+    @Test
+    public void testCorrectMemorySubFraction() throws Exception {
+        try (MiniCluster miniCluster = new MiniCluster(createMiniClusterConfiguration())) {
+            miniCluster.start();
+            JobGraph jobGraph = getJobGraph(2, 1. / 2);
+            miniCluster.executeJobBlocking(jobGraph);
+        }
+    }
+
+    @Test
+    public void testIncorrectMemorySubFraction() {
+        try (MiniCluster miniCluster = new MiniCluster(createMiniClusterConfiguration())) {
+            miniCluster.start();
+            JobGraph jobGraph = getJobGraph(2, 0.6);
+            miniCluster.executeJobBlocking(jobGraph);
+        } catch (Exception e) {
+            Throwable rootCause = ExceptionUtils.getRootCause(e);
+            Assert.assertEquals(MemoryReservationException.class, rootCause.getClass());
+        }
+    }
+
+    private JobGraph getJobGraph(int times, double memorySubFraction) {
+        Configuration configuration = new Configuration();
+        StreamExecutionEnvironment env = TestUtils.getExecutionEnvironment(configuration);
+        env.setParallelism(1);
+
+        final int n = 10;
+        DataStream<String> data =
+                env.fromSequence(1, n).map(d -> RandomStringUtils.randomAlphabetic(1024 * 1024));
+        DataStream<Integer> counter =
+                data.transform("cache", Types.INT, new CacheDataOperator(times, memorySubFraction));
+        DataStreamUtils.setManagedMemoryWeight(counter, 100);
+        counter.addSink(
+                new SinkFunction<Integer>() {
+                    @Override
+                    public void invoke(Integer value, Context context) throws Exception {
+                        Assert.assertEquals((Integer) (n * times), value);
+                        SinkFunction.super.invoke(value, context);
+                    }
+                });
+        return env.getStreamGraph().getJobGraph();
+    }
+
+    private static class CacheDataOperator extends AbstractStreamOperator<Integer>
+            implements OneInputStreamOperator<String, Integer>,
+                    BoundedOneInput,
+                    StreamOperatorStateHandler.CheckpointedStreamOperator {
+
+        private final int times;
+        private final double memorySubFraction;
+        private transient ListStateWithCache<String>[] cached;
+
+        public CacheDataOperator(int times, double memorySubFraction) {
+            this.times = times;
+            this.memorySubFraction = memorySubFraction;
+        }
+
+        @Override
+        public void processElement(StreamRecord<String> element) throws Exception {
+            for (int i = 0; i < times; i += 1) {
+                cached[i].add(element.getValue());
+            }
+        }
+
+        @Override
+        public void endInput() throws Exception {
+            int counter = 0;
+            for (int i = 0; i < times; i += 1) {
+                for (String ignored : cached[i].get()) {
+                    counter += 1;
+                }
+                cached[i].clear();
+            }
+            output.collect(new StreamRecord<>(counter));
+        }
+
+        @Override
+        public void initializeState(StateInitializationContext context) throws Exception {
+            //noinspection unchecked
+            cached = new ListStateWithCache[times];
+            for (int i = 0; i < times; i += 1) {
+                cached[i] =
+                        new ListStateWithCache<>(
+                                StringSerializer.INSTANCE,
+                                getContainingTask(),
+                                getRuntimeContext(),
+                                context,
+                                getOperatorID(),
+                                memorySubFraction);
+            }
+        }
+
+        @Override
+        public void snapshotState(StateSnapshotContext context) throws Exception {
+            super.snapshotState(context);
+        }
+    }
+}

--- a/flink-ml-core/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCacheTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCacheTest.java
@@ -41,11 +41,11 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorStateHandler;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.Random;
 

--- a/flink-ml-core/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCacheTest.java
+++ b/flink-ml-core/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCacheTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.ml.common.datastream.DataStreamUtils;
 import org.apache.flink.ml.util.TestUtils;
@@ -59,7 +58,6 @@ public class ListStateWithCacheTest {
         // Set managed memory size to a small value, so when the instance of ListStateWithCache
         // tries to allocate memory, it will use up all managed memory assigned to itself.
         configuration.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.ofMebiBytes(16));
-        configuration.set(RestOptions.PORT, 18082);
         configuration.set(
                 ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
         return new MiniClusterConfiguration.Builder()

--- a/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCache.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCache.java
@@ -96,7 +96,7 @@ public class ListStateWithCache<T> implements ListState<T> {
             OperatorScopeManagedMemoryManager manager =
                     OperatorScopeManagedMemoryManager.getOrCreate(operatorID);
             double memorySubFraction = manager.getFraction(key);
-            if (fraction * memorySubFraction > 0) {
+            if (memorySubFraction > 0) {
                 MemoryManager memoryManager = containingTask.getEnvironment().getMemoryManager();
                 segmentPool =
                         new LazyMemorySegmentPool(

--- a/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCache.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/ListStateWithCache.java
@@ -94,7 +94,7 @@ public class ListStateWithCache<T> implements ListState<T> {
                                 runtimeContext.getUserCodeClassLoader());
         if (fraction > 0) {
             OperatorScopeManagedMemoryManager manager =
-                    OperatorScopeManagedMemoryManager.getOrCreate(operatorID);
+                    OperatorScopeManagedMemoryManager.getOrCreate(containingTask, operatorID);
             double memorySubFraction = manager.getFraction(key);
             if (memorySubFraction > 0) {
                 MemoryManager memoryManager = containingTask.getEnvironment().getMemoryManager();

--- a/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManager.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManager.java
@@ -45,25 +45,25 @@ public class OperatorScopeManagedMemoryManager {
 
     /**
      * Stores instances corresponding to operators. The instance is expected to be released after
-     * some point after the corresponding operator ID is unused.
+     * some point after the corresponding task and operator ID are garbage-collected.
      */
     private static final Map<
                     Tuple2<StreamTask<?, ?>, OperatorID>, OperatorScopeManagedMemoryManager>
             managers = Collections.synchronizedMap(new WeakHashMap<>());
 
     /** Stores keys and weights of memory usages. */
-    protected Map<String, Double> weights = new HashMap<>();
+    private final Map<String, Double> weights = new HashMap<>();
     /** Indicates whether the `weights` is frozen. */
-    protected boolean frozen = false;
+    private boolean frozen = false;
     /** Stores sum of weights of all usages. */
-    protected double sum;
+    private double sum;
 
     private OperatorScopeManagedMemoryManager() {}
 
     /**
-     * Gets or creates an instance identified by the operator ID.
+     * Gets or creates an instance identified by the containing task and operator ID.
      *
-     * @param containingTask The container task.
+     * @param containingTask The containing task.
      * @param operatorID The operator ID.
      * @return An instance of {@link OperatorScopeManagedMemoryManager}.
      */

--- a/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManager.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManager.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A manager for operator-scope managed memory.
+ *
+ * <p>Every operator must create one (and only one) instance of this class to manage usages of
+ * operator-scope managed memery. In the operator, for every usage, {@link #register} is called to
+ * declare its weight of memory usage with a key. Then, the fraction of memory can be obtained by
+ * calling {@link #getFraction}.
+ *
+ * <p>Note that all calls of {@link #register} must be before those of {@link #getFraction}.
+ */
+public class OperatorScopeManagedMemoryManager {
+
+    protected Map<String, Double> weights = new HashMap<>();
+    protected boolean frozen = false;
+    protected double sum;
+
+    public void register(String key, double weight) {
+        Preconditions.checkState(!frozen, "Cannot call register after getFraction is called.");
+        Preconditions.checkArgument(weight >= 0, "The weight must be non-negative.");
+        weights.put(key, weight);
+    }
+
+    public double getFraction(String key) {
+        Preconditions.checkArgument(weights.containsKey(key));
+        if (!frozen) {
+            frozen = true;
+            sum = weights.values().stream().mapToDouble(d -> d).sum();
+        }
+        return sum > 0 ? weights.get(key) / sum : 0;
+    }
+}

--- a/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManager.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManager.java
@@ -55,7 +55,7 @@ public class OperatorScopeManagedMemoryManager {
     /** Stores sum of weights of all usages. */
     protected double sum;
 
-    OperatorScopeManagedMemoryManager() {}
+    private OperatorScopeManagedMemoryManager() {}
 
     /**
      * Gets or creates an instance identified by the operator ID.

--- a/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManager.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManager.java
@@ -18,33 +18,75 @@
 
 package org.apache.flink.iteration.datacache.nonkeyed;
 
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.util.Preconditions;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * A manager for operator-scope managed memory.
  *
- * <p>Every operator must create one (and only one) instance of this class to manage usages of
- * operator-scope managed memery. In the operator, for every usage, {@link #register} is called to
- * declare its weight of memory usage with a key. Then, the fraction of memory can be obtained by
- * calling {@link #getFraction}.
+ * <p>Every operator must call {@link #getOrCreate} to get an instance to manage usages of
+ * operator-scope managed memory.
  *
- * <p>Note that all calls of {@link #register} must be before those of {@link #getFraction}.
+ * <p>In the operator, for every usage of operator-scope managed memory, {@link #register} is called
+ * to declare its weight of memory usage with a key. Then, the fraction of memory can be obtained by
+ * calling {@link #getFraction}. Note that all calls of {@link #register} must be before those of
+ * {@link #getFraction}.
  */
+@PublicEvolving
 public class OperatorScopeManagedMemoryManager {
 
+    /**
+     * Stores instances corresponding to operators. The instance is expected to be released after
+     * some point after the corresponding operator ID is unused.
+     */
+    private static final Map<OperatorID, OperatorScopeManagedMemoryManager> managers =
+            Collections.synchronizedMap(new WeakHashMap<>());
+
+    /** Stores keys and weights of memory usages. */
     protected Map<String, Double> weights = new HashMap<>();
+    /** Indicates whether the `weights` is frozen. */
     protected boolean frozen = false;
+    /** Stores sum of weights of all usages. */
     protected double sum;
 
+    OperatorScopeManagedMemoryManager() {}
+
+    /**
+     * Gets or creates an instance identified by the operator ID.
+     *
+     * @param operatorID The operator ID.
+     * @return An instance of {@link OperatorScopeManagedMemoryManager}.
+     */
+    public static OperatorScopeManagedMemoryManager getOrCreate(OperatorID operatorID) {
+        return managers.computeIfAbsent(
+                operatorID, (key) -> new OperatorScopeManagedMemoryManager());
+    }
+
+    /**
+     * Registers a usage of operator-scope managed memory with memory weight declared.
+     *
+     * @param key The key to identify the usage.
+     * @param weight The weight of memory usage.
+     */
     public void register(String key, double weight) {
         Preconditions.checkState(!frozen, "Cannot call register after getFraction is called.");
+        Preconditions.checkState(!weights.containsKey(key), "Cannot set a same key {} twice.", key);
         Preconditions.checkArgument(weight >= 0, "The weight must be non-negative.");
         weights.put(key, weight);
     }
 
+    /**
+     * Gets the fraction of operator-scope managed memory for the usage.
+     *
+     * @param key The key to identify the usage.
+     * @return The fraction.
+     */
     public double getFraction(String key) {
         Preconditions.checkArgument(weights.containsKey(key));
         if (!frozen) {

--- a/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManagerTest.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManagerTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.iteration.datacache.nonkeyed;
 
+import org.apache.flink.runtime.jobgraph.OperatorID;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,7 +31,9 @@ public class OperatorScopeManagedMemoryManagerTest {
 
     @Test
     public void testUsage() {
-        OperatorScopeManagedMemoryManager manager = new OperatorScopeManagedMemoryManager();
+        OperatorID operatorID = new OperatorID();
+        OperatorScopeManagedMemoryManager manager =
+                OperatorScopeManagedMemoryManager.getOrCreate(operatorID);
         manager.register("state-1", 100);
         manager.register("state-2", 400);
         Assert.assertEquals(manager.getFraction("state-1"), 0.2, EPS);
@@ -38,7 +42,9 @@ public class OperatorScopeManagedMemoryManagerTest {
 
     @Test
     public void testZeroUsage() {
-        OperatorScopeManagedMemoryManager manager = new OperatorScopeManagedMemoryManager();
+        OperatorID operatorID = new OperatorID();
+        OperatorScopeManagedMemoryManager manager =
+                OperatorScopeManagedMemoryManager.getOrCreate(operatorID);
         manager.register("state-1", 0);
         manager.register("state-2", 0);
         Assert.assertEquals(manager.getFraction("state-1"), 0, EPS);
@@ -47,7 +53,9 @@ public class OperatorScopeManagedMemoryManagerTest {
 
     @Test
     public void testInvalidUsage() {
-        OperatorScopeManagedMemoryManager manager = new OperatorScopeManagedMemoryManager();
+        OperatorID operatorID = new OperatorID();
+        OperatorScopeManagedMemoryManager manager =
+                OperatorScopeManagedMemoryManager.getOrCreate(operatorID);
         try {
             manager.register("state-1", 100);
             Assert.assertEquals(manager.getFraction("state-1"), 1., EPS);

--- a/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManagerTest.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManagerTest.java
@@ -77,8 +77,7 @@ public class OperatorScopeManagedMemoryManagerTest {
             manager.register("state-1", 100);
             Assert.assertEquals(manager.getFraction("state-1"), 1., EPS);
             manager.register("state-2", 400);
-            Assert.assertEquals(manager.getFraction("state-2"), 0.8, EPS);
-            throw new RuntimeException();
+            Assert.fail();
         } catch (Exception e) {
             Assert.assertEquals(
                     IllegalStateException.class, ExceptionUtils.getRootCause(e).getClass());

--- a/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManagerTest.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/datacache/nonkeyed/OperatorScopeManagedMemoryManagerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.iteration.datacache.nonkeyed;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests the behavior of the {@link OperatorScopeManagedMemoryManager}. */
+public class OperatorScopeManagedMemoryManagerTest {
+
+    private static final double EPS = 1e-9;
+
+    @Test
+    public void testUsage() {
+        OperatorScopeManagedMemoryManager manager = new OperatorScopeManagedMemoryManager();
+        manager.register("state-1", 100);
+        manager.register("state-2", 400);
+        Assert.assertEquals(manager.getFraction("state-1"), 0.2, EPS);
+        Assert.assertEquals(manager.getFraction("state-2"), 0.8, EPS);
+    }
+
+    @Test
+    public void testZeroUsage() {
+        OperatorScopeManagedMemoryManager manager = new OperatorScopeManagedMemoryManager();
+        manager.register("state-1", 0);
+        manager.register("state-2", 0);
+        Assert.assertEquals(manager.getFraction("state-1"), 0, EPS);
+        Assert.assertEquals(manager.getFraction("state-2"), 0, EPS);
+    }
+
+    @Test
+    public void testInvalidUsage() {
+        OperatorScopeManagedMemoryManager manager = new OperatorScopeManagedMemoryManager();
+        try {
+            manager.register("state-1", 100);
+            Assert.assertEquals(manager.getFraction("state-1"), 1., EPS);
+            manager.register("state-2", 400);
+            Assert.assertEquals(manager.getFraction("state-2"), 0.8, EPS);
+            throw new RuntimeException();
+        } catch (Exception e) {
+            Assert.assertEquals(
+                    IllegalStateException.class, ExceptionUtils.getRootCause(e).getClass());
+        }
+    }
+}

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
@@ -250,12 +250,7 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
             manager.register(stateKey, 1.);
             points =
                     new ListStateWithCache<>(
-                            new VectorWithNormSerializer(),
-                            stateKey,
-                            containingTask,
-                            getRuntimeContext(),
-                            context,
-                            operatorID);
+                            new VectorWithNormSerializer(), stateKey, context, this);
         }
 
         @Override

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/clustering/kmeans/KMeans.java
@@ -36,6 +36,7 @@ import org.apache.flink.iteration.IterationListener;
 import org.apache.flink.iteration.Iterations;
 import org.apache.flink.iteration.ReplayableDataStreamList;
 import org.apache.flink.iteration.datacache.nonkeyed.ListStateWithCache;
+import org.apache.flink.iteration.datacache.nonkeyed.OperatorScopeManagedMemoryManager;
 import org.apache.flink.iteration.operator.OperatorStateUtils;
 import org.apache.flink.ml.api.Estimator;
 import org.apache.flink.ml.common.datastream.DataStreamUtils;
@@ -239,9 +240,13 @@ public class KMeans implements Estimator<KMeans, KMeansModel>, KMeansParams<KMea
                     context.getOperatorStateStore()
                             .getListState(new ListStateDescriptor<>("centroids", type));
 
+            OperatorScopeManagedMemoryManager manager = new OperatorScopeManagedMemoryManager();
+            manager.register("points-state", 1.);
             points =
                     new ListStateWithCache<>(
                             new VectorWithNormSerializer(),
+                            manager,
+                            "points-state",
                             getContainingTask(),
                             getRuntimeContext(),
                             context,


### PR DESCRIPTION
## What is the purpose of the change

Right now, by default, an instance of `ListStateWithCache` uses up all the operator-scope managed memory.

It could bring some bugs in some situations, for example, when there exist more than one `ListStateWithCache`s in a single operator, or there are other places using operator-scope managed memory.

This PR tries to fix bugs with such default behaviors.

## Brief change log

- Adds `OperatorScopeManagedMemoryManager` to manage all usages of operator-scope managed memory in one operator. Every usage must register itself to the manager, then obtain the sub-fraction of memory it can use.
- Update the constructor of `ListStateWithCache` to get sub-fraction of operator-scope managed memory from an instance of `OperatorScopeManagedMemoryManager`.
- Adds unit tests for validation of the changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
