### PR TITLE
[FLINK-32889] Fix calcuation of weighted areaUnderROC and areaUnderPRC in BinaryClassificationEvaluator

### DIFF
--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/evaluation/BinaryClassificationEvaluatorTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/evaluation/BinaryClassificationEvaluatorTest.java
@@ -118,7 +118,8 @@ public class BinaryClassificationEvaluatorTest extends AbstractTestBase {
             new double[] {
                 0.8571428571428571, 0.9377705627705628, 0.8571428571428571, 0.6488095238095237
             };
-    private static final double EXPECTED_DATA_W = 0.8911680911680911;
+    private static final double[] EXPECTED_DATA_W =
+            new double[] {0.8717948717948718, 0.9510202726261435};
     private static final double EPS = 1.0e-5;
 
     @Before
@@ -297,14 +298,20 @@ public class BinaryClassificationEvaluatorTest extends AbstractTestBase {
     public void testEvaluateWithWeight() {
         BinaryClassificationEvaluator eval =
                 new BinaryClassificationEvaluator()
-                        .setMetricsNames(BinaryClassificationEvaluatorParams.AREA_UNDER_ROC)
+                        .setMetricsNames(
+                                BinaryClassificationEvaluatorParams.AREA_UNDER_ROC,
+                                BinaryClassificationEvaluatorParams.AREA_UNDER_PR)
                         .setWeightCol("weight");
         Table evalResult = eval.transform(inputDataTableWithWeight)[0];
-        List<Row> results = IteratorUtils.toList(evalResult.execute().collect());
+        Row result = (Row) IteratorUtils.toList(evalResult.execute().collect()).get(0);
         assertArrayEquals(
-                new String[] {BinaryClassificationEvaluatorParams.AREA_UNDER_ROC},
+                new String[] {
+                    BinaryClassificationEvaluatorParams.AREA_UNDER_ROC,
+                    BinaryClassificationEvaluatorParams.AREA_UNDER_PR
+                },
                 evalResult.getResolvedSchema().getColumnNames().toArray());
-        assertEquals(EXPECTED_DATA_W, results.get(0).getFieldAs(0), EPS);
+        assertArrayEquals(
+                EXPECTED_DATA_W, new double[] {result.getFieldAs(0), result.getFieldAs(1)}, 1e-9);
     }
 
     @Test

--- a/flink-ml-lib/src/test/java/org/apache/flink/ml/evaluation/BinaryClassificationEvaluatorTest.java
+++ b/flink-ml-lib/src/test/java/org/apache/flink/ml/evaluation/BinaryClassificationEvaluatorTest.java
@@ -311,7 +311,7 @@ public class BinaryClassificationEvaluatorTest extends AbstractTestBase {
                 },
                 evalResult.getResolvedSchema().getColumnNames().toArray());
         assertArrayEquals(
-                EXPECTED_DATA_W, new double[] {result.getFieldAs(0), result.getFieldAs(1)}, 1e-9);
+                EXPECTED_DATA_W, new double[] {result.getFieldAs(0), result.getFieldAs(1)}, EPS);
     }
 
     @Test

--- a/flink-ml-python/pyflink/ml/evaluation/tests/tests_binaryclassification.py
+++ b/flink-ml-python/pyflink/ml/evaluation/tests/tests_binaryclassification.py
@@ -16,10 +16,10 @@
 # limitations under the License.
 ################################################################################
 import os
-
 from pyflink.common import Types
-from pyflink.ml.linalg import Vectors, DenseVectorTypeInfo
+
 from pyflink.ml.evaluation.binaryclassification import BinaryClassificationEvaluator
+from pyflink.ml.linalg import Vectors, DenseVectorTypeInfo
 from pyflink.ml.tests.test_utils import PyFlinkMLTestCase
 
 
@@ -111,7 +111,7 @@ class BinaryClassificationEvaluatorTest(PyFlinkMLTestCase):
         self.expected_data_m = [0.8571428571428571, 0.9377705627705628,
                                 0.8571428571428571, 0.6488095238095237]
 
-        self.expected_data_w = 0.8911680911680911
+        self.expected_data_w = [0.8717948717948718, 0.9510202726261435]
 
         self.eps = 1e-5
 
@@ -185,11 +185,11 @@ class BinaryClassificationEvaluatorTest(PyFlinkMLTestCase):
 
     def test_evaluate_with_weight(self):
         evaluator = BinaryClassificationEvaluator() \
-            .set_metrics_names("areaUnderROC") \
+            .set_metrics_names("areaUnderROC", "areaUnderPR") \
             .set_weight_col("weight")
         output = evaluator.transform(self.input_data_table_with_weight)[0]
         self.assertEqual(
-            ["areaUnderROC"],
+            ["areaUnderROC", "areaUnderPR"],
             output.get_schema().get_field_names())
         results = [result for result in output.execute().collect()]
         result = results[0]


### PR DESCRIPTION
## What is the purpose of the change

Right now, BinaryClassificationEvaluator gives wrong areaUnderROC (auROC) and areaUnderPRC (auPRC) values when a weight column provided. This PR provides fix for their calculation.

## Brief change log

- Correct the expected values in the weighted case in BinaryClassificationEvaluatorTest. 
- Correct the calculation of weighted auROC and auPRC. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
