### PR TITLE
[FLINK-35066] Fix the unwrap from IterationRecord during keyBy

### DIFF
--- a/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/operator/allround/MultipleInputAllRoundWrapperOperator.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/operator/allround/MultipleInputAllRoundWrapperOperator.java
@@ -127,8 +127,10 @@ public class MultipleInputAllRoundWrapperOperator<OUT>
         @Override
         public void setKeyContextElement(StreamRecord<IterationRecord<IN>> record)
                 throws Exception {
-            reusedInput.replace(record.getValue(), record.getTimestamp());
-            input.setKeyContextElement(reusedInput);
+            if (record.getValue().getType() == IterationRecord.Type.RECORD) {
+                reusedInput.replace(record.getValue().getValue(), record.getTimestamp());
+                input.setKeyContextElement(reusedInput);
+            }
         }
     }
 }

--- a/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/operator/perround/MultipleInputPerRoundWrapperOperator.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/main/java/org/apache/flink/iteration/operator/perround/MultipleInputPerRoundWrapperOperator.java
@@ -177,7 +177,7 @@ public class MultipleInputPerRoundWrapperOperator<OUT>
             if (element.getValue().getType() == IterationRecord.Type.RECORD) {
                 // Ensures the operators are created.
                 getWrappedOperator(element.getValue().getEpoch());
-                reusedInput.replace(element.getValue(), element.getTimestamp());
+                reusedInput.replace(element.getValue().getValue(), element.getTimestamp());
                 operatorInputsByEpoch
                         .get(element.getValue().getEpoch())
                         .get(inputIndex)

--- a/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/allround/MultipleInputAllRoundWrapperOperatorTest.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/allround/MultipleInputAllRoundWrapperOperatorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.iteration.IterationListener;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.OperatorUtils;
 import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.iteration.proxy.ProxyKeySelector;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
@@ -75,9 +76,18 @@ public class MultipleInputAllRoundWrapperOperatorTest extends TestLogger {
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new,
                                 new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
                         .setupOutputForSingletonOperatorChain(wrapperFactory, operatorId)
                         .build()) {
             harness.processElement(new StreamRecord<>(IterationRecord.newRecord(5, 1), 2), 0);

--- a/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/allround/OneInputAllRoundWrapperOperatorTest.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/allround/OneInputAllRoundWrapperOperatorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.OperatorUtils;
 import org.apache.flink.iteration.operator.OperatorWrapper;
 import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.iteration.proxy.ProxyKeySelector;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
@@ -79,7 +80,10 @@ public class OneInputAllRoundWrapperOperatorTest extends TestLogger {
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 OneInputStreamTask::new,
                                 new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
                         .setupOutputForSingletonOperatorChain(wrapperFactory, operatorId)
                         .build()) {
             harness.processElement(new StreamRecord<>(IterationRecord.newRecord(5, 1), 2));

--- a/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/allround/TwoInputAllRoundWrapperOperatorTest.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/allround/TwoInputAllRoundWrapperOperatorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.iteration.IterationListener;
 import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.OperatorUtils;
 import org.apache.flink.iteration.operator.WrapperOperatorFactory;
+import org.apache.flink.iteration.proxy.ProxyKeySelector;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
@@ -74,8 +75,14 @@ public class TwoInputAllRoundWrapperOperatorTest extends TestLogger {
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 TwoInputStreamTask::new,
                                 new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
                         .setupOutputForSingletonOperatorChain(wrapperFactory, operatorId)
                         .build()) {
             harness.processElement(new StreamRecord<>(IterationRecord.newRecord(5, 1), 2), 0);

--- a/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/perround/MultipleInputPerRoundWrapperOperatorTest.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/perround/MultipleInputPerRoundWrapperOperatorTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.iteration.operator.OperatorUtils;
 import org.apache.flink.iteration.operator.WrapperOperatorFactory;
 import org.apache.flink.iteration.operator.allround.LifeCycle;
 import org.apache.flink.iteration.operator.allround.OneInputAllRoundWrapperOperator;
+import org.apache.flink.iteration.proxy.ProxyKeySelector;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
@@ -77,9 +78,18 @@ public class MultipleInputPerRoundWrapperOperatorTest extends TestLogger {
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new,
                                 new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
                         .setupOutputForSingletonOperatorChain(wrapperFactory, operatorId)
                         .build()) {
             harness.processElement(new StreamRecord<>(IterationRecord.newRecord(5, 1), 2), 0);

--- a/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/perround/OneInputPerRoundWrapperOperatorTest.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/perround/OneInputPerRoundWrapperOperatorTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.iteration.operator.OperatorUtils;
 import org.apache.flink.iteration.operator.OperatorWrapper;
 import org.apache.flink.iteration.operator.WrapperOperatorFactory;
 import org.apache.flink.iteration.operator.allround.LifeCycle;
+import org.apache.flink.iteration.proxy.ProxyKeySelector;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
@@ -93,7 +94,10 @@ public class OneInputPerRoundWrapperOperatorTest extends TestLogger {
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 OneInputStreamTask::new,
                                 new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
                         .setupOutputForSingletonOperatorChain(wrapperFactory, operatorId)
                         .build()) {
             harness.processElement(new StreamRecord<>(IterationRecord.newRecord(5, 1), 2));

--- a/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/perround/TwoInputPerRoundWrapperOperatorTest.java
+++ b/flink-ml-iteration/flink-ml-iteration-common/src/test/java/org/apache/flink/iteration/operator/perround/TwoInputPerRoundWrapperOperatorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.iteration.IterationRecord;
 import org.apache.flink.iteration.operator.OperatorUtils;
 import org.apache.flink.iteration.operator.WrapperOperatorFactory;
 import org.apache.flink.iteration.operator.allround.LifeCycle;
+import org.apache.flink.iteration.proxy.ProxyKeySelector;
 import org.apache.flink.iteration.typeinfo.IterationRecordTypeInfo;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
@@ -75,8 +76,14 @@ public class TwoInputPerRoundWrapperOperatorTest extends TestLogger {
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 TwoInputStreamTask::new,
                                 new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
-                        .addInput(new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
+                        .addInput(
+                                new IterationRecordTypeInfo<>(BasicTypeInfo.INT_TYPE_INFO),
+                                1,
+                                new ProxyKeySelector<Integer, Integer>(x -> x % 2))
                         .setupOutputForSingletonOperatorChain(wrapperFactory, operatorId)
                         .build()) {
             harness.processElement(new StreamRecord<>(IterationRecord.newRecord(5, 1), 2), 0);


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a bug in the iteration logic, where the input record was not unwrapped from the IterationRecord before setKeyContext() methods.

## Brief change log

- Unwrap data from IterationRecord before invoking setKeyContext() methods in iteration body

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
