### PR TITLE
[FLINK-36653] Fix OnlineLogisticRegressionModel updating logic

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['macOS-latest', 'ubuntu-20.04']
+        os: ['macOS-12', 'ubuntu-20.04']
         # TODO: Revert back to 3.7 once the Mac agent's Python v3.7 contains bz2 again,
         # the issue can be tracked via https://github.com/actions/setup-python/issues/682.
         python-version: ['3.7.16', '3.8']

--- a/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/OnlineLogisticRegressionModel.java
+++ b/flink-ml-lib/src/main/java/org/apache/flink/ml/classification/logisticregression/OnlineLogisticRegressionModel.java
@@ -145,6 +145,10 @@ public class OnlineLogisticRegressionModel
             LogisticRegressionModelData modelData = streamRecord.getValue();
             coefficient = modelData.coefficient;
             modelDataVersion = modelData.modelVersion;
+            servable =
+                    new LogisticRegressionModelServable(
+                            new LogisticRegressionModelData(coefficient, modelDataVersion));
+            ParamUtils.updateExistingParams(servable, params);
             for (Row dataPoint : bufferedPointsState.get()) {
                 processElement(new StreamRecord<>(dataPoint));
             }
@@ -160,7 +164,7 @@ public class OnlineLogisticRegressionModel
             if (servable == null) {
                 servable =
                         new LogisticRegressionModelServable(
-                                new LogisticRegressionModelData(coefficient, 0L));
+                                new LogisticRegressionModelData(coefficient, modelDataVersion));
                 ParamUtils.updateExistingParams(servable, params);
             }
             Vector features = (Vector) dataPoint.getField(servable.getFeaturesCol());


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the bug that OnlineLogisticRegressionModel has failed to update its model when a new model data comes in.

The reason this bug was not revealed by UTs is that the scale of test prediction data is too small (<= 0.5 * numSubtasks). Given that the input data is distributed evenly among all subtasks, it leads to one subtask only processing one piece of data, so the updating logic of model data is not fully verified.

## Brief change log

- Update the model servable so long as a new model data comes in.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
